### PR TITLE
P5: pulse-scheduler close-out (goal 1 complete)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -353,6 +353,16 @@ This keeps the plugin lean for distribution while allowing comprehensive test co
 
 ---
 
+## Scheduled Maintenance
+
+Unattended fleet maintenance lives in a separate repo:
+[hiivmind-pulse-scheduler](https://github.com/hiivmind/hiivmind-pulse-scheduler) —
+a shared `TEMPLATE-workspace-maintenance.md` composes the headless skills
+(status pre-check → refresh → fleet healthcheck → PR on the workspace repo);
+thin per-workspace stubs are symlinked into `~/.claude/scheduled-tasks/`.
+
+---
+
 ## Plugin Development Resources
 
 When working on plugin structure, use the `plugin-dev` skills:

--- a/docs/superpowers/specs/2026-07-10-workspace-root-and-headless-orchestration-design.md
+++ b/docs/superpowers/specs/2026-07-10-workspace-root-and-headless-orchestration-design.md
@@ -611,15 +611,15 @@ runs are in scope for v1 of the template — otherwise P3 alone).
 
 Deliverables:
 
-- [ ] P5.1 New repo `hiivmind-pulse-scheduler`: CLAUDE.md, symlink deployment
+- [x] P5.1 New repo `hiivmind-pulse-scheduler`: CLAUDE.md, symlink deployment
       docs (copy corpus-scheduler conventions).
-- [ ] P5.2 `TEMPLATE-workspace-maintenance.md`: status pre-check
+- [x] P5.2 `TEMPLATE-workspace-maintenance.md`: status pre-check
       (optimization-never-gate) → refresh → fleet healthcheck → commit/PR to
       workspace repo, with superseded-PR cleanup.
-- [ ] P5.3 One stub (`workspace-maintenance-hiivmind/`) with
+- [x] P5.3 One stub (`workspace-maintenance-hiivmind/`) with
       `WORKSPACE_PATH` / `WORKSPACE_REPO` / `BRANCH_PREFIX`; symlinked into
       `~/.claude/scheduled-tasks/`.
-- [ ] P5.4 Fleet report format in the PR body: per-repo grades + deltas,
+- [x] P5.4 Fleet report format in the PR body: per-repo grades + deltas,
       `asks_recorded` / `proposed_actions` under a "Needs attention" heading.
 
 Exit criteria: one unattended scheduled run against the hiivmind workspace
@@ -675,7 +675,7 @@ work. Status values: `not-started | in-progress | blocked({on}) | done`.
 | P2 | Python extraction (poll, checks) | P0 | ✅ done | 2026-07-11 |
 | P3 | Headless skills (status/healthcheck/refresh) | P1, P2 | ✅ done | 2026-07-11 |
 | P4 | Executor split + headless policy | P1 | ✅ done | 2026-07-11 |
-| P5 | pulse-scheduler + fleet report **(goal 1)** | P3 (opt. P4.3) | not-started | |
+| P5 | pulse-scheduler + fleet report **(goal 1)** | P3 (opt. P4.3) | ✅ done | 2026-07-12 |
 | P6 | Workflow v3: ledger, steps, gates **(goal 2)** | P4 | not-started | |
 | P7 | Housekeeping (CLAUDE.md, DAG doc, lint) | P0+ (final: P6) | not-started | |
 


### PR DESCRIPTION
## P5 — hiivmind-pulse-scheduler (completes goal 1)

Spec/docs close-out for P5. **The substantive P5 deliverable lives in a separate new repo:**
[hiivmind/hiivmind-pulse-scheduler](https://github.com/hiivmind/hiivmind-pulse-scheduler)
(pushed directly to its `main` per the plan — skeleton + shared `TEMPLATE-workspace-maintenance.md` + the `workspace-maintenance-hiivmind` stub, symlinked into `~/.claude/scheduled-tasks/`).

This branch contains only the plugin-repo close-out (no plugin code changed, **no version bump**):
- Tick P5.1–P5.4; §8.9 table P5 row → ✅ done (2026-07-12)
- CLAUDE.md: add `## Scheduled Maintenance` section

### Dogfood (Task 4 — executed live)
One unattended run against the hiivmind workspace produced a fleet-report PR (hiivmind/hiivmind-workspace #1, since **merged**): corrected stale `workspace.id` + `repositories[].full_name`; fleet audit `hiivmind-pulse-gh` B (6.5/9); all four result files validated; clean diff (no transients). Second-run pre-check verified at logic level. Refresh was scoped to workspace + repositories (full multi-section path is P3-validated).

### Reviews
Per-task reviews clean (Tasks 1–5). Final whole-branch review (opus): **READY TO MERGE**, no Critical/Important. One Minor (latent `previous_grades` short-name↔full-name join in Phase 5 — plan-verbatim, non-blocking). pytest 30/30 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)