### PR TITLE
ci: add auto-label workflow for issue triage

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,37 @@
+name: Auto-label issues
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.issue.title.toLowerCase();
+            const body = (context.payload.issue.body || '').toLowerCase();
+            const text = title + ' ' + body;
+            const labels = [];
+
+            if (/\b(bug|error|crash|fix|broken|regression|fault|defect)\b/.test(text)) {
+              labels.push('bug');
+            }
+            if (/\b(feature|enhance|request|improve|add support|proposal)\b/.test(text)) {
+              labels.push('enhancement');
+            }
+
+            if (labels.length > 0) {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels
+              });
+              core.info(`Added labels: ${labels.join(', ')}`);
+            } else {
+              core.info('No matching keywords found, no labels added');
+            }


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that auto-labels new issues based on keywords in the title and body
- Issues matching bug-related keywords (`bug`, `error`, `crash`, `fix`, etc.) get the `bug` label
- Issues matching feature-related keywords (`feature`, `enhance`, `request`, etc.) get the `enhancement` label

## Test plan
- [ ] Create a test issue with "bug" in the title — verify `bug` label is applied
- [ ] Create a test issue with "feature request" in the body — verify `enhancement` label is applied
- [ ] Create a test issue with no matching keywords — verify no labels are added
- [ ] Create a test issue matching both patterns — verify both labels are applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)