### PR TITLE
[feat]: Add automated PR review assistance operations

### DIFF
--- a/.hiivmind/github/workflows/pr-lifecycle.yaml
+++ b/.hiivmind/github/workflows/pr-lifecycle.yaml
@@ -20,5 +20,11 @@ actions:
   - name: "Highlight review needs"
     type: operation
     operation: "show PRs that need review or have requested changes"
+  - name: "Summarize PR diffs"
+    type: operation
+    operation: "for each open PR needing review, summarize the diff: what changed, why, and potential risks"
+  - name: "Offer review actions"
+    type: operation
+    operation: "for PRs needing review, offer to request specific reviewers or perform a self-review of the changes"
 
 cooldown_minutes: 15

--- a/templates/workflows/pr-lifecycle.yaml
+++ b/templates/workflows/pr-lifecycle.yaml
@@ -20,5 +20,11 @@ actions:
   - name: "Highlight review needs"
     type: operation
     operation: "show PRs that need review or have requested changes"
+  - name: "Summarize PR diffs"
+    type: operation
+    operation: "for each open PR needing review, summarize the diff: what changed, why, and potential risks"
+  - name: "Offer review actions"
+    type: operation
+    operation: "for PRs needing review, offer to request specific reviewers or perform a self-review of the changes"
 
 cooldown_minutes: 15


### PR DESCRIPTION
## Summary
Extends the PR lifecycle workflow with automated operations to summarize diffs and suggest review actions for open pull requests.

## Changes
- Adds "Summarize PR diffs" operation to generate concise summaries of changes, rationale, and potential risks per PR
- Adds "Offer review actions" operation to suggest reviewer assignments or self-review prompts
- Applies updates to both `.hiivmind/github/workflows/pr-lifecycle.yaml` and `templates/workflows/pr-lifecycle.yaml`

## Testing
Manual inspection confirms new operations follow the expected structure and wording; cooldown interval remains unchanged at 15 minutes.

## Notes
No behavioral logic was implemented—only new workflow steps are defined. These operations are intended to assist human reviewers and do not auto-close or approve PRs.

## Checklist
- [x] Documentation updated (via workflow file updates)
- [x] Breaking changes introduced: no
- [x] Dependencies added/modified: no