### PR TITLE
P3: headless skills (gh-status/healthcheck/refresh-headless) + freshness_status.py

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gh",
   "description": "GitHub workspace initialization and API documentation corpus. Run init once, then use gh CLI directly with routing guide and corpus for GraphQL/REST operations.",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "author": {
     "name": "Nathaniel Ramm <nathaniel@hiivmind.ai>"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,6 +179,9 @@ Use natural language to describe any GitHub operation:
 | `gh-heartbeat` | Present/execute heartbeat-triggered workflows |
 | `gh-workflows` | Manage and run workflow definitions |
 | `gh-discover` | Discover workspace resources |
+| `gh-status-headless` | Headless status pre-check → status-result.yaml (zero prompts) |
+| `gh-healthcheck-headless` | Headless fleet governance audit → healthcheck-result.yaml |
+| `gh-refresh-headless` | Headless config sync (replays recorded decisions) → refresh-result.yaml |
 
 ### Skill Architecture
 
@@ -295,7 +298,10 @@ hiivmind-pulse-gh/
 │   ├── gh-healthcheck/    # Repository governance audit
 │   ├── gh-heartbeat/      # Present/execute heartbeat-triggered workflows
 │   ├── gh-workflows/      # Manage and run workflow definitions
-│   └── gh-discover/       # Discover workspace resources
+│   ├── gh-discover/       # Discover workspace resources
+│   ├── gh-status-headless/       # Headless status pre-check
+│   ├── gh-healthcheck-headless/  # Headless fleet governance audit
+│   └── gh-refresh-headless/      # Headless config sync
 ├── lib/
 │   ├── patterns/                         # HOW to do things (executable guides)
 │   │   ├── config-parsing.md
@@ -307,6 +313,7 @@ hiivmind-pulse-gh/
 │   │   └── scripts/                      # Deterministic Python (PEP 723, uv run)
 │   │       ├── poll.py                   # Heartbeat engine (GraphQL + lakehouse)
 │   │       ├── evaluate_checks.py        # Mechanical healthcheck evaluator
+│   │       ├── freshness_status.py       # Staleness computation for headless status
 │   │       └── validate_result.py        # Headless result contract validator
 │   └── references/                       # WHAT exists (static lookup data)
 │       ├── api-routing.md                # Quick reference + method selection

--- a/docs/superpowers/specs/2026-07-10-workspace-root-and-headless-orchestration-design.md
+++ b/docs/superpowers/specs/2026-07-10-workspace-root-and-headless-orchestration-design.md
@@ -570,11 +570,11 @@ needs `poll.py`'s rate-limit/status helpers).
 Deliverables (each: `inputs:` frontmatter, State block, ABORT-emits-result,
 result gitignored, zero prompts):
 
-- [ ] P3.1 `gh-status-headless` → `status-result.yaml` (`refresh_needed`).
-- [ ] P3.2 `gh-healthcheck-headless` → `healthcheck-result.yaml`; iterates
+- [x] P3.1 `gh-status-headless` → `status-result.yaml` (`refresh_needed`).
+- [x] P3.2 `gh-healthcheck-headless` → `healthcheck-result.yaml`; iterates
       `repositories[]` or a passed repo filter; honors dismissals; updates
       committed `healthcheck.yaml`.
-- [ ] P3.3 `gh-refresh-headless` → `refresh-result.yaml`; replays recorded
+- [x] P3.3 `gh-refresh-headless` → `refresh-result.yaml`; replays recorded
       init/refresh decisions (decision-capture fields added to config where
       needed).
 
@@ -673,7 +673,7 @@ work. Status values: `not-started | in-progress | blocked({on}) | done`.
 | P0 | Workspace root formalization | — | ✅ done | 2026-07-10 |
 | P1 | Result contract + validator | P0 | ✅ done | 2026-07-10 |
 | P2 | Python extraction (poll, checks) | P0 | ✅ done | 2026-07-11 |
-| P3 | Headless skills (status/healthcheck/refresh) | P1, P2 | not-started | |
+| P3 | Headless skills (status/healthcheck/refresh) | P1, P2 | ✅ done | 2026-07-11 |
 | P4 | Executor split + headless policy | P1 | not-started | |
 | P5 | pulse-scheduler + fleet report **(goal 1)** | P3 (opt. P4.3) | not-started | |
 | P6 | Workflow v3: ledger, steps, gates **(goal 2)** | P4 | not-started | |

--- a/lib/pulse/scripts/freshness_status.py
+++ b/lib/pulse/scripts/freshness_status.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Compute per-section staleness from a freshness.yaml file.
+
+Timestamps are the authority: any stored `stale:` flag is ignored and staleness
+is recomputed as (now - last_checked) > threshold_hours, with null last_checked
+always stale. Output is the `sections` + `refresh_needed` payload of the
+`status` result kind (lib/patterns/headless-contract.md).
+
+Usage: freshness_status.py --freshness <freshness.yaml> [--now <ISO 8601 UTC>]
+
+Exit codes: 0 ok (JSON on stdout), 2 file missing or unparseable.
+"""
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+DEFAULT_THRESHOLD_HOURS = 168
+
+
+def parse_ts(s: str) -> datetime:
+    return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--freshness", required=True)
+    ap.add_argument("--now", default="")
+    args = ap.parse_args()
+
+    path = Path(args.freshness)
+    if not path.exists():
+        print(f"error: file not found: {path}", file=sys.stderr)
+        return 2
+
+    import yaml
+    try:
+        doc = yaml.safe_load(path.read_text()) or {}
+    except yaml.YAMLError as e:
+        print(f"error: unparseable YAML: {e}", file=sys.stderr)
+        return 2
+
+    now = parse_ts(args.now) if args.now else datetime.now(timezone.utc)
+    default_threshold = (doc.get("defaults") or {}).get(
+        "threshold_hours", DEFAULT_THRESHOLD_HOURS)
+
+    sections = []
+    for sid, s in (doc.get("sections") or {}).items():
+        if not isinstance(s, dict):
+            continue
+        last = s.get("last_checked")
+        threshold = s.get("threshold_hours", default_threshold)
+        # pyyaml parses unquoted ISO timestamps to datetime; normalize to str + UTC
+        if isinstance(last, datetime):
+            checked = last if last.tzinfo else last.replace(tzinfo=timezone.utc)
+            last = checked.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        if last is None:
+            stale = True
+        else:
+            try:
+                age_hours = (now - parse_ts(str(last))).total_seconds() / 3600
+                stale = age_hours > threshold
+            except ValueError:
+                stale = True
+        sections.append({"id": sid, "stale": stale, "last_checked": last})
+
+    print(json.dumps({"sections": sections,
+                      "refresh_needed": any(s["stale"] for s in sections)}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/pulse/scripts/tests/fixtures/freshness-fresh.yaml
+++ b/lib/pulse/scripts/tests/fixtures/freshness-fresh.yaml
@@ -1,0 +1,8 @@
+defaults:
+  threshold_hours: 168
+sections:
+  workspace:
+    last_checked: "2026-07-10T11:00:00Z"
+  projects:
+    threshold_hours: 24
+    last_checked: "2026-07-10T00:00:00Z"   # 12h < 24h -> fresh

--- a/lib/pulse/scripts/tests/fixtures/freshness-mixed.yaml
+++ b/lib/pulse/scripts/tests/fixtures/freshness-mixed.yaml
@@ -1,0 +1,19 @@
+defaults:
+  threshold_hours: 168
+sections:
+  workspace:
+    threshold_hours: 720
+    last_checked: "2026-07-01T12:00:00Z"   # 216h old, threshold 720h -> fresh
+    stale: false
+  projects:
+    threshold_hours: 168
+    last_checked: "2026-07-01T12:00:00Z"   # 216h old, threshold 168h -> stale (recomputed; stored flag ignored)
+    stale: false
+  views:
+    threshold_hours: 24
+    last_checked: null                      # never checked -> stale
+    stale: true
+  teams:
+    last_checked: "2026-07-09T12:00:00Z"   # 24h old, defaults 168h -> fresh
+  repo_settings:
+    last_checked: 2026-07-09T12:00:00Z     # UNQUOTED — pyyaml parses this to a datetime object

--- a/lib/pulse/scripts/tests/test_freshness_status.py
+++ b/lib/pulse/scripts/tests/test_freshness_status.py
@@ -1,0 +1,50 @@
+"""Tests for freshness_status.py — deterministic staleness from freshness.yaml."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = "lib/pulse/scripts/freshness_status.py"
+FIXTURES = Path("lib/pulse/scripts/tests/fixtures")
+
+
+def run(*args):
+    return subprocess.run([sys.executable, SCRIPT, *args],
+                          capture_output=True, text=True)
+
+
+def test_mixed_staleness():
+    r = run("--freshness", str(FIXTURES / "freshness-mixed.yaml"),
+            "--now", "2026-07-10T12:00:00Z")
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    by_id = {s["id"]: s for s in out["sections"]}
+    assert by_id["workspace"]["stale"] is False
+    assert by_id["projects"]["stale"] is True       # stored stale: false is ignored
+    assert by_id["views"]["stale"] is True
+    assert by_id["views"]["last_checked"] is None
+    assert by_id["teams"]["stale"] is False         # falls back to defaults threshold
+    assert by_id["repo_settings"]["stale"] is False  # unquoted yaml timestamp handled
+    assert by_id["repo_settings"]["last_checked"] == "2026-07-09T12:00:00Z"  # normalized to str
+    assert out["refresh_needed"] is True
+
+
+def test_all_fresh():
+    r = run("--freshness", str(FIXTURES / "freshness-fresh.yaml"),
+            "--now", "2026-07-10T12:00:00Z")
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["refresh_needed"] is False
+    assert all(s["stale"] is False for s in out["sections"])
+
+
+def test_missing_file_exit_2(tmp_path):
+    r = run("--freshness", str(tmp_path / "nope.yaml"))
+    assert r.returncode == 2
+
+
+def test_unparseable_exit_2(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("sections: [unclosed")
+    r = run("--freshness", str(bad))
+    assert r.returncode == 2

--- a/skills/gh-healthcheck-headless/SKILL.md
+++ b/skills/gh-healthcheck-headless/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: gh-healthcheck-headless
+description: >
+  Headless multi-repo governance audit. Fetches per-repo API data, evaluates the 11-check catalog
+  deterministically via evaluate_checks.py honoring team dismissals, writes healthcheck-result.yaml
+  (kind: healthcheck) and updates the committed healthcheck.yaml governance record. Zero prompts;
+  explicit inputs only. Use when: a scheduled fleet audit runs, an orchestrator needs repo grades.
+  Trigger phrases: "headless healthcheck", "fleet healthcheck", "scheduled governance audit".
+inputs:
+  workspace_path: "required — absolute path to the workspace root (directory containing .hiivmind/github/)"
+  repos: "optional — comma-separated repo filter (full owner/name or short names); default: every entry in the config repositories[] catalog"
+  result_path: "optional — where to write the result (default: {workspace_path}/.hiivmind/github/healthcheck-result.yaml)"
+  update_governance: "optional — also update the committed healthcheck.yaml (default: true)"
+  mode: "optional — actor mode recorded in the result: interactive | scheduled (default: scheduled)"
+outputs:
+  result_file: "healthcheck-result.yaml conforming to lib/patterns/headless-contract.md (kind: healthcheck)"
+  governance: "updated {workspace_path}/.hiivmind/github/healthcheck.yaml (unless update_governance: false)"
+author: hiivmind
+---
+
+# Headless Fleet Healthcheck
+
+The 11-check governance catalog (`lib/references/healthcheck-checks.md`) evaluated per repo,
+deterministically, with dismissals honored. Read-only against GitHub — fixes are never applied.
+
+## Path Convention
+
+`{PLUGIN_ROOT}` = plugin root (where plugin.json lives).
+
+## Contract
+
+- **Zero prompts. Explicit inputs only (D4). Every exit writes a result file.**
+- A repo that fails to evaluate does not abort the run: record an `errors[]` entry and
+  continue with the remaining repos (partial fleets are valid results).
+
+## State
+
+```
+computed:
+  CONFIG_DIR   = {workspace_path}/.hiivmind/github
+  RESULT_PATH  = {result_path input, or CONFIG_DIR/healthcheck-result.yaml}
+  RUN_AT       = $(date -u +%Y-%m-%dT%H:%M:%SZ)
+  LOGIN        = yq -r '.workspace.login' CONFIG_DIR/config.yaml
+  GH_LOGIN     = $(gh api user --jq .login)   ("unknown" on failure, + errors[] entry)
+  MACHINE      = $(hostname -s)
+  MODE         = {mode input, default "scheduled"}
+  REPOS        = resolved full_name list (Phase 1)
+  REPO_RESULTS = []   (per-repo JSON blocks from evaluate_checks.py)
+  ERRORS       = []
+```
+
+## Phase 1: VALIDATE + SCOPE
+
+**Outputs:** REPOS.
+
+1. `workspace_path` missing → ABORT `"missing required input: workspace_path"`.
+2. `CONFIG_DIR/config.yaml` missing or lacking a top-level `workspace:` key →
+   ABORT `"not a workspace root: {workspace_path}"`.
+3. `gh` unavailable → ABORT `"gh CLI not found"`.
+4. Catalog:
+
+```bash
+yq -r '.repositories[].full_name' "${CONFIG_DIR}/config.yaml"
+```
+
+   Empty catalog and no `repos` input → ABORT `"repositories catalog is empty"`.
+5. If `repos` input given: match each entry against catalog `full_name` or `name`;
+   entries with no catalog match are still evaluated if they look like `owner/name`
+   (API-only repos are legitimate — see spec Part 9), otherwise append
+   `"unknown repo: {entry}"` to ERRORS and drop it. REPOS = the resolved full names.
+6. Verify gitignore coverage: append `*-result.yaml` to `CONFIG_DIR/.gitignore` if missing.
+
+## Phase 2: EVALUATE (per repo)
+
+**Outputs:** REPO_RESULTS.
+
+For each `FULL` (owner/name) in REPOS:
+
+1. Fetch API data into a fresh temp dir (404s are expected for some endpoints —
+   a missing file is how evaluate_checks.py learns the resource is absent):
+
+```bash
+DATA_DIR=$(mktemp -d)
+fetch() { gh api "$1" > "$DATA_DIR/$2" 2>/dev/null || rm -f "$DATA_DIR/$2"; }
+
+fetch "repos/${FULL}" repo.json
+DEFAULT_BRANCH=$(jq -r '.default_branch // "main"' "$DATA_DIR/repo.json" 2>/dev/null || echo main)
+fetch "repos/${FULL}/branches/${DEFAULT_BRANCH}/protection" protection.json
+fetch "repos/${FULL}/rulesets" rulesets.json
+fetch "repos/${FULL}/labels?per_page=100" labels.json
+fetch "repos/${FULL}/actions/workflows" workflows.json
+fetch "repos/${FULL}/releases?per_page=30" releases.json
+fetch "repos/${FULL}/tags?per_page=30" tags.json
+fetch "repos/${FULL}/contents/" root-contents.json
+fetch "repos/${FULL}/contents/.github" github-contents.json
+```
+
+   If `repo.json` is missing after the fetch (repo inaccessible), append
+   `"{FULL}: repo metadata unavailable"` to ERRORS and continue to the next repo.
+
+2. Evaluate deterministically:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/evaluate_checks.py" \
+  --repo "$FULL" --data-dir "$DATA_DIR" \
+  --relationships "${CONFIG_DIR}/relationships.yaml" \
+  --dismissals "${CONFIG_DIR}/healthcheck.yaml"
+```
+
+   Append the printed JSON object to REPO_RESULTS. Non-zero exit → append
+   `"{FULL}: evaluate_checks failed"` to ERRORS, continue.
+
+3. Space repos out (fleet politeness): no parallel fetching; sequential per repo.
+
+## Phase 3: AGGREGATE + WRITE RESULT
+
+**Outputs:** RESULT_PATH written and validated.
+
+1. Aggregate: `score` = sum of repo scores, `total` = sum of repo totals, `grade` from
+   score/total fraction — A ≥ 0.90, B ≥ 0.72, C ≥ 0.54, D ≥ 0.36, F below (same table
+   evaluate_checks.py uses; total 0 → F).
+2. Write RESULT_PATH:
+
+```yaml
+contract_version: 1
+kind: healthcheck
+workspace: {LOGIN}
+run_at: {RUN_AT}
+actor: { gh_login: {GH_LOGIN}, machine: {MACHINE}, mode: {MODE} }
+repos: {REPO_RESULTS}          # each: {repo, score, total, grade, checks}
+aggregate: { score: {sum}, total: {sum}, grade: {computed} }
+errors: {ERRORS}
+```
+
+3. Validate:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py" "$RESULT_PATH" --kind healthcheck
+```
+
+   Exit ≠ 0 → skill bug; report validator stderr verbatim.
+
+## Phase 4: UPDATE GOVERNANCE RECORD
+
+**Outputs:** updated `CONFIG_DIR/healthcheck.yaml` (skip entirely if `update_governance: false`).
+
+1. Create from `{PLUGIN_ROOT}/templates/healthcheck.yaml.template` if missing.
+2. Set `last_run`: `timestamp: RUN_AT`, `scope:` comma-joined short names (or `fleet`
+   when the whole catalog ran), `aggregate_score / aggregate_total / aggregate_grade`.
+3. For each repo result, write `repos.{short-name}` (short name = part after `/`):
+   `score`, `total`, `grade`, and each check with `status`, `detail`, `data`, plus
+   `last_evaluated: RUN_AT` (the governance record keeps timestamps; the result file
+   does not need them).
+4. **Preserve `dismissals:` untouched** — merge, never overwrite. Repos not evaluated
+   this run keep their existing blocks.
+5. Do NOT commit or push — the orchestrator (P5) owns the commit/PR step.
+
+## ABORT semantics
+
+On ABORT: write RESULT_PATH with `repos: []`, `aggregate: {score: 0, total: 0, grade: F}`,
+`errors: [<reason>, ...]`, all common fields populated; validate; stop. Fallback write
+locations as in gh-status-headless.
+
+## Related
+
+- `lib/patterns/headless-contract.md` — schema
+- `lib/references/healthcheck-checks.md` — the catalog evaluate_checks.py implements
+- `skills/gh-healthcheck/` — the interactive sibling (fix/dismiss flows live there)

--- a/skills/gh-refresh-headless/SKILL.md
+++ b/skills/gh-refresh-headless/SKILL.md
@@ -49,7 +49,10 @@ computed:
   GH_LOGIN     = $(gh api user --jq .login)   ("unknown" on failure, + errors[] entry)
   MACHINE      = $(hostname -s)
   MODE         = {mode input, default "scheduled"}
-  ALL_SECTIONS = section ids present in CONFIG_DIR/freshness.yaml
+  ALL_SECTIONS = union of the section ids in CONFIG_DIR/freshness.yaml (if present)
+                 and every id in TARGETS — so a target absent from freshness.yaml is
+                 still refreshed and reported, never silently dropped (resolved after
+                 TARGETS in Phase 1)
   TARGETS      = resolved per the priority order above (minus "automations")
   SECTION_RESULTS = []   ({id, status} per section in ALL_SECTIONS)
   ERRORS       = []
@@ -66,12 +69,17 @@ computed:
 4. **Pull before reconcile** (multi-machine rule, workspace-detection.md): if CONFIG_DIR
    is a git repo with a remote, `git -C CONFIG_DIR pull --ff-only` first; a pull failure
    is an ERRORS entry, not an abort (proceed on local state).
-5. Resolve TARGETS by the priority order in the intro. For the stale fallback, run
+5. **Bootstrap freshness.yaml** if `CONFIG_DIR/freshness.yaml` is missing (a workspace that
+   predates freshness tracking): create it from `{PLUGIN_ROOT}/templates/freshness.yaml.template`.
+   This is not an abort — it gives Phase 2 a file to stamp and lets the stale-fallback run.
+6. Resolve TARGETS by the priority order in the intro. For the stale fallback, run
    `uv run {PLUGIN_ROOT}/lib/pulse/scripts/freshness_status.py --freshness CONFIG_DIR/freshness.yaml`
-   and take sections with `stale: true`. Remove `automations` from TARGETS always.
+   and take sections with `stale: true` (exit 2 → treat as no stale info: empty fallback,
+   append an ERRORS entry). Remove `automations` from TARGETS always.
    Unknown section ids in the `sections` input → ERRORS entry, dropped.
-6. Verify gitignore coverage (`*-result.yaml`), append if missing.
-7. Record baseline for config_updated:
+   Then set ALL_SECTIONS = the union of freshness.yaml's section ids and TARGETS.
+7. Verify gitignore coverage (`*-result.yaml`), append if missing.
+8. Record baseline for config_updated:
 
 ```bash
 BASELINE=$(git -C "$CONFIG_DIR" status --porcelain 2>/dev/null | sort | shasum | cut -d' ' -f1)
@@ -89,7 +97,8 @@ ALL_SECTIONS:
   Phase 4 (query GitHub, write the section's config file — see the "Refreshable Sections"
   table in `skills/gh-refresh/SKILL.md`; GraphQL via `lib/patterns/graphql-execution.md`).
   - Success → `{id, status: refreshed}`; update the section in freshness.yaml
-    (`last_checked: RUN_AT`, `stale: false`).
+    (`last_checked: RUN_AT`, `stale: false`), creating the `sections.{id}` entry if the
+    section was a target not previously tracked in freshness.yaml.
   - Any error → `{id, status: failed}`, append `"{id}: {error}"` to ERRORS, leave
     freshness untouched, continue.
 

--- a/skills/gh-refresh-headless/SKILL.md
+++ b/skills/gh-refresh-headless/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: gh-refresh-headless
+description: >
+  Headless config sync. Refreshes workspace config sections against GitHub without prompting,
+  replaying the section selection recorded by interactive gh-refresh (automation.refresh_sections)
+  or an explicit sections input. Writes refresh-result.yaml (kind: refresh). Zero prompts;
+  explicit inputs only. Use when: a scheduled run found refresh_needed, an orchestrator syncs
+  catalogs before a fleet audit. Trigger phrases: "headless refresh", "scheduled config sync".
+inputs:
+  workspace_path: "required — absolute path to the workspace root (directory containing .hiivmind/github/)"
+  sections: "optional — comma-separated section ids to refresh, overriding the recorded decision"
+  result_path: "optional — where to write the result (default: {workspace_path}/.hiivmind/github/refresh-result.yaml)"
+  mode: "optional — actor mode recorded in the result: interactive | scheduled (default: scheduled)"
+outputs:
+  result_file: "refresh-result.yaml conforming to lib/patterns/headless-contract.md (kind: refresh)"
+  config: "refreshed section files + freshness.yaml timestamps under {workspace_path}/.hiivmind/github/"
+author: hiivmind
+---
+
+# Headless Config Refresh
+
+Sync cached workspace config with GitHub, unattended. The interactive sibling asks which
+sections to refresh; this skill **replays a recorded decision** instead:
+
+Target sections, in priority order:
+1. `sections` input (explicit override)
+2. `automation.refresh_sections` from config.yaml (recorded by interactive gh-refresh)
+3. Every currently-stale section (fallback when nothing was ever recorded)
+
+## Path Convention
+
+`{PLUGIN_ROOT}` = plugin root (where plugin.json lives).
+
+## Contract
+
+- **Zero prompts. Explicit inputs only (D4). Every exit writes a result file.**
+- A section that fails does not abort the run: mark it `failed`, record the error, continue.
+- Sections whose refresh requires user interaction by nature (`automations` — UI-only data,
+  manual template) are marked `skipped`, never attempted.
+
+## State
+
+```
+computed:
+  CONFIG_DIR   = {workspace_path}/.hiivmind/github
+  RESULT_PATH  = {result_path input, or CONFIG_DIR/refresh-result.yaml}
+  RUN_AT       = $(date -u +%Y-%m-%dT%H:%M:%SZ)
+  LOGIN        = yq -r '.workspace.login' CONFIG_DIR/config.yaml
+  GH_LOGIN     = $(gh api user --jq .login)   ("unknown" on failure, + errors[] entry)
+  MACHINE      = $(hostname -s)
+  MODE         = {mode input, default "scheduled"}
+  ALL_SECTIONS = section ids present in CONFIG_DIR/freshness.yaml
+  TARGETS      = resolved per the priority order above (minus "automations")
+  SECTION_RESULTS = []   ({id, status} per section in ALL_SECTIONS)
+  ERRORS       = []
+```
+
+## Phase 1: VALIDATE + RESOLVE TARGETS
+
+**Outputs:** TARGETS.
+
+1. `workspace_path` missing → ABORT `"missing required input: workspace_path"`.
+2. `CONFIG_DIR/config.yaml` missing or lacking `^workspace:` → ABORT
+   `"not a workspace root: {workspace_path}"`.
+3. `gh` unavailable → ABORT `"gh CLI not found"`.
+4. **Pull before reconcile** (multi-machine rule, workspace-detection.md): if CONFIG_DIR
+   is a git repo with a remote, `git -C CONFIG_DIR pull --ff-only` first; a pull failure
+   is an ERRORS entry, not an abort (proceed on local state).
+5. Resolve TARGETS by the priority order in the intro. For the stale fallback, run
+   `uv run {PLUGIN_ROOT}/lib/pulse/scripts/freshness_status.py --freshness CONFIG_DIR/freshness.yaml`
+   and take sections with `stale: true`. Remove `automations` from TARGETS always.
+   Unknown section ids in the `sections` input → ERRORS entry, dropped.
+6. Verify gitignore coverage (`*-result.yaml`), append if missing.
+7. Record baseline for config_updated:
+
+```bash
+BASELINE=$(git -C "$CONFIG_DIR" status --porcelain 2>/dev/null | sort | shasum | cut -d' ' -f1)
+```
+
+## Phase 2: REFRESH
+
+**Outputs:** SECTION_RESULTS.
+
+Read `{PLUGIN_ROOT}/lib/references/api-routing.md` in full once, then for each section in
+ALL_SECTIONS:
+
+- Not in TARGETS → record `{id, status: skipped}`.
+- In TARGETS → execute the same per-section refresh procedure as interactive gh-refresh
+  Phase 4 (query GitHub, write the section's config file — see the "Refreshable Sections"
+  table in `skills/gh-refresh/SKILL.md`; GraphQL via `lib/patterns/graphql-execution.md`).
+  - Success → `{id, status: refreshed}`; update the section in freshness.yaml
+    (`last_checked: RUN_AT`, `stale: false`).
+  - Any error → `{id, status: failed}`, append `"{id}: {error}"` to ERRORS, leave
+    freshness untouched, continue.
+
+Headless deviations from the interactive procedure: never use corpus lookup interactively;
+if syntax is uncertain, mark the section `failed` with error `"{id}: syntax uncertain,
+needs interactive run"` rather than guessing mutations. (All refresh queries are read-only,
+so the risk is wasted calls, not damage — but a wrong query recorded as success would
+corrupt the cache.)
+
+## Phase 3: WRITE + VALIDATE
+
+**Outputs:** RESULT_PATH written and validated.
+
+1. Compute config_updated:
+
+```bash
+NOW=$(git -C "$CONFIG_DIR" status --porcelain 2>/dev/null | sort | shasum | cut -d' ' -f1)
+# config_updated = [ "$NOW" != "$BASELINE" ]
+```
+
+   If CONFIG_DIR is not a git repo, fall back to: config_updated = any section refreshed.
+2. Update `cache.last_synced_at: RUN_AT` in config.yaml if any section refreshed.
+3. Write RESULT_PATH:
+
+```yaml
+contract_version: 1
+kind: refresh
+workspace: {LOGIN}
+run_at: {RUN_AT}
+actor: { gh_login: {GH_LOGIN}, machine: {MACHINE}, mode: {MODE} }
+sections: {SECTION_RESULTS}    # every section in ALL_SECTIONS: {id, status}
+config_updated: {bool}
+errors: {ERRORS}
+```
+
+4. Validate:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py" "$RESULT_PATH" --kind refresh
+```
+
+5. Do NOT commit or push the workspace repo — the orchestrator owns that.
+
+## ABORT semantics
+
+On ABORT: write RESULT_PATH with `sections: []`, `config_updated: false`,
+`errors: [<reason>, ...]`, all common fields populated; validate; stop. Fallback write
+locations as in gh-status-headless.
+
+## Related
+
+- `lib/patterns/headless-contract.md` — schema
+- `skills/gh-refresh/` — interactive sibling; Phase 4 procedures are shared, Phase 5
+  records the decision this skill replays

--- a/skills/gh-refresh/SKILL.md
+++ b/skills/gh-refresh/SKILL.md
@@ -255,6 +255,17 @@ For each refreshed section:
 
 ISO 8601 UTC: `2024-01-15T14:30:00Z`
 
+### Decision Capture (headless replay)
+
+Record the sections just refreshed so `gh-refresh-headless` can replay this decision
+without prompting (spec: decision capture — headless variants replay, never guess):
+
+1. Read `automation.refresh_sections` from config.yaml (treat missing as `[]`)
+2. Set it to the **union** of the existing list and the sections refreshed this run
+3. Set `automation.refresh_recorded_at` to the current UTC timestamp
+
+The list only grows through interactive use; the team prunes it by editing config.yaml.
+
 ---
 
 ## Phase 6: REPORT

--- a/skills/gh-status-headless/SKILL.md
+++ b/skills/gh-status-headless/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: gh-status-headless
+description: >
+  Headless workspace status pre-check for schedulers and orchestrators. Computes per-section
+  config freshness and API rate limit, writes status-result.yaml (kind: status) per the headless
+  result contract. Zero prompts; explicit inputs only — never discovers a workspace. Use when:
+  a scheduled run must decide whether a refresh is warranted, an orchestrator gates on
+  refresh_needed. Trigger phrases: "headless status", "status headless", "scheduled status check".
+inputs:
+  workspace_path: "required — absolute path to the workspace root (directory containing .hiivmind/github/)"
+  result_path: "optional — where to write the result (default: {workspace_path}/.hiivmind/github/status-result.yaml)"
+  mode: "optional — actor mode recorded in the result: interactive | scheduled (default: scheduled)"
+outputs:
+  result_file: "status-result.yaml conforming to lib/patterns/headless-contract.md (kind: status)"
+author: hiivmind
+---
+
+# Headless Status Pre-Check
+
+Cheap, read-only pre-check: is the workspace config fresh, and is API budget available?
+Orchestrators read the result **file**, not this skill's prose output.
+
+## Path Convention
+
+`{PLUGIN_ROOT}` = plugin root (where plugin.json lives). Scripts run as
+`uv run {PLUGIN_ROOT}/lib/pulse/scripts/<script>.py`.
+
+## Contract
+
+- **Zero prompts.** Never ask the user anything.
+- **Explicit inputs only** (D4). If `workspace_path` was not provided, ABORT — do not walk up.
+- **Every exit writes a result file** — including every ABORT below.
+
+## State
+
+```
+computed:
+  CONFIG_DIR   = {workspace_path}/.hiivmind/github
+  RESULT_PATH  = {result_path input, or CONFIG_DIR/status-result.yaml}
+  RUN_AT       = $(date -u +%Y-%m-%dT%H:%M:%SZ)  (captured once, at start)
+  LOGIN        = yq -r '.workspace.login' CONFIG_DIR/config.yaml   ("unknown" until Phase 1)
+  GH_LOGIN     = $(gh api user --jq .login)       ("unknown" on failure, + errors[] entry)
+  MACHINE      = $(hostname -s)
+  MODE         = {mode input, default "scheduled"}
+  ERRORS       = []   (accumulate strings; goes into errors[])
+```
+
+## Phase 1: VALIDATE
+
+**Outputs:** validated CONFIG_DIR, LOGIN.
+
+1. If `workspace_path` input missing → ABORT `"missing required input: workspace_path"`.
+2. If `CONFIG_DIR/config.yaml` missing, or `grep -q '^workspace:' CONFIG_DIR/config.yaml`
+   fails → ABORT `"not a workspace root: {workspace_path}"`.
+3. If `gh` CLI unavailable (`command -v gh`) → ABORT `"gh CLI not found"`.
+4. Set LOGIN from config. Verify gitignore coverage: if `CONFIG_DIR/.gitignore` exists and
+   lacks a `*-result.yaml` line, append it.
+
+## Phase 2: GATHER
+
+**Outputs:** SECTIONS, REFRESH_NEEDED, RATE_LIMIT.
+
+1. Freshness (deterministic):
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/freshness_status.py" \
+  --freshness "${CONFIG_DIR}/freshness.yaml"
+```
+
+   - Exit 0 → SECTIONS and REFRESH_NEEDED from the JSON.
+   - Exit 2 (missing/unparseable freshness.yaml) → SECTIONS = [], REFRESH_NEEDED = true
+     (unknown freshness must trigger a refresh, never silently skip one), append
+     `"freshness.yaml missing or unparseable"` to ERRORS.
+
+2. Rate limit:
+
+```bash
+gh api rate_limit --jq '.resources.core.remaining'
+```
+
+   - Success → RATE_LIMIT = the integer.
+   - Failure → RATE_LIMIT = null, append `"rate_limit query failed"` to ERRORS (not an abort).
+
+## Phase 3: WRITE + VALIDATE
+
+**Outputs:** RESULT_PATH written and validated.
+
+1. Write RESULT_PATH:
+
+```yaml
+contract_version: 1
+kind: status
+workspace: {LOGIN}
+run_at: {RUN_AT}
+actor:
+  gh_login: {GH_LOGIN}
+  machine: {MACHINE}
+  mode: {MODE}
+sections: {SECTIONS}          # [{id, stale, last_checked}, ...]
+rate_limit_remaining: {RATE_LIMIT}
+refresh_needed: {REFRESH_NEEDED}
+errors: {ERRORS}
+```
+
+2. Validate:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py" "$RESULT_PATH" --kind status
+```
+
+   Exit ≠ 0 means this skill has a bug — report the validator's stderr verbatim.
+
+3. Print a one-line summary for logs (informational only — the file is the contract):
+   `status: refresh_needed={REFRESH_NEEDED} sections_stale={count} rate_limit={RATE_LIMIT}`
+
+## ABORT semantics
+
+On any ABORT: write RESULT_PATH with `sections: []`, `rate_limit_remaining: null`,
+`refresh_needed: false`, `errors: [<abort reason>, ...]`, all common fields populated
+(LOGIN may be `"unknown"` if config was unreadable), then validate and stop. If even
+CONFIG_DIR is unusable, write to the `result_path` input; if neither is available,
+write `status-result.yaml` in the current directory and say so.
+
+## Related
+
+- `lib/patterns/headless-contract.md` — the schema this writes
+- `lib/patterns/workspace-detection.md` — D4: why this skill never discovers
+- `skills/gh-refresh-headless/` — what an orchestrator runs when refresh_needed

--- a/templates/config.yaml.template
+++ b/templates/config.yaml.template
@@ -22,6 +22,12 @@ repositories: []
 # Populated by hiivmind-pulse-gh-workspace-init
 milestones: {}
 
+# Headless automation decisions (recorded by interactive skills, replayed by headless siblings)
+# refresh_sections: sections gh-refresh-headless may sync without prompting.
+# Recorded as the union of sections refreshed interactively; edit to prune.
+automation:
+  refresh_sections: []
+
 # Cache metadata
 cache:
   initialized_at: {{initialized_at}}


### PR DESCRIPTION
## P3 — Headless Skills

Implements `docs/superpowers/plans/2026-07-10-p3-headless-skills.md` (spec Part 4 §P3). Three headless skill variants that each write a contract-valid result file with **zero prompts**, giving the P5 scheduler composable building blocks. Executed via subagent-driven-development (fresh implementer + task reviewer per task, opus-level whole-branch review).

### What landed
- **`lib/pulse/scripts/freshness_status.py`** (+ tests, 2 fixtures) — deterministic per-section staleness → `{sections:[{id,stale,last_checked}], refresh_needed}`; timestamps are authority (stored `stale:` flags ignored), unquoted-YAML timestamps normalized to UTC, exit 0/2.
- **`skills/gh-status-headless/`** (P3.1) — read-only status pre-check → `status-result.yaml` (kind: status), consuming `freshness_status.py` + rate limit.
- **`skills/gh-healthcheck-headless/`** (P3.2) — fleet governance audit via `evaluate_checks.py` (dismissals honored) → `healthcheck-result.yaml` + updates committed `healthcheck.yaml` (dismissals preserved, no commit/push).
- **`skills/gh-refresh-headless/`** (P3.3) — decision-replay config sync → `refresh-result.yaml`, replaying `automation.refresh_sections`.
- **`gh-refresh` + `config.yaml.template`** — decision capture into `automation.refresh_sections` (monotonic union).
- Close-out: spec P3.1–P3.3 ticked, §8.9 P3 row ✅, CLAUDE.md updated, version 4.6.0 → **4.7.0**.

### Conventions honored
D4 (headless never discovers — explicit `workspace_path`, ABORT never walks up) · zero prompts · ABORT still emits a contract-valid result with `errors[]` · actor block (`gh_login`/`machine`/`mode`) on every kind · results gitignored (`*-result.yaml`) and gated by `validate_result.py` before success.

### Verification
- 30/30 tests green.
- Each headless skill dogfood-run against the real workspace (`~/git/hiivmind`): all wrote `VALID` result files. gh-healthcheck-headless graded the fleet (B) with dismissals preserved and no `$WS` commit; gh-refresh-headless refreshed the `workspace` section (and incidentally corrected a stale cached `workspace.id`). Broken-input runs (throwaway dirs) all still produced `VALID` results with populated `errors[]`.

### Hardening beyond the plan (1 commit, reviewed RESOLVED)
`gh-refresh-headless` originally iterated `ALL_SECTIONS` derived solely from `freshness.yaml`, so a target supplied via the `sections` input (or a missing `freshness.yaml` entirely) was silently dropped — no refresh/skip/fail, no error. Fix: `ALL_SECTIONS = union(freshness ids, TARGETS)`, bootstrap missing `freshness.yaml` from template, exit-2 stale-fallback degrades with an `errors[]` entry, Phase 2 creates the freshness entry for a not-yet-tracked target.

### Known follow-ups (out of scope — real-workspace data, not diff defects)
- Real `config.yaml` catalog has a stale `full_name` for this repo (`hiivmind/gh` 404s).
- Real `relationships.yaml` schema (`relationships: [{repositories:[...]}]`) doesn't match what `evaluate_checks.py` expects (`project_repo_links: [{repos:[...]}]`), so `project_linkage` under-reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
