### PR TITLE
P4: workflow executor split + headless policy (gh-workflow-run-headless)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gh",
   "description": "GitHub workspace initialization and API documentation corpus. Run init once, then use gh CLI directly with routing guide and corpus for GraphQL/REST operations.",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "author": {
     "name": "Nathaniel Ramm <nathaniel@hiivmind.ai>"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ Executable guides with step-by-step instructions:
 | `lib/patterns/workspace-detection.md` | Git remote → owner/repo |
 | `lib/patterns/corpus-lookup.md` | Look up API syntax when uncertain |
 | `lib/patterns/healthcheck-evaluation.md` | Healthcheck evaluation logic per check |
+| `lib/patterns/workflow-execution.md` | THE workflow executor (single normative description; interactive + headless) |
 
 ### References (WHAT exists)
 
@@ -182,6 +183,7 @@ Use natural language to describe any GitHub operation:
 | `gh-status-headless` | Headless status pre-check → status-result.yaml (zero prompts) |
 | `gh-healthcheck-headless` | Headless fleet governance audit → healthcheck-result.yaml |
 | `gh-refresh-headless` | Headless config sync (replays recorded decisions) → refresh-result.yaml |
+| `gh-workflow-run-headless` | Run a v2 workflow unattended under its headless policy → workflow-run-result.yaml |
 
 ### Skill Architecture
 
@@ -301,7 +303,8 @@ hiivmind-pulse-gh/
 │   ├── gh-discover/       # Discover workspace resources
 │   ├── gh-status-headless/       # Headless status pre-check
 │   ├── gh-healthcheck-headless/  # Headless fleet governance audit
-│   └── gh-refresh-headless/      # Headless config sync
+│   ├── gh-refresh-headless/      # Headless config sync
+│   └── gh-workflow-run-headless/ # Headless workflow run (policy-projected)
 ├── lib/
 │   ├── patterns/                         # HOW to do things (executable guides)
 │   │   ├── config-parsing.md

--- a/docs/backlogs/2026-07-11-relationships-schema-drift.md
+++ b/docs/backlogs/2026-07-11-relationships-schema-drift.md
@@ -1,0 +1,55 @@
+# Backlog: `relationships.yaml` schema drift vs. `evaluate_checks.py`
+
+**Date:** 2026-07-11
+**Status:** Open
+**Severity:** Medium (produces a wrong check result)
+**Found in:** P3 dogfood verification (PR #120 — `gh-healthcheck-headless` run against `~/git/hiivmind`)
+**Scope:** contract between the real `relationships.yaml` and `lib/pulse/scripts/evaluate_checks.py` (P2)
+
+## Problem
+
+The shape of the real workspace's `relationships.yaml` does not match the shape
+`evaluate_checks.py` reads when scoring the `project_linkage` check:
+
+- **Real file:** `relationships: [{ repositories: [...] }]`
+- **`evaluate_checks.py` expects:** `project_repo_links: [{ repos: [...] }]`
+
+Because the reader looks for the key/shape it never finds, `project_linkage`
+scores `fail` even when the repo IS linked to a project — a **false negative**
+that drags down the repo and aggregate governance grade.
+
+## Impact
+
+- `project_linkage` under-reports for every repo in a workspace whose
+  `relationships.yaml` uses the `relationships:`/`repositories:` shape.
+- Aggregate grades from `gh-healthcheck-headless` (and the interactive
+  `gh-healthcheck`) are pessimistic by up to one check per repo.
+- Any policy gating on the healthcheck grade inherits the false negative.
+
+## Decision needed (which side is authoritative)
+
+One of:
+1. **Fix the reader** — make `evaluate_checks.py` accept the
+   `relationships: [{repositories:[...]}]` shape (and/or both shapes) — if
+   `relationships.yaml` as written is the intended schema.
+2. **Fix the data + document the schema** — normalize `relationships.yaml` to
+   `project_repo_links: [{repos:[...]}]` and pin the schema in a template/pattern
+   so future files match the reader.
+3. **Align both to a single documented schema** and add a fixture-backed test in
+   `lib/pulse/scripts/tests/` so the drift can't recur silently.
+
+Preference: option 3 — pick one schema, document it (template + a line in the
+healthcheck-checks reference), and add a `project_linkage` fixture test to
+`evaluate_checks.py`'s suite so a mismatched shape fails CI instead of silently
+scoring `fail`.
+
+## Evidence
+
+- Live P3 dogfood: `project_linkage` read `fail` for a repo known to be linked;
+  inspection showed the key/shape mismatch above.
+
+## Notes
+
+Pre-existing P2/real-data drift, **not** introduced by the P3 diff — P3 only
+consumes `evaluate_checks.py` as-is. Surfaced because P3 was the first run of the
+evaluator against the real workspace's `relationships.yaml`.

--- a/docs/backlogs/2026-07-11-workspace-config-stale-catalog.md
+++ b/docs/backlogs/2026-07-11-workspace-config-stale-catalog.md
@@ -1,0 +1,53 @@
+# Backlog: Stale repository catalog in the dogfood workspace config
+
+**Date:** 2026-07-11
+**Status:** Open
+**Severity:** Medium (data, not code)
+**Found in:** P3 dogfood verification (PR #120 — `gh-healthcheck-headless` / `gh-refresh-headless` run against `~/git/hiivmind`)
+**Scope:** workspace data — `~/git/hiivmind/.hiivmind/github/config.yaml` (the `hiivmind-workspace` repo), not the plugin code
+
+## Problem
+
+The committed workspace `config.yaml` holds stale cached identifiers that no longer
+match GitHub:
+
+1. **`repositories[].full_name` for the plugin repo is wrong:** cached as
+   `hiivmind/gh`, which 404s. The real repository is `hiivmind/hiivmind-pulse-gh`.
+   `gh-healthcheck-headless` could not fetch repo metadata for that catalog entry —
+   the dogfood run had to use the skill's `repos` override to evaluate the correct
+   `owner/name` instead.
+2. **`workspace.id` was stale** (`O_kgDODUFJxM4BKJj5` vs. the actual
+   `O_kgDODUFJxA`). This one was **auto-corrected** by the `gh-refresh-headless`
+   dogfood run when it refreshed the `workspace` section — noted here only so the
+   correction is traceable and intentional, not a silent surprise on the next diff.
+
+## Impact
+
+- Any headless or interactive fleet audit that iterates the catalog by
+  `full_name` silently skips or misreports the plugin repo until the catalog is
+  fixed.
+- `workspace.id` is now corrected in the working tree but that change is
+  uncommitted (see below).
+
+## Evidence
+
+- `gh api repos/hiivmind/gh` → 404; `gh api repos/hiivmind/hiivmind-pulse-gh` → 200.
+- `gh-healthcheck-headless` errors[] on the stale entry; grade produced only after
+  the `repos` override.
+
+## Proposed fix
+
+- Refresh the `repositories` catalog for the dogfood workspace (interactive
+  `gh-refresh`, or `gh-refresh-headless --sections repositories` once that section
+  is refreshable) so `full_name` resolves to `hiivmind/hiivmind-pulse-gh`.
+- Review, then commit the corrected `workspace.id` (and the refreshed catalog) to
+  the `hiivmind-workspace` repo. The P3 dogfood runs left these as **uncommitted
+  working-tree changes** in `~/git/hiivmind/.hiivmind/github/` — the headless
+  skills deliberately never commit/push the workspace repo (the orchestrator owns
+  that step).
+
+## Notes
+
+Not a defect in the P3 diff — the headless skills behaved correctly given bad
+cached data (surfaced the 404 as an `errors[]` entry, corrected the org id on
+refresh). This is workspace-state hygiene.

--- a/docs/superpowers/specs/2026-07-10-workspace-root-and-headless-orchestration-design.md
+++ b/docs/superpowers/specs/2026-07-10-workspace-root-and-headless-orchestration-design.md
@@ -588,16 +588,16 @@ input still yields a valid result file with `errors[]` populated.
 
 Deliverables:
 
-- [ ] P4.1 Single executor pattern: `workflow-execution.md` becomes the one
+- [x] P4.1 Single executor pattern: `workflow-execution.md` becomes the one
       normative execution description; gh-heartbeat §4/§5 and gh-workflows
       "Run" reduced to delegation stubs referencing it.
-- [ ] P4.2 `headless:` policy block added to the workflow schema
+- [x] P4.2 `headless:` policy block added to the workflow schema
       (`on_ask`, `on_mutation`, `mutation_allowlist`); documented in
       `workflow-execution.md`; `operation-blocklist.md` declared
       unconditional in headless mode.
-- [ ] P4.3 `gh-workflow-run-headless` → `workflow-run-result.yaml` with
+- [x] P4.3 `gh-workflow-run-headless` → `workflow-run-result.yaml` with
       `findings` / `proposed_actions` / `asks_recorded`.
-- [ ] P4.4 Two shipped templates annotated with `headless:` blocks as
+- [x] P4.4 Two shipped templates annotated with `headless:` blocks as
       reference implementations (suggest: repo-healthcheck, stale-check).
 
 Exit criteria: the same workflow YAML runs interactively (ASKs prompt) and
@@ -674,7 +674,7 @@ work. Status values: `not-started | in-progress | blocked({on}) | done`.
 | P1 | Result contract + validator | P0 | ✅ done | 2026-07-10 |
 | P2 | Python extraction (poll, checks) | P0 | ✅ done | 2026-07-11 |
 | P3 | Headless skills (status/healthcheck/refresh) | P1, P2 | ✅ done | 2026-07-11 |
-| P4 | Executor split + headless policy | P1 | not-started | |
+| P4 | Executor split + headless policy | P1 | ✅ done | 2026-07-11 |
 | P5 | pulse-scheduler + fleet report **(goal 1)** | P3 (opt. P4.3) | not-started | |
 | P6 | Workflow v3: ledger, steps, gates **(goal 2)** | P4 | not-started | |
 | P7 | Housekeeping (CLAUDE.md, DAG doc, lint) | P0+ (final: P6) | not-started | |

--- a/lib/patterns/workflow-execution.md
+++ b/lib/patterns/workflow-execution.md
@@ -40,7 +40,7 @@ Caller contexts:
 |--------|------|----------|------------------|
 | gh-heartbeat (auto + user-selected workflows) | interactive | pre-approved | true |
 | gh-workflows "Run" (on demand) | interactive | pre-approved | false |
-| gh-workflow-run-headless | headless | pre-approved | true (unless its `ignore_cooldown` input) |
+| gh-workflow-run-headless | headless | pre-approved | true — but the skill pre-checks the cooldown itself (Phase 2) so it can emit `skipped-cooldown`, then delegates with `enforce_cooldown: false`; skipped entirely under its `ignore_cooldown` input |
 
 Poll-state paths in this document are relative to `{workspace_root}/.hiivmind/github/`.
 
@@ -254,7 +254,7 @@ delete, …); read-only operations always execute.
 | Mutation | per `on_mutation` — **propose**: append a one-line description (verb + target) to `proposed_actions`, do not execute; **allow-listed**: execute if the operation's verb is in `mutation_allowlist`, else propose; **allow**: execute |
 | `SHOW` / `PRESENT` phases | no user to show to; notable items become `findings` entries — `kind` from the workflow's domain (e.g. `stale-item`, `ci-failure`), `severity` via `INFER` with `inferred: true` |
 | `INFER` | executes normally; any finding it classifies carries `inferred: true` and its label in `classification` |
-| `INVOKE skill X` | if a headless sibling exists (`X-headless`), invoke it with explicit inputs (`workspace_path` from context); otherwise append `"invoke {X}"` to `proposed_actions` |
+| `INVOKE skill X` | if a headless sibling exists (`X-headless`), invoke it with explicit inputs (its `workspace_path` = the context's `workspace_root`); otherwise append `"invoke {X}"` to `proposed_actions` |
 | `STOP "reason"` | normal completion (outcome `success`); the reason lands in the result summary, not `errors` |
 | `params` with `default: null` | if the caller did not supply the param: append to `asks_recorded`, outcome `aborted` |
 

--- a/lib/patterns/workflow-execution.md
+++ b/lib/patterns/workflow-execution.md
@@ -227,6 +227,58 @@ presented workflows and the user selected which to run), downstream execution MU
 
 ---
 
+## Headless Execution (v2 Projection)
+
+One workflow definition serves both modes. A per-workflow policy block declares how
+interactive constructs project onto an unattended run — headless runs **replay policy**
+instead of guessing:
+
+```yaml
+headless:
+  enabled: true           # default false — a headless run of a non-enabled workflow
+                          # aborts (outcome: aborted, error "workflow not headless-enabled")
+  on_ask: record          # record | default | abort  (default: record)
+  on_mutation: propose    # propose | allow-listed | allow  (default: propose)
+  mutation_allowlist: []  # operation verbs permitted under allow-listed, e.g. [comment, label]
+```
+
+### Interpretation overrides in headless mode
+
+All other rows of the v2 interpretation table apply unchanged. A **mutation** is any
+state-changing GitHub operation (create, update, close, comment, label, merge, assign,
+delete, …); read-only operations always execute.
+
+| Construct | Headless behavior |
+|-----------|-------------------|
+| `ASK "q" (options)` | per `on_ask` — **record**: append `"{phase}: {q}"` to `asks_recorded`, then take the explicitly non-mutating option (skip/none/cancel) if one is offered, else end that branch and continue; **default**: take the workflow-declared default option, falling back to record behavior when none exists; **abort**: outcome `aborted`, write result, stop |
+| Mutation | per `on_mutation` — **propose**: append a one-line description (verb + target) to `proposed_actions`, do not execute; **allow-listed**: execute if the operation's verb is in `mutation_allowlist`, else propose; **allow**: execute |
+| `SHOW` / `PRESENT` phases | no user to show to; notable items become `findings` entries — `kind` from the workflow's domain (e.g. `stale-item`, `ci-failure`), `severity` via `INFER` with `inferred: true` |
+| `INFER` | executes normally; any finding it classifies carries `inferred: true` and its label in `classification` |
+| `INVOKE skill X` | if a headless sibling exists (`X-headless`), invoke it with explicit inputs (`workspace_path` from context); otherwise append `"invoke {X}"` to `proposed_actions` |
+| `STOP "reason"` | normal completion (outcome `success`); the reason lands in the result summary, not `errors` |
+| `params` with `default: null` | if the caller did not supply the param: append to `asks_recorded`, outcome `aborted` |
+
+### Unconditional rules (regardless of `on_mutation`)
+
+- `lib/references/operation-blocklist.md` applies **absolutely** in headless mode — a
+  blocked operation is never executed, not even under `on_mutation: allow`; it is
+  appended to `proposed_actions` prefixed `"blocked: "`.
+- Cooldowns are enforced (context `enforce_cooldown: true`); an active cooldown yields
+  outcome `skipped-cooldown` with a valid result file — never a silent skip.
+- v1 (`actions:`) workflows are not headless-runnable: outcome `aborted`, error
+  `"v1 workflows have no headless projection"`.
+
+### Result file
+
+Headless runs write `workflow-run-result.yaml` per `lib/patterns/headless-contract.md`
+(kind `workflow-run`) to `{workspace_root}/.hiivmind/github/workflow-run-result.yaml`
+(or the caller's `result_path`), and still record `last_run_at` / `last_result` /
+`run_count` in poll-state as usual. `run_id` = `{UTC date}-{gh_login}-{n}` with `n` =
+UTC `HHMMSS` at run start — actor-embedded so concurrent machines cannot collide
+(interim scheme until the P6 run ledger assigns sequence numbers).
+
+---
+
 ## Cooldown Check
 
 Before executing any workflow (skip when the context has `enforce_cooldown: false`):

--- a/lib/patterns/workflow-execution.md
+++ b/lib/patterns/workflow-execution.md
@@ -17,6 +17,35 @@ Execute workflows after triggers fire, with format detection, parameter resoluti
 
 ---
 
+## Single Executor
+
+This document is the ONE normative execution description. gh-heartbeat, gh-workflows
+"Run", and gh-workflow-run-headless are **callers**: they select workflows, obtain
+approval, build an execution context, and delegate here. Skills MUST NOT re-describe
+execution steps.
+
+Callers supply an execution context:
+
+| Field | Values | Meaning |
+|-------|--------|---------|
+| `mode` | `interactive` \| `headless` | interactive: ASK/SHOW reach a user. headless: policy projection (see Headless Execution below) |
+| `approval` | `pre-approved` \| `ask` | pre-approved skips the `auto: false` permission gate (step 3 of the flow) |
+| `enforce_cooldown` | `true` \| `false` | on-demand interactive runs pass `false` |
+| `workspace_root` | path | resolved by the caller (interactive walk-up, or explicit headless input — D4) |
+| `repo` | `owner/name` or empty | repo scope, when the caller has one |
+
+Caller contexts:
+
+| Caller | mode | approval | enforce_cooldown |
+|--------|------|----------|------------------|
+| gh-heartbeat (auto + user-selected workflows) | interactive | pre-approved | true |
+| gh-workflows "Run" (on demand) | interactive | pre-approved | false |
+| gh-workflow-run-headless | headless | pre-approved | true (unless its `ignore_cooldown` input) |
+
+Poll-state paths in this document are relative to `{workspace_root}/.hiivmind/github/`.
+
+---
+
 ## Format Detection
 
 Workflows exist in two formats. Detect which format before executing:
@@ -200,14 +229,14 @@ presented workflows and the user selected which to run), downstream execution MU
 
 ## Cooldown Check
 
-Before executing any workflow:
+Before executing any workflow (skip when the context has `enforce_cooldown: false`):
 
 ```bash
 WORKFLOW_NAME="$1"
 WORKFLOW_FILE="$2"
 
 COOLDOWN=$(yq -r '.cooldown_minutes // 5' "$WORKFLOW_FILE")
-LAST_RUN=$(yq -r ".workflows.\"${WORKFLOW_NAME}\".last_run_at // \"null\"" .hiivmind/github/poll-state.yaml)
+LAST_RUN=$(yq -r ".workflows.\"${WORKFLOW_NAME}\".last_run_at // \"null\"" "${WORKSPACE_ROOT}/.hiivmind/github/poll-state.yaml")
 
 if [[ "$LAST_RUN" != "null" ]]; then
     NOW=$(date -u +%s)

--- a/lib/references/operation-blocklist.md
+++ b/lib/references/operation-blocklist.md
@@ -24,6 +24,13 @@ When a user requests a blocked operation:
 
 **Do not proceed** with blocked operations under any circumstances.
 
+### Headless mode
+
+In headless workflow runs this blocklist is **unconditional**: it overrides any
+`headless.on_mutation` policy, including `allow`. The executor records the blocked
+operation in the result file's `proposed_actions` with a `"blocked: "` prefix and
+continues. See `lib/patterns/workflow-execution.md` — Headless Execution.
+
 ## Why These Operations Are Blocked
 
 ### Repository Deletion

--- a/skills/gh-healthcheck-headless/SKILL.md
+++ b/skills/gh-healthcheck-headless/SKILL.md
@@ -125,7 +125,7 @@ uv run "${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/evaluate_checks.py" \
 contract_version: 1
 kind: healthcheck
 workspace: {LOGIN}
-run_at: {RUN_AT}
+run_at: "{RUN_AT}"    # quote: an unquoted ISO-8601 value parses as a YAML datetime; the contract requires a string
 actor: { gh_login: {GH_LOGIN}, machine: {MACHINE}, mode: {MODE} }
 repos: {REPO_RESULTS}          # each: {repo, score, total, grade, checks}
 aggregate: { score: {sum}, total: {sum}, grade: {computed} }

--- a/skills/gh-heartbeat/SKILL.md
+++ b/skills/gh-heartbeat/SKILL.md
@@ -152,32 +152,17 @@ Display what was detected:
 
 ### 4. Execute Auto Workflows
 
-**Execution context:** Auto workflows are pre-approved by definition. Execute without confirmation.
-When invoking downstream skills (operations, refresh), all execution is pre-approved — do NOT
-re-confirm with the user.
+Auto workflows are pre-approved by definition — execute without confirmation, and do NOT
+re-confirm operations invoked downstream.
 
-**See:** `{PLUGIN_ROOT}/lib/patterns/workflow-execution.md`
-
-For each workflow in `auto_workflows`:
-
-1. Load workflow YAML from `.hiivmind/github/workflows/`
-2. Detect format:
-   - **If `workflow:` field exists (v2):** Follow the pseudocode handoff pattern:
-     - Read `state:` field and initialize variables
-     - If `params:` exists, resolve parameters (extract from context → apply defaults → ASK for required)
-     - Follow the `workflow:` pseudocode as executable instructions
-     - Use gh-operations for data operations, AskUserQuestion for `ASK` statements
-     - Track state variables through FSM phases
-   - **If `actions:` field exists (v1):** Fall back to sequential dispatch:
-     - Execute actions in order
-     - `operation` → invoke gh-operations with the operation string
-     - `skill_invoke` → invoke the named skill
-3. Update poll-state.yaml with result
+**Delegate to the executor:** for each workflow in `auto_workflows`, execute it per
+`{PLUGIN_ROOT}/lib/patterns/workflow-execution.md` with context
+`{mode: interactive, approval: pre-approved, enforce_cooldown: true, workspace_root: <resolved root>}`.
+The executor owns format detection (v1/v2), parameter resolution, FSM interpretation,
+and poll-state result recording — this skill only reports the outcome:
 
 ```
 Running auto workflow: auto-refresh
-  Following workflow pseudocode...
-  EXECUTE: Invoking skill hiivmind-pulse-gh:gh-refresh
   Result: success
 ```
 
@@ -210,13 +195,9 @@ without any further confirmation. This means:
 
 **See:** `{PLUGIN_ROOT}/lib/patterns/workflow-execution.md` (Pre-Approved Execution section)
 
-For each selected workflow, execute using the workflow execution pattern:
-
-1. Load workflow YAML
-2. Detect format:
-   - **v2 (`workflow:` field):** Follow pseudocode handoff — resolve params, follow FSM
-   - **v1 (`actions:` field):** Sequential dispatch
-3. Update poll-state.yaml with result
+**Delegate to the executor:** for each selected workflow, execute it per
+`{PLUGIN_ROOT}/lib/patterns/workflow-execution.md` with context
+`{mode: interactive, approval: pre-approved, enforce_cooldown: true, workspace_root: <resolved root>}`.
 
 ### 6. Collect Results
 

--- a/skills/gh-refresh-headless/SKILL.md
+++ b/skills/gh-refresh-headless/SKILL.md
@@ -127,7 +127,7 @@ NOW=$(git -C "$CONFIG_DIR" status --porcelain 2>/dev/null | sort | shasum | cut 
 contract_version: 1
 kind: refresh
 workspace: {LOGIN}
-run_at: {RUN_AT}
+run_at: "{RUN_AT}"    # quote: an unquoted ISO-8601 value parses as a YAML datetime; the contract requires a string
 actor: { gh_login: {GH_LOGIN}, machine: {MACHINE}, mode: {MODE} }
 sections: {SECTION_RESULTS}    # every section in ALL_SECTIONS: {id, status}
 config_updated: {bool}

--- a/skills/gh-status-headless/SKILL.md
+++ b/skills/gh-status-headless/SKILL.md
@@ -91,7 +91,7 @@ gh api rate_limit --jq '.resources.core.remaining'
 contract_version: 1
 kind: status
 workspace: {LOGIN}
-run_at: {RUN_AT}
+run_at: "{RUN_AT}"    # quote: an unquoted ISO-8601 value parses as a YAML datetime; the contract requires a string
 actor:
   gh_login: {GH_LOGIN}
   machine: {MACHINE}

--- a/skills/gh-workflow-run-headless/SKILL.md
+++ b/skills/gh-workflow-run-headless/SKILL.md
@@ -102,13 +102,14 @@ Update poll-state (`last_run_at`, `last_result`, `run_count`) as the executor sp
 contract_version: 1
 kind: workflow-run
 workspace: {LOGIN}
-run_at: {RUN_AT}
+run_at: "{RUN_AT}"               # quote: an unquoted ISO-8601 value parses as a YAML datetime; the contract requires a string
 actor: { gh_login: {GH_LOGIN}, machine: {MACHINE}, mode: {MODE} }
 workflow: {workflow name from YAML}
 repos: {[repo input] if given, else repos the workflow touched, else []}
-run_id: {RUN_ID}
+run_id: "{RUN_ID}"               # quote: keep it a string (the {date}-... prefix would otherwise risk datetime coercion)
 outcome: {OUTCOME}
 findings: {FINDINGS}              # [{kind, repo, severity, detail?, ref?, classification?, inferred?}]
+                                 # ref, when present, is a MAPPING: { type: <str>, id: <any>, url: <str> } (see headless-contract.md) — never a bare string
 proposed_actions: {PROPOSED_ACTIONS}
 asks_recorded: {ASKS_RECORDED}
 errors: {ERRORS}

--- a/skills/gh-workflow-run-headless/SKILL.md
+++ b/skills/gh-workflow-run-headless/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: gh-workflow-run-headless
+description: >
+  Run a v2 workflow non-interactively under its headless policy. ASKs are recorded, withheld
+  mutations become proposed_actions, notable items become typed findings; writes
+  workflow-run-result.yaml (kind: workflow-run). Zero prompts; explicit inputs only. Use when:
+  a scheduler runs a workflow unattended, an orchestrator needs a workflow's findings as data.
+  Trigger phrases: "headless workflow run", "run workflow headless", "scheduled workflow".
+inputs:
+  workspace_path: "required — absolute path to the workspace root (directory containing .hiivmind/github/)"
+  workflow: "required — workflow name; resolved to {workspace_path}/.hiivmind/github/workflows/{workflow}.yaml"
+  workflow_path: "optional — explicit YAML path, overriding name resolution (e.g. a repo-overlay workflow)"
+  params: "optional — parameter values as a YAML/JSON map; params with default: null and no value here abort the run"
+  repo: "optional — owner/name repo scope recorded in the result and passed to the executor context"
+  result_path: "optional — default: {workspace_path}/.hiivmind/github/workflow-run-result.yaml"
+  ignore_cooldown: "optional — skip the cooldown check (default: false)"
+  mode: "optional — actor mode recorded in the result: interactive | scheduled (default: scheduled)"
+outputs:
+  result_file: "workflow-run-result.yaml conforming to lib/patterns/headless-contract.md (kind: workflow-run)"
+author: hiivmind
+---
+
+# Headless Workflow Run
+
+Execute one v2 workflow with no user present. This skill is a thin caller: it builds the
+execution context and delegates to the executor
+(`lib/patterns/workflow-execution.md` — read the **Headless Execution** section in full
+before executing). The workflow definition is untouched — the same YAML serves
+interactive runs.
+
+## Path Convention
+
+`{PLUGIN_ROOT}` = plugin root (where plugin.json lives).
+
+## Contract
+
+- **Zero prompts. Explicit inputs only (D4). Every exit writes a result file** —
+  including cooldown skips (`outcome: skipped-cooldown`) and aborts (`outcome: aborted`).
+- The operation blocklist is absolute regardless of the workflow's `on_mutation` policy.
+
+## State
+
+```
+computed:
+  CONFIG_DIR   = {workspace_path}/.hiivmind/github
+  WF_PATH      = {workflow_path input, or CONFIG_DIR/workflows/{workflow}.yaml}
+  RESULT_PATH  = {result_path input, or CONFIG_DIR/workflow-run-result.yaml}
+  RUN_AT       = $(date -u +%Y-%m-%dT%H:%M:%SZ)
+  LOGIN        = yq -r '.workspace.login' CONFIG_DIR/config.yaml
+  GH_LOGIN     = $(gh api user --jq .login)   ("unknown" on failure, + errors[] entry)
+  MACHINE      = $(hostname -s)
+  MODE         = {mode input, default "scheduled"}
+  RUN_ID       = {UTC date}-{GH_LOGIN}-{UTC HHMMSS}   e.g. 2026-07-10-octocat-093012
+  OUTCOME      = success | failure | skipped-cooldown | aborted
+  FINDINGS, PROPOSED_ACTIONS, ASKS_RECORDED, ERRORS = []   (accumulated by the executor)
+```
+
+## Phase 1: VALIDATE
+
+**Outputs:** loaded workflow, policy.
+
+1. `workspace_path` or `workflow` missing → ABORT `"missing required input: {name}"`.
+2. `CONFIG_DIR/config.yaml` missing or lacking `^workspace:` → ABORT
+   `"not a workspace root: {workspace_path}"`.
+3. `WF_PATH` missing → ABORT `"workflow not found: {WF_PATH}"`.
+4. Load the YAML. No `workflow:` field (v1 or malformed) → ABORT
+   `"v1 workflows have no headless projection"` / `"invalid workflow YAML"`.
+5. `headless.enabled` not `true` → ABORT `"workflow not headless-enabled: {workflow}"`.
+6. `enabled: false` on the workflow itself → ABORT `"workflow disabled: {workflow}"`.
+7. Resolve params: merge the `params` input over the workflow's declared defaults.
+   Any param left at `default: null` → append its name to ASKS_RECORDED, ABORT
+   `"missing required param: {name}"` (outcome: aborted — the contract's designed
+   behavior for unanswerable required params).
+8. Verify gitignore coverage (`*-result.yaml`) in CONFIG_DIR, append if missing.
+
+## Phase 2: COOLDOWN
+
+Unless `ignore_cooldown: true`: perform the executor's cooldown check against
+`CONFIG_DIR/poll-state.yaml`. If active → OUTCOME = `skipped-cooldown`, go straight to
+Phase 4 (write result; this is a valid, complete run).
+
+## Phase 3: EXECUTE
+
+**Delegate to the executor:** run the workflow per
+`{PLUGIN_ROOT}/lib/patterns/workflow-execution.md` with context
+`{mode: headless, approval: pre-approved, enforce_cooldown: false (already checked),
+workspace_root: {workspace_path}, repo: {repo input}}`, applying the Headless Execution
+projection with the workflow's `headless:` policy. Accumulate FINDINGS,
+PROPOSED_ACTIONS, ASKS_RECORDED per the projection table.
+
+- Pseudocode completed (end or `STOP`) → OUTCOME = `success`.
+- Unrecoverable error → OUTCOME = `failure`, append to ERRORS, proceed to Phase 4.
+- `on_ask: abort` triggered → OUTCOME = `aborted`, proceed to Phase 4.
+
+Update poll-state (`last_run_at`, `last_result`, `run_count`) as the executor specifies.
+
+## Phase 4: WRITE + VALIDATE
+
+1. Write RESULT_PATH:
+
+```yaml
+contract_version: 1
+kind: workflow-run
+workspace: {LOGIN}
+run_at: {RUN_AT}
+actor: { gh_login: {GH_LOGIN}, machine: {MACHINE}, mode: {MODE} }
+workflow: {workflow name from YAML}
+repos: {[repo input] if given, else repos the workflow touched, else []}
+run_id: {RUN_ID}
+outcome: {OUTCOME}
+findings: {FINDINGS}              # [{kind, repo, severity, detail?, ref?, classification?, inferred?}]
+proposed_actions: {PROPOSED_ACTIONS}
+asks_recorded: {ASKS_RECORDED}
+errors: {ERRORS}
+```
+
+2. Validate:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py" "$RESULT_PATH" --kind workflow-run
+```
+
+   Exit ≠ 0 → skill bug; report validator stderr verbatim.
+
+3. Print a one-line log summary:
+   `workflow-run: {workflow} outcome={OUTCOME} findings={n} proposed={n} asks={n}`
+
+## ABORT semantics
+
+Every ABORT above sets OUTCOME = `aborted`, appends the reason to ERRORS, and falls
+through to Phase 4 — the result file is always written and validated. If CONFIG_DIR is
+unusable, write to the `result_path` input, else `workflow-run-result.yaml` in the
+current directory, and say so.
+
+## Related
+
+- `lib/patterns/workflow-execution.md` — the executor + Headless Execution projection
+- `lib/patterns/headless-contract.md` — the workflow-run schema
+- `lib/references/operation-blocklist.md` — absolute in headless mode

--- a/skills/gh-workflows/SKILL.md
+++ b/skills/gh-workflows/SKILL.md
@@ -157,56 +157,14 @@ yq -i '.enabled = false' "$WORKFLOWS_DIR/${WF_NAME}.yaml"  # disable
 
 ### Run Workflow (On Demand)
 
-**See:** `{PLUGIN_ROOT}/lib/patterns/workflow-execution.md`
+On-demand runs are pre-approved by the user's request and skip cooldowns.
 
-1. Load the workflow YAML
-2. Skip cooldown check (on-demand ignores cooldown)
-3. Detect format and execute:
-
-**V2 workflows (has `workflow:` field):**
-
-1. If workflow has `params:`, resolve parameters:
-   - Extract values from the user's run request (e.g., "run commit-summary last 3 days on main")
-   - Apply defaults for params not mentioned
-   - ASK for required params (where `default: null`) that weren't provided
-2. Initialize `state:` variables
-3. Follow the `workflow:` pseudocode as executable instructions
-4. Update poll-state.yaml with result
-
-```
-Running workflow: ci-monitor
-
-Following workflow pseudocode...
-
-GATHER: Listing recent failed workflow runs...
-  Found 2 failures.
-  Classifying each failure...
-
-PRESENT:
-  | Workflow | Branch | Classification | You Touched | Time |
-  |----------|--------|----------------|-------------|------|
-  | CI       | main   | test           | yes         | 2h ago |
-  | Deploy   | main   | infra          | no          | 5h ago |
-
-  Which failure to investigate?
-```
-
-**V1 workflows (has `actions:` field, legacy):**
-
-1. Execute actions sequentially
-2. Update poll-state.yaml with result
-
-```
-Running workflow: pr-lifecycle
-
-Action 1/2: Summarize open PRs
-[operations skill output]
-
-Action 2/2: Highlight review needs
-[operations skill output]
-
-Workflow complete. Result: success
-```
+**Delegate to the executor:** execute the named workflow per
+`{PLUGIN_ROOT}/lib/patterns/workflow-execution.md` with context
+`{mode: interactive, approval: pre-approved, enforce_cooldown: false, workspace_root: <resolved root>}`.
+The executor owns format detection, parameter resolution (extract from the run request →
+defaults → ASK for required), FSM interpretation, and poll-state recording. Report the
+executor's summary when it finishes.
 
 ### Create Workflow
 

--- a/templates/workflow.yaml.template
+++ b/templates/workflow.yaml.template
@@ -8,6 +8,14 @@ description: "{{workflow_description}}"
 enabled: true
 auto: false  # true = execute without asking, false = present and ask
 
+# Headless policy (optional) — how this workflow projects onto unattended runs.
+# See lib/patterns/workflow-execution.md "Headless Execution". Absent => headless disabled.
+# headless:
+#   enabled: true
+#   on_ask: record          # record | default | abort
+#   on_mutation: propose    # propose | allow-listed | allow
+#   mutation_allowlist: []  # verbs permitted when allow-listed, e.g. [comment, label]
+
 trigger:
   type: {{trigger_type}}  # session_poll | post_operation | freshness | on_demand
   source: {{trigger_source}}  # pull_requests | issues | actions | projects | config

--- a/templates/workflows/repo-healthcheck.yaml
+++ b/templates/workflows/repo-healthcheck.yaml
@@ -7,6 +7,13 @@ description: "Run governance healthcheck to assess repository maturity"
 enabled: true
 auto: false  # Must be explicitly requested — never runs automatically
 
+# Reference headless annotation: the audit is read-only; INVOKE maps to the
+# gh-healthcheck-headless sibling when present (see workflow-execution.md).
+headless:
+  enabled: true
+  on_ask: record
+  on_mutation: propose   # fixes are proposed, never applied unattended
+
 trigger:
   type: on_demand
   condition: user_requested

--- a/templates/workflows/stale-check.yaml
+++ b/templates/workflows/stale-check.yaml
@@ -7,6 +7,14 @@ description: "Find stale PRs and issues, prioritize by age, and offer actions"
 enabled: true
 auto: false
 
+# Reference headless annotation: stale items become findings; ping/label may run
+# unattended, close is only ever proposed.
+headless:
+  enabled: true
+  on_ask: record
+  on_mutation: allow-listed
+  mutation_allowlist: [comment, label]
+
 trigger:
   type: session_poll
   source: pull_requests


### PR DESCRIPTION
## P4 — Workflow Executor Split + Headless Policy

Traces to `docs/superpowers/specs/2026-07-10-workspace-root-and-headless-orchestration-design.md` (Part 6.1, §P4). Makes `lib/patterns/workflow-execution.md` the single normative workflow executor, adds a per-workflow `headless:` policy block so the same v2 YAML runs interactively and unattended, and ships `gh-workflow-run-headless` writing `workflow-run-result.yaml`.

### What changed

- **P4.1 — Single executor.** `workflow-execution.md` gains a `## Single Executor` section: callers build an execution context (`mode`, `approval`, `enforce_cooldown`, `workspace_root`, `repo`) and delegate. gh-heartbeat §4/§5 and gh-workflows "Run" reduced to delegation stubs — no execution steps re-described (verified: `grep "Detect format"` → 0 in both callers).
- **P4.2 — Headless policy + projection.** `## Headless Execution (v2 Projection)` documents the `headless:` block (`enabled`, `on_ask`, `on_mutation`, `mutation_allowlist`) and the projection table (ASK→asks_recorded, mutation→proposed_actions per policy, SHOW→findings, INFER/INVOKE/STOP/params-null). The operation blocklist is declared **unconditional** in headless mode — even under `on_mutation: allow`, blocked ops go to `proposed_actions` prefixed `"blocked: "`, never executed.
- **P4.3 — `gh-workflow-run-headless`.** New thin-caller skill: VALIDATE → COOLDOWN → EXECUTE (delegate) → WRITE+VALIDATE. Zero prompts, explicit inputs only (D4). Writes `workflow-run-result.yaml` (kind: workflow-run) with `findings` / `proposed_actions` / `asks_recorded`; every exit (including cooldown skip and abort) emits a validator-passing result.
- **P4.4 — Reference annotations.** `repo-healthcheck.yaml` (read-only → `on_mutation: propose`) and `stale-check.yaml` (`allow-listed`, `[comment, label]`) gain additive `headless:` blocks; interactive definitions unchanged.

### Dogfood + hardening

A live headless `stale-check` run against the real workspace produced a **valid** result (outcome `success`, 30 `stale-item` findings, 0 proposed actions, 1 recorded ASK). It surfaced a contract-fidelity gap in the plan-verbatim result templates: an unquoted ISO-8601 `run_at` parses as a YAML datetime (validator requires str) and a bare-string `findings[].ref` is rejected (contract requires the `{type,id,url}` mapping). Fixed across **all four** headless result templates (`run_at`/`run_id` quoted) and documented `ref`'s mapping shape in `gh-workflow-run-headless`.

Also folds in the two P3 dogfood follow-up backlog docs (stale catalog, relationships schema drift).

### Verification

- `uv run pytest -q` → 30/30 green (no Python changed; sanity).
- Live dogfood result validates: `validate_result.py --kind workflow-run` exit 0.
- Interactive-parity: workspace `stale-check.yaml` diff is additive-only (the `headless:` block; 0 changed lines) — same YAML, both modes.
- Whole-branch review (opus): **READY TO MERGE**, no Critical/Important; two Minor doc nits applied.

Version bumped 4.7.0 → 4.8.0. Spec P4.1–P4.4 ticked; §8.9 P4 row ✅ done 2026-07-11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
