### PR TITLE
P6: Workflow schema v3 — run ledger, steps, gates, resumability (goal 2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   "repository": "https://github.com/hiivmind/hiivmind-pulse-gh",
   "metadata": {
     "description": "GitHub workspace initialization and API documentation corpus. Run init once, then use gh CLI directly with routing guide and corpus for GraphQL/REST operations.",
-    "version": "4.0.0"
+    "version": "4.9.0"
   },
   "plugins": [
     {
       "name": "gh",
       "source": "./",
       "description": "GitHub workspace initialization and embedded API documentation corpus. Initialize once to cache project/repo IDs, then use gh CLI directly with routing guide for API decisions and corpus for exact syntax. Covers Projects v2, milestones, issues, PRs, branch protection, rulesets, actions, secrets, variables, and releases.",
-      "version": "4.0.0",
+      "version": "4.9.0",
       "keywords": [
         "github",
         "graphql",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gh",
   "description": "GitHub workspace initialization and API documentation corpus. Run init once, then use gh CLI directly with routing guide and corpus for GraphQL/REST operations.",
-  "version": "4.8.0",
+  "version": "4.9.0",
   "author": {
     "name": "Nathaniel Ramm <nathaniel@hiivmind.ai>"
   },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Static lookup data for routing and domain info:
 | Reference | Purpose |
 |-----------|---------|
 | `lib/references/api-routing.md` | Quick reference + method selection guide |
-| `lib/references/domains/*.md` | Per-domain detailed syntax (25 files) |
+| `lib/references/domains/*.md` | Per-domain detailed syntax (26 files) |
 | `lib/references/token-permissions.md` | Token permission requirements |
 | `lib/references/healthcheck-checks.md` | Healthcheck check catalog (11 checks) |
 
@@ -324,7 +324,7 @@ hiivmind-pulse-gh/
 │   └── references/                       # WHAT exists (static lookup data)
 │       ├── api-routing.md                # Quick reference + method selection
 │       ├── token-permissions.md          # Token permission requirements
-│       └── domains/                      # Per-domain detailed syntax (25 files)
+│       └── domains/                      # Per-domain detailed syntax (26 files)
 │           ├── issues.md
 │           ├── pull-requests.md
 │           └── ...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,7 @@ Executable guides with step-by-step instructions:
 | `lib/patterns/corpus-lookup.md` | Look up API syntax when uncertain |
 | `lib/patterns/healthcheck-evaluation.md` | Healthcheck evaluation logic per check |
 | `lib/patterns/workflow-execution.md` | THE workflow executor (single normative description; interactive + headless) |
+| `lib/patterns/run-ledger.md` | Run ledger: resumable cross-repo runs |
 
 ### References (WHAT exists)
 
@@ -317,7 +318,9 @@ hiivmind-pulse-gh/
 │   │       ├── poll.py                   # Heartbeat engine (GraphQL + lakehouse)
 │   │       ├── evaluate_checks.py        # Mechanical healthcheck evaluator
 │   │       ├── freshness_status.py       # Staleness computation for headless status
-│   │       └── validate_result.py        # Headless result contract validator
+│   │       ├── validate_result.py        # Headless result contract validator
+│   │       ├── resolve_run.py            # Run-ledger operations
+│   │       └── workflow_lint.py          # Workflow YAML lint
 │   └── references/                       # WHAT exists (static lookup data)
 │       ├── api-routing.md                # Quick reference + method selection
 │       ├── token-permissions.md          # Token permission requirements

--- a/README.md
+++ b/README.md
@@ -1,63 +1,75 @@
 # hiivmind-pulse-gh
 
-A Claude Code plugin for deep GitHub automation — Projects v2, Milestones, Branch Protection, and more.
+A Claude Code plugin that enriches **every** GitHub operation with cached workspace
+context — Projects v2, milestones, branch protection, and more — and layers on a
+headless automation engine for unattended fleet maintenance and resumable,
+cross-repo workflows.
 
 ## The Problem
 
 GitHub's APIs are powerful but painful:
-- **GraphQL node IDs** — Every operation needs opaque IDs like `PVT_kwDOBx...`
-- **Repeated lookups** — "What's the ID for the Status field? What's the option ID for 'In Progress'?"
-- **Context amnesia** — Each Claude session starts fresh, forgetting your org structure
+- **GraphQL node IDs** — every operation needs opaque IDs like `PVT_kwDOBx...`
+- **Repeated lookups** — "What's the ID for the Status field? The option ID for 'In Progress'?"
+- **Context amnesia** — each Claude session starts fresh, forgetting your org structure
+- **No unattended path** — scheduled or headless maintenance needs zero-prompt skills and
+  a machine-readable result contract, not interactive prose
 
 ## The Solution
 
-This plugin takes a **discover-once, use-forever** approach:
+A **discover-once, use-forever** cache plus a deterministic Python engine:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
 │  1. DISCOVER                                                     │
-│     Init skill inspects your GitHub org structure               │
-│     → Projects, fields, options, repositories, milestones       │
+│     Init inspects your GitHub org structure                     │
+│     → projects, fields, options, repositories, milestones       │
 │                                                                  │
 │  2. CACHE                                                        │
-│     Store discovered IDs in .hiivmind/github/config.yaml        │
-│     → Committed to git, shared with team                        │
+│     Store discovered IDs in {workspace_root}/.hiivmind/github/   │
+│     → committed to a shared workspace repo, synced across team   │
 │                                                                  │
 │  3. USE                                                          │
-│     Gateway command routes to appropriate skill                 │
-│     → Natural language intent detection, corpus-backed syntax   │
+│     Gateway routes intent → skill; every op is enriched with     │
+│     cached IDs. Headless skills + workflows automate the rest.   │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
+**Rule of thumb:** if a workspace root resolves above your cwd (a
+`.hiivmind/github/config.yaml` with a top-level `workspace:` section, at any parent
+depth), route **all** GitHub operations through this plugin — even simple ones —
+so they pick up context enrichment (auto-link to project, set Status, resolve
+milestone names, etc.).
+
 ## Installation
 
-### 1. Install Prerequisites
+### 1. Install prerequisites
 
 | Tool | Purpose | Install |
 |------|---------|---------|
 | **gh** | GitHub CLI | [cli.github.com](https://cli.github.com/) |
 | **jq** | JSON processing | `apt install jq` / `brew install jq` |
-| **yq** | YAML processing | [github.com/mikefarah/yq](https://github.com/mikefarah/yq) |
+| **yq** (v4+) | YAML processing | [github.com/mikefarah/yq](https://github.com/mikefarah/yq) |
+| **uv** | runs the bundled Python scripts (PEP 723) | [docs.astral.sh/uv](https://docs.astral.sh/uv/) |
 
 ```bash
 # Verify installation
-gh auth status && jq --version && yq --version
+gh auth status && jq --version && yq --version && uv --version
 
 # Ensure gh has required scopes
-gh auth refresh -s read:project -s project -s repo
+gh auth refresh -s read:project -s project -s repo -s read:org
 ```
 
-### 2. Install the Plugin
+### 2. Install the plugin
 
-```bash
+Run these in Claude Code (not a terminal):
+
+```
 # Add the marketplace
-/plugin marketplace add hiivmind/gh
+/plugin marketplace add hiivmind/hiivmind-pulse-gh
 
-# Install the plugin
-/plugin install hiivmind-pulse-gh@hiivmind-pulse-gh
+# Install the plugin (plugin name `gh`, marketplace `hiivmind-pulse-gh`)
+/plugin install gh@hiivmind-pulse-gh
 ```
-
-Run these commands in Claude Code (not in a terminal).
 
 ## Gateway Command
 
@@ -77,118 +89,129 @@ The primary entry point for all GitHub operations:
 /gh protect main branch with required reviews
 /gh trigger workflow ci.yml
 
-# Discover capabilities
+# Discover / explore
 /gh discover
 /gh what can I do with projects
-/gh explore milestones
 /gh help
 ```
 
-### How It Works
+### How it works
 
-1. **Intent Detection** — Parses natural language to determine domain + operation + target
-2. **Context Check** — Verifies workspace is initialized (if needed)
-3. **Confirmation** — Asks before mutations
-4. **Execution** — Routes to appropriate skill with corpus-backed API syntax
-
-### Interactive Menu
-
-Run without arguments for a guided menu:
-
-```
-/gh
-```
-
-### Discovery Mode
-
-Explore available operations across all 26 GitHub domains:
-
-```
-/gh discover
-```
-
-**What you get:**
-
-1. **Quick Reference Table** — All domains with their API support (CLI, REST, GraphQL)
-2. **Domain Drill-Down** — Select a domain to see its full operation matrix
-3. **CLI Commands** — Ready-to-use `gh` commands for each operation
-4. **Handoff to Execute** — When ready, seamlessly transition to the operations skill
-
-**Example session:**
-
-```
-You: /gh discover
-
-Claude: === GitHub Operations Quick Reference ===
-
-        | Domain          | gh CLI | REST | GraphQL | Notes                    |
-        |-----------------|--------|------|---------|--------------------------|
-        | Issues          | ✓      | ✓    | ✓       | Full CRUD via all methods|
-        | Pull Requests   | ✓      | ✓    | ✓       | Full CRUD via all methods|
-        | Projects v2     | ✓      | Read | ✓       | Views UI-only            |
-        | Milestones      | ✗      | ✓    | Read    | CRUD via REST            |
-        ... [26 domains total]
-
-        Which domain would you like to explore?
-
-You: Projects v2
-
-Claude: === Projects v2 Domain ===
-
-        | Operation        | gh CLI | REST | GraphQL | Notes                   |
-        |------------------|--------|------|---------|-------------------------|
-        | Add item         | ✓      | ✗    | ✓       | addProjectV2ItemById    |
-        | Update field     | ✓      | ✗    | ✓       | updateProjectV2ItemField|
-        | Archive item     | ✓      | ✗    | ✓       |                         |
-        ...
-
-        CLI Commands:
-        | Operation   | Command                                              |
-        |-------------|------------------------------------------------------|
-        | Add item    | gh project item-add {number} --owner {o} --url {url} |
-        | Edit field  | gh project item-edit --id {id} --field-id {f} ...    |
-
-        What would you like to do?
-        1. Execute an operation now
-        2. Explore another domain
-        3. Done
-```
+1. **Intent detection** — parses natural language → domain + operation + target
+2. **Context check** — verifies a workspace is initialized; offers init if not
+3. **Freshness check** — offers a refresh if the cached config is stale
+4. **Confirmation** — asks before mutations
+5. **Execution** — routes to the right skill with corpus-backed API syntax
 
 ## Skills
 
-The plugin provides **seven skills** with a clear dependency structure:
+The plugin ships **11 skills** — seven interactive, four headless (zero-prompt,
+for schedulers and orchestrators).
 
-### Skill Overview
+### Interactive
 
-| Skill | Purpose | When to Use |
-|-------|---------|-------------|
-| `gh-init` | Validate environment, discover org structure, create config.yaml | First-time setup (once per workspace) |
-| `gh-refresh` | Sync cached config with GitHub | Periodically, or when "ID not found" errors occur |
-| `gh-operations` | Execute GitHub operations (all domains) | Via gateway command |
-| `gh-discover` | Explore available operations across all 26 domains | Find the right operation, learn what's possible |
-| `gh-healthcheck` | On-demand governance audit for repository maturity | Evaluate branch protection, CI/CD, docs, security policy, etc. |
-| `gh-heartbeat` | Process triggered workflows on session wake-up | Automatically on session start when pending work is detected |
-| `gh-workflows` | Manage event-driven workflows for GitHub automation | List, enable, disable, run, or create workflows |
-| `hiivmind-corpus-github-docs-navigate` | Look up GitHub API syntax (GraphQL/REST) | When uncertain about exact API syntax (external corpus) |
+| Skill | Purpose |
+|-------|---------|
+| `gh-init` | First-time setup: validate environment, discover org structure, place the workspace root, write `config.yaml` |
+| `gh-refresh` | Sync cached config with GitHub |
+| `gh-operations` | Execute GitHub operations across all domains |
+| `gh-discover` | Explore available operations across every domain |
+| `gh-healthcheck` | On-demand repository governance audit |
+| `gh-heartbeat` | Present/execute heartbeat-triggered workflows on session start |
+| `gh-workflows` | Manage and run workflow definitions |
 
-### Skill Hierarchy
+### Headless (zero prompts, explicit inputs only, every exit writes a result file)
 
+| Skill | Purpose |
+|-------|---------|
+| `gh-status-headless` | Status pre-check → `status-result.yaml` (is a refresh warranted?) |
+| `gh-refresh-headless` | Config sync replaying recorded decisions → `refresh-result.yaml` |
+| `gh-healthcheck-headless` | Fleet governance audit → `healthcheck-result.yaml` |
+| `gh-workflow-run-headless` | Run a workflow unattended under its headless policy → `workflow-run-result.yaml` |
+
+> Syntax lookup uses an external corpus, `hiivmind-corpus-github-docs-navigate`
+> (declared as a plugin dependency), for exact GraphQL/REST definitions when needed.
+
+## Headless orchestration & the result contract
+
+Every headless skill is **read-only against GitHub** (except committed workspace
+files), takes **explicit inputs only** (never discovers a workspace), and on **every**
+exit writes a result file conforming to a versioned contract
+(`lib/patterns/headless-contract.md`):
+
+```yaml
+contract_version: 1
+kind: status | healthcheck | refresh | workflow-run
+workspace: <login>
+run_at: "<ISO 8601>"          # always a quoted string
+actor: { gh_login: <str>, machine: <str>, mode: interactive | scheduled }
+# ...kind-specific fields...
+errors: []
 ```
-gh-init            ← Run FIRST (creates config.yaml)
-       │
-       ▼
-gh-operations      ← Requires init completed
-gh-refresh         ← Requires init completed
-gh-healthcheck     ← Requires init completed (read-only audit)
-       │
-       ├── hiivmind-corpus-github-docs-navigate ← External corpus (syntax lookup)
-       │
-gh-discover        ← Independent (explore capabilities)
-gh-workflows       ← Independent (manage automation)
-gh-heartbeat       ← Triggered by SessionStart hook
+
+Result files are validated mechanically:
+
+```bash
+uv run lib/pulse/scripts/validate_result.py <file> --kind <kind>   # exit 0/1/2
 ```
 
-## Supported Domains
+Orchestrators read the result **file**, never the skill's prose — so a scheduled run
+is deterministic and auditable.
+
+## Workflows (v1 → v3)
+
+Workflows are declarative YAML in `{workspace_root}/.hiivmind/github/workflows/`.
+Three formats coexist and are fully backward-compatible (a file has exactly one of
+`actions:` / `workflow:` / `steps:`):
+
+| Version | Shape | Use |
+|---------|-------|-----|
+| **v1** | `actions:` — sequential dispatch | Simple linear automations (legacy) |
+| **v2** | `workflow:` — a pseudocode FSM with `state:`, phases, `GOTO` | Interactive, single-repo triggered workflows |
+| **v3** | `steps:` — a DAG over v2 blocks with `repos:`, `depends_on:`, `gate:` | Cross-repo, resumable, gate-driven releases |
+
+**v3 run ledger.** A v3 run persists as a ledger record so it survives sessions — a
+run started in one session (or on one machine) is resumed by any later session or
+scheduled run:
+
+- Cross-repo runs → `{workspace_root}/.hiivmind/github/runs/{workflow}-{run_id}.yaml`
+  (**committed** — the team's shared release-state view)
+- Single-repo/personal runs → `runs/local/` (gitignored)
+
+The ledger is only ever read/written through `resolve_run.py` (the LLM never
+hand-edits it); the LLM evaluates each **gate's** truth against GitHub and records
+it. Gate-blocked runs surface in the heartbeat so releases advance as a side effect
+of normal session starts. Lint any workflow file with:
+
+```bash
+uv run lib/pulse/scripts/workflow_lint.py path/to/workflow.yaml
+```
+
+A `release-train.yaml` reference workflow ships in `templates/workflows/`.
+
+## The Python engine
+
+Deterministic, mechanical work lives in self-contained PEP 723 scripts
+(`lib/pulse/scripts/`, run via `uv run`) so skills stay orchestration documents:
+
+| Script | Responsibility |
+|--------|----------------|
+| `poll.py` | Heartbeat engine — GraphQL polling + workflow trigger detection; surfaces gate-blocked runs |
+| `evaluate_checks.py` | Mechanical healthcheck evaluator (11-check catalog) |
+| `freshness_status.py` | Per-section staleness computation for the status pre-check |
+| `validate_result.py` | Headless result-contract validator |
+| `resolve_run.py` | Deterministic run-ledger operations (create/advance/gate/lease) |
+| `workflow_lint.py` | Workflow YAML lint (v1/v2/v3 schema, FSM refs, headless policy, DAG acyclicity) |
+
+## Scheduled fleet maintenance
+
+Unattended maintenance lives in a separate repo,
+[hiivmind-pulse-scheduler](https://github.com/hiivmind/hiivmind-pulse-scheduler):
+a shared `TEMPLATE-workspace-maintenance.md` composes the headless skills
+(status pre-check → refresh → fleet healthcheck → PR on the workspace repo), and
+thin per-workspace stubs are symlinked into `~/.claude/scheduled-tasks/`.
+
+## Supported domains
 
 | Domain | Operations | API |
 |--------|------------|-----|
@@ -204,11 +227,14 @@ gh-heartbeat       ← Triggered by SessionStart hook
 | **Variables** | set, update, delete, list | REST |
 | **Releases** | create, update, delete, upload | REST |
 
-> **Note:** This table shows commonly used domains for quick reference. The plugin supports **26 domains** via corpus lookup — if you have permissions, it can help. Some dangerous operations (delete repository, transfer ownership) are blocked for safety. See `lib/references/operation-blocklist.md`.
+> This table shows commonly used domains. The plugin supports **any** GitHub domain
+> via corpus lookup — **26 domains** have dedicated syntax references under
+> `lib/references/domains/`. Some dangerous operations (delete repository, transfer
+> ownership) are blocked for safety; see `lib/references/operation-blocklist.md`.
 
 ## Quick Start
 
-### First-Time Setup
+### First-time setup
 
 ```
 You: /gh create issue for new feature
@@ -234,7 +260,7 @@ Claude: [Runs gh-init]
         Now proceeding with your original request...
 ```
 
-### Daily Usage
+### Daily usage
 
 ```
 You: /gh create issue for authentication timeout
@@ -247,29 +273,38 @@ Claude: Create issue in acme-corp/api?
 You: Yes
 
 Claude: Issue #143 created: https://github.com/acme-corp/api/issues/143
+        Linked to Product Roadmap · Status → Backlog
 ```
 
-## Workspace Configuration
+## Workspace configuration
 
-### Philosophy
+### The workspace-root model
 
-The workspace config separates **shared team knowledge** from **personal user data**:
+The **workspace root** is typically the parent folder holding an org's repo clones.
+`.hiivmind/github/` there is its own small **git repo** shared by the team (remote
+`{login}-workspace`) — it holds shared structure, and gitignores per-machine
+transients. Any operation whose cwd is at or below the workspace root is enriched.
 
 ```
-.hiivmind/
-└── github/
-    ├── config.yaml      # SHARED — commit to git
-    │                    # Org structure, project IDs, field mappings
-    │
-    ├── freshness.yaml   # SHARED — tracks config staleness
-    │
-    └── user.yaml        # PERSONAL — add to .gitignore
-                         # Your identity, cached permissions
+{workspace_root}/                    ← parent of repo clones
+├── api/                             ← a repo clone
+├── frontend/                        ← a repo clone
+└── .hiivmind/
+    └── github/                      ← its own git repo (the "workspace repo")
+        ├── config.yaml              # SHARED — org structure, project/field/milestone IDs
+        ├── freshness.yaml           # SHARED — per-section staleness tracking
+        ├── healthcheck.yaml         # SHARED — fleet governance record
+        ├── workflows/               # SHARED — workflow definitions
+        ├── runs/                    # SHARED — committed cross-repo run ledgers
+        ├── runs/local/              # gitignored — per-machine single-repo runs
+        ├── user.yaml                # PERSONAL — gitignored
+        └── *-result.yaml            # gitignored — headless result files
 ```
 
-### What Gets Cached
+### What gets cached
 
 **config.yaml** (shared):
+
 ```yaml
 workspace:
   type: organization
@@ -294,114 +329,68 @@ cache:
   last_synced_at: "2025-12-08T22:05:29Z"
 ```
 
-### Multi-Repository Setup
-
-For organizations with multiple repos, use symlinks to share config:
-
-```bash
-# Create centralized config
-mkdir -p ~/github-workspaces/acme-corp
-cd ~/github-workspaces/acme-corp
-# Run /gh init here
-
-# Symlink from each repository
-cd ~/projects/api
-ln -s ~/github-workspaces/acme-corp .hiivmind
-
-cd ~/projects/frontend
-ln -s ~/github-workspaces/acme-corp .hiivmind
-```
-
 ## Architecture
 
 ```
 hiivmind-pulse-gh/
 ├── .claude-plugin/
-│   └── plugin.json                       # Plugin manifest
-│
+│   ├── plugin.json                       # Plugin manifest + dependencies
+│   └── marketplace.json                  # Marketplace manifest
 ├── commands/
 │   ├── gh.md                             # Gateway command
 │   └── intent-mapping.yaml               # Intent detection rules
-│
 ├── skills/
-│   ├── gh-init/           # Workspace initialization
-│   ├── gh-refresh/        # Config sync
-│   ├── gh-operations/     # Execute operations
-│   ├── gh-discover/       # Explore capabilities
-│   ├── gh-healthcheck/    # Repository governance audit
-│   ├── gh-heartbeat/      # Session wake-up handler
-│   └── gh-workflows/      # Workflow management
-│
+│   ├── gh-init/  gh-refresh/  gh-operations/  gh-discover/
+│   ├── gh-healthcheck/  gh-heartbeat/  gh-workflows/
+│   ├── gh-status-headless/       # Headless status pre-check
+│   ├── gh-refresh-headless/      # Headless config sync
+│   ├── gh-healthcheck-headless/  # Headless fleet audit
+│   └── gh-workflow-run-headless/ # Headless workflow run
 ├── hooks/
 │   ├── hooks.json                        # Hook configuration
-│   ├── heartbeat.sh                      # Heartbeat polling logic
+│   ├── heartbeat.sh                      # SessionStart poll (workspace-root walk-up)
 │   ├── post-operation-check.sh           # Post-operation validation
 │   └── validate-gh-operation.sh          # Operation validation
-│
 ├── lib/
 │   ├── patterns/                         # HOW to do things (executable guides)
-│   │   ├── authentication.md
-│   │   ├── config-parsing.md
-│   │   ├── corpus-lookup.md
-│   │   ├── error-handling.md             # Error handling overview
-│   │   ├── error-auth.md                 # Auth-specific errors
-│   │   ├── error-graphql.md              # GraphQL-specific errors
-│   │   ├── error-rest.md                 # REST-specific errors
-│   │   ├── error-local.md                # Local/tool errors
-│   │   ├── graphql-execution.md
-│   │   ├── graphql-queries.md
-│   │   ├── healthcheck-evaluation.md
-│   │   ├── id-resolution.md
-│   │   ├── poll-state.md
-│   │   ├── tool-detection.md
-│   │   ├── workflow-execution.md
-│   │   └── workspace-detection.md
-│   │
+│   │   ├── config-parsing.md  id-resolution.md  graphql-execution.md
+│   │   ├── workspace-detection.md  corpus-lookup.md  error-*.md
+│   │   ├── headless-contract.md          # The headless result schema
+│   │   ├── workflow-execution.md         # THE workflow executor (v1/v2/v3)
+│   │   └── run-ledger.md                 # Run-ledger schema + resume protocol
+│   ├── pulse/
+│   │   └── scripts/                      # Deterministic Python (PEP 723, uv run)
+│   │       ├── poll.py  evaluate_checks.py  freshness_status.py
+│   │       ├── validate_result.py  resolve_run.py  workflow_lint.py
+│   │       └── tests/                    # pytest suite
 │   └── references/                       # WHAT exists (static lookup data)
-│       ├── api-routing.md                # GraphQL vs REST decisions
-│       ├── config-schema.md              # Config file schema
-│       ├── healthcheck-checks.md         # Healthcheck check catalog
-│       ├── operation-blocklist.md        # Blocked dangerous operations
-│       ├── token-permissions.md          # Token permission requirements
-│       ├── workflow-triggers.md          # Workflow trigger events
+│       ├── api-routing.md  config-schema.md  healthcheck-checks.md
+│       ├── operation-blocklist.md  token-permissions.md  workflow-triggers.md
 │       └── domains/                      # Per-domain API syntax (26 files)
-│
-├── docs/
-│   └── quickstart.md                     # Quick start guide
-│
 ├── templates/
-│   ├── config.yaml.template
-│   ├── freshness.yaml.template
-│   ├── healthcheck.yaml.template
-│   ├── user.yaml.template
-│   ├── repo.yaml.template
-│   ├── teams.yaml.template
-│   ├── views.yaml.template
-│   ├── relationships.yaml.template
-│   ├── automations.yaml.template
-│   ├── poll-state.yaml.template
-│   ├── workflow.yaml.template
-│   ├── gitignore.template
-│   └── workflows/                        # 10 pre-built workflow templates
-│       ├── auto-refresh.yaml
-│       ├── ci-monitor.yaml
-│       ├── issue-triage.yaml
-│       ├── pr-lifecycle.yaml
-│       └── ...
-│
+│   ├── config.yaml.template  freshness.yaml.template  healthcheck.yaml.template
+│   ├── user.yaml.template  workspace-gitignore.template  ...
+│   └── workflows/                        # Pre-built workflow templates (incl. release-train.yaml)
+├── docs/
+│   ├── superpowers/                      # Specs and phased implementation plans
+│   └── backlogs/                         # Tracked follow-ups
+├── pyproject.toml  uv.lock               # Python dev/test env
 └── # External dependency: hiivmind-corpus-github
 ```
 
-### Design Principles
+### Design principles
 
-1. **Skills over MCP** — Load on-demand, not all upfront. Better context efficiency.
-2. **Pattern library** — Reusable markdown patterns, not embedded shell scripts.
-3. **Corpus lookup** — Just-in-time API syntax from bundled documentation.
-4. **Cache structure, not data** — IDs are stable; item data changes constantly.
-5. **Shared config, personal permissions** — Team collaborates; permissions are individual.
-6. **Graceful degradation** — Works without config (explicit params required).
+1. **Skills over MCP** — load on-demand, better context efficiency.
+2. **Skills orchestrate, scripts compute** — deterministic work lives in Python
+   (PEP 723, `uv run`), not embedded shell in skills.
+3. **Pattern library** — reusable markdown patterns referenced via `See:`.
+4. **Corpus lookup** — just-in-time API syntax from bundled documentation.
+5. **Cache structure, not data** — IDs are stable; item data changes constantly.
+6. **Shared config, personal transients** — team collaborates; per-machine state is gitignored.
+7. **Result files, not prose** — headless runs communicate via a validated contract.
+8. **Graceful degradation** — works without config (explicit params required).
 
-### How Operations Work
+### How operations work
 
 ```
 1. ROUTE       →   2. RESOLVE   →   3. EXECUTE
@@ -413,46 +402,44 @@ api-routing.md     cache            or gh api REST
                   corpus (if uncertain about syntax)
 ```
 
-1. **Route** — Consult `lib/references/api-routing.md` for GraphQL vs REST decision
-2. **Resolve** — Get IDs from cached config; if uncertain about syntax, query the external GitHub API corpus
-3. **Execute** — Run the operation via `gh api` with temp file for complex queries
-
 ## Troubleshooting
 
 | Problem | Solution |
 |---------|----------|
-| "No workspace configuration found" | Run `/hiivmind-pulse-gh` and accept init prompt |
+| "No workspace configuration found" | Run `/gh` and accept the init prompt |
 | "Field ID not found" | Run `/gh refresh` to sync with GitHub |
 | "Config is stale" | Run `/gh refresh` |
 | `gh: command not found` | Install GitHub CLI: [cli.github.com](https://cli.github.com/) |
 | `yq: command not found` | Install yq v4+: [github.com/mikefarah/yq](https://github.com/mikefarah/yq) |
-| Permission errors | `gh auth refresh -s read:project -s project -s repo` |
+| `uv: command not found` | Install uv: [docs.astral.sh/uv](https://docs.astral.sh/uv/) |
+| Permission errors | `gh auth refresh -s read:project -s project -s repo -s read:org` |
 | "Resource not accessible" | Check access: `gh repo view owner/repo` |
 
 ## Limitations
 
-- **Claude Code only** — This is a Claude Code plugin (skills), not an MCP server. Won't work with VS Code Copilot, Cursor, or other LLM tools.
-- **Requires local tools** — `gh`, `jq`, `yq` must be installed on the machine where Claude Code runs.
-- **Inherits gh permissions** — Can only access what your `gh` CLI can access. No elevation, no bypass.
+- **Claude Code only** — this is a Claude Code plugin (skills), not an MCP server.
+- **Requires local tools** — `gh`, `jq`, `yq`, and `uv` must be installed where Claude Code runs.
+- **Inherits gh permissions** — can only access what your `gh` CLI can. No elevation, no bypass.
 
 ## Testing
 
-Tests are maintained in a separate repository to keep the plugin installation lean:
+Two suites:
 
-**[hiivmind-pulse-gh-tests](https://github.com/hiivmind/hiivmind-pulse-gh-tests)**
+**Python unit tests (in-repo)** cover the deterministic engine:
 
 ```bash
-# Clone test repo
+uv run pytest          # 47 tests across lib/pulse/scripts/tests/
+```
+
+**End-to-end / integration tests** live in a separate repository to keep the plugin
+lean for distribution:
+[hiivmind-pulse-gh-tests](https://github.com/hiivmind/hiivmind-pulse-gh-tests).
+
+```bash
 git clone https://github.com/hiivmind/hiivmind-pulse-gh-tests.git
 cd hiivmind-pulse-gh-tests
-
-# Setup (clones this repo + installs deps)
-./scripts/setup.sh
-
-# Run tests
-./node_modules/.bin/bats e2e/smoke/   # Quick smoke tests
-./node_modules/.bin/bats unit/        # Full unit tests
-./node_modules/.bin/bats integration/ # Integration tests
+./scripts/setup.sh                     # clones this repo + installs deps
+./node_modules/.bin/bats e2e/smoke/    # smoke tests
 ```
 
 ## Contributing
@@ -462,10 +449,14 @@ commands/*.md                              → Gateway and slash commands
 skills/*/SKILL.md                          → Skill documentation
 hooks/                                     → Event-driven hook scripts
 lib/patterns/*.md                          → Executable patterns (HOW to do things)
+lib/pulse/scripts/*.py                     → Deterministic Python (PEP 723)
 lib/references/*.md                        → Static lookup data (WHAT exists)
 templates/                                 → Config and workflow templates
-docs/                                      → Quick start and documentation
+docs/superpowers/                          → Specs and phased implementation plans
 ```
+
+When working on plugin structure, use the `plugin-dev` skills (plugin-structure,
+skill-development, command-development, hook-development).
 
 ## License
 

--- a/docs/superpowers/specs/2026-07-10-workspace-root-and-headless-orchestration-design.md
+++ b/docs/superpowers/specs/2026-07-10-workspace-root-and-headless-orchestration-design.md
@@ -631,14 +631,14 @@ with no upstream changes exits at the pre-check without a PR.
 **Depends on:** P4 (executor + policy). P6.1–P6.2 have no dependency on P5.
 Sub-phased because the run ledger is independently useful:
 
-- [ ] P6.1 Run ledger: `runs/{workflow}-{run_id}.yaml` schema; executor writes
+- [x] P6.1 Run ledger: `runs/{workflow}-{run_id}.yaml` schema; executor writes
       it for every run; committed-vs-transient split per Part 9 decision.
-- [ ] P6.2 `resolve_run.py`: create/advance/gate-evaluate ledger records
+- [x] P6.2 `resolve_run.py`: create/advance/gate-evaluate ledger records
       deterministically; tests.
-- [ ] P6.3 Schema v3: `repos:` scope + `steps:`/`depends_on:`/`gate:`;
+- [x] P6.3 Schema v3: `repos:` scope + `steps:`/`depends_on:`/`gate:`;
       documented in `workflow-execution.md`; `workflow_lint.py` extended for
       DAG acyclicity and gate syntax.
-- [ ] P6.4 Resumability: executor picks up `blocked-on-gate` runs,
+- [x] P6.4 Resumability: executor picks up `blocked-on-gate` runs,
       re-evaluates gates, continues; heartbeat watches `runs/` for
       gate-blocked runs as a poll source.
 - [ ] P6.5 Reference workflow: `release-train.yaml` for the corpus →
@@ -676,7 +676,7 @@ work. Status values: `not-started | in-progress | blocked({on}) | done`.
 | P3 | Headless skills (status/healthcheck/refresh) | P1, P2 | ✅ done | 2026-07-11 |
 | P4 | Executor split + headless policy | P1 | ✅ done | 2026-07-11 |
 | P5 | pulse-scheduler + fleet report **(goal 1)** | P3 (opt. P4.3) | ✅ done | 2026-07-12 |
-| P6 | Workflow v3: ledger, steps, gates **(goal 2)** | P4 | not-started | |
+| P6 | Workflow v3: ledger, steps, gates **(goal 2)** | P4 | in-progress (P6.5 pending live release) | |
 | P7 | Housekeeping (CLAUDE.md, DAG doc, lint) | P0+ (final: P6) | not-started | |
 
 ## Part 9: Risks and open questions

--- a/lib/patterns/run-ledger.md
+++ b/lib/patterns/run-ledger.md
@@ -20,7 +20,7 @@ mint colliding records. `resolve_run.py create` refuses to overwrite.
 ledger_version: 1
 workflow: release-train
 run_id: 2026-07-11-octocat-093012
-status: running | blocked-on-gate | done | failed | aborted
+status: running | blocked-on-gate | done | failed
 created_at: <ISO 8601>
 updated_at: <ISO 8601>
 actor: { gh_login: <str>, machine: <str>, mode: interactive | scheduled }   # creator
@@ -32,6 +32,9 @@ steps:
     repo: <name or [names]>
     depends_on: []               # step ids
     gate: <str or null>          # natural-language condition; null = no gate
+    has_workflow: <bool>         # true if the step carries a workflow block; a satisfied
+                                 # gate completes a gate-only step but leaves a gate+workflow
+                                 # step runnable so its block still executes
     gate_satisfied: <bool|null>  # null until evaluated; set via resolve_run.py gate-result
     gate_checked_at: <ISO|null>
     status: pending | running | blocked-on-gate | done | failed | skipped

--- a/lib/patterns/run-ledger.md
+++ b/lib/patterns/run-ledger.md
@@ -1,0 +1,92 @@
+# Pattern: Run Ledger
+
+Workflow runs persist as ledger records so runs survive sessions: a run started in
+one session (or machine) is resumed by any later one. The LLM **never hand-edits
+ledger YAML** — all reads/writes go through `resolve_run.py`.
+
+## Location and placement
+
+| Run kind | Path | Git status |
+|---|---|---|
+| cross-repo (v3 `steps:`, or >1 repo) | `{workspace_root}/.hiivmind/github/runs/{workflow}-{run_id}.yaml` | **committed** — the team's shared release-state view |
+| single-repo / personal | `{workspace_root}/.hiivmind/github/runs/local/{workflow}-{run_id}.yaml` | gitignored (`runs/local/`) |
+
+`run_id` = `{UTC date}-{gh_login}-{HHMMSS}` — actor-embedded so two machines cannot
+mint colliding records. `resolve_run.py create` refuses to overwrite.
+
+## Schema (`ledger_version: 1`)
+
+```yaml
+ledger_version: 1
+workflow: release-train
+run_id: 2026-07-11-octocat-093012
+status: running | blocked-on-gate | done | failed | aborted
+created_at: <ISO 8601>
+updated_at: <ISO 8601>
+actor: { gh_login: <str>, machine: <str>, mode: interactive | scheduled }   # creator
+repos: [<owner/name or catalog name>, ...]
+params: {}                       # resolved param values at creation
+state_snapshot: {}               # v2 state vars at last suspension (informational)
+steps:
+  - id: tag-lib                  # unique
+    repo: <name or [names]>
+    depends_on: []               # step ids
+    gate: <str or null>          # natural-language condition; null = no gate
+    gate_satisfied: <bool|null>  # null until evaluated; set via resolve_run.py gate-result
+    gate_checked_at: <ISO|null>
+    status: pending | running | blocked-on-gate | done | failed | skipped
+    actor: { gh_login, machine } | null    # who last advanced this step (I4)
+    started_at: <ISO|null>
+    finished_at: <ISO|null>
+    lease: { leased_by: "<gh_login>@<machine>", leased_at: <ISO> } | null
+    notes: []                    # free-form audit strings
+```
+
+v2 (flat) runs get a one-step ledger (`steps: [{id: run, ...}]`) in `runs/local/`
+so every run leaves a record — the poll-state `last_result` enum stays for cheap
+triggers; the ledger holds the real history.
+
+## Run-status derivation (computed by resolve_run.py, never by hand)
+
+any step `running` → `running`; else any `failed` → `failed`; else any step
+runnable (deps met, gate cleared) → `running`; else any gate-waiting step →
+`blocked-on-gate`; else all `done`/`skipped` → `done`.
+
+## Resume protocol (multi-machine)
+
+1. **Pull the workspace repo first** — the ledger is shared state; local copies are
+   never authority.
+2. `resolve_run.py next --file <ledger>` → runnable / blocked / done.
+3. For each blocked step: evaluate the gate's truth against GitHub (`gh` queries
+   derived from the condition text), then record it:
+   `resolve_run.py gate-result --file <ledger> --step <id> --satisfied true|false`.
+4. For each runnable step: acquire the lease
+   (`resolve_run.py lease --file <ledger> --step <id> --by "<gh_login>@<machine>"`),
+   execute, then `update --status done|failed`. Leases are **advisory**: an expired
+   lease (default TTL 120 min) is stolen; execution must be idempotent.
+5. Commit + push the ledger change (committed runs) so other machines see it.
+
+## CLI reference
+
+```
+uv run {PLUGIN_ROOT}/lib/pulse/scripts/resolve_run.py <subcommand> ...
+
+create      --runs-dir DIR --workflow W --run-id ID --actor-login L --actor-machine M
+            [--mode interactive|scheduled] [--params JSON] [--repos CSV]
+            [--steps JSON] [--local]        → validates DAG, writes ledger, prints path
+next        --file LEDGER                   → JSON {status, runnable[], blocked[{id,gate}], done}
+update      --file LEDGER --step ID --status S
+            [--actor-login L --actor-machine M] [--note TEXT]
+gate-result --file LEDGER --step ID --satisfied true|false [--note TEXT]
+lease       --file LEDGER --step ID --by WHO [--ttl-minutes 120]
+```
+
+Exit codes: 0 ok, 1 validation/state error, 2 file missing/unparseable,
+3 lease actively held by someone else.
+
+## Related patterns
+
+- `workflow-execution.md` — V3 Execution (who calls these commands, and when)
+- `workspace-detection.md` — multi-machine topology, pull-before-reconcile
+- `headless-contract.md` — the workflow-run result file (per-run report; the ledger
+  is the durable history)

--- a/lib/patterns/workflow-execution.md
+++ b/lib/patterns/workflow-execution.md
@@ -51,9 +51,10 @@ Poll-state paths in this document are relative to `{workspace_root}/.hiivmind/gi
 Workflows exist in two formats. Detect which format before executing:
 
 ```
-IF workflow YAML has 'workflow:' field → use pseudocode handoff (v2)
-ELIF workflow YAML has 'actions:' field → use sequential dispatch (v1, legacy)
-ELSE → error: workflow has neither actions nor workflow field
+IF workflow YAML has 'steps:' field    → use step-DAG execution (v3)
+ELIF workflow YAML has 'workflow:' field → use pseudocode handoff (v2)
+ELIF workflow YAML has 'actions:' field  → use sequential dispatch (v1, legacy)
+ELSE → error: workflow has none of steps/workflow/actions
 ```
 
 ---
@@ -138,6 +139,81 @@ state:
 ```
 
 The pseudocode reads and writes these variables throughout execution. They exist only for the duration of the workflow run — no persistence across sessions.
+
+---
+
+## V3 Execution: Step DAG
+
+v3 adds a DAG layer over v2 — additions only, fully backward-compatible:
+
+```yaml
+repos: [<catalog name or owner/name>, ...]   # scope; names resolve via the workspace
+                                             # repositories[] catalog; depends_on context
+                                             # available from relationships.yaml
+steps:
+  - id: <unique>
+    repo: <name or [names]>                  # which repo(s) this step acts on
+    depends_on: [<step ids>]                 # optional
+    gate: "<natural-language condition>"     # optional; blocks until satisfied
+    workflow: |                              # optional; a v2-style pseudocode block
+      PHASE: ...
+```
+
+A step needs `workflow`, `gate`, or both (gate-only steps are pure checkpoints).
+Params and the `headless:` policy work exactly as in v2 and apply to every step.
+
+### Execution flow
+
+```
+1. LOAD workflow YAML; resolve params (v2 rules)
+2. LEDGER (see lib/patterns/run-ledger.md — all ledger I/O via resolve_run.py):
+   ├── new run:  RUN_ID = {UTC date}-{gh_login}-{HHMMSS}
+   │             resolve_run.py create --runs-dir {workspace_root}/.hiivmind/github/runs
+   │               --workflow {name} --run-id {RUN_ID} --actor-login/-machine/--mode ...
+   │               --repos {resolved} --params {json} --steps {json from steps:}
+   │             (cross-repo → committed runs/; single-repo → add --local)
+   └── resume:   pull the workspace repo FIRST, then locate the ledger
+                 (explicit run_id, or the newest non-terminal ledger for this workflow)
+3. LOOP until next reports done, or only blocked remain, or a step fails:
+   a. next = resolve_run.py next --file {ledger}
+   b. FOR each blocked step: evaluate the gate condition against GitHub —
+      translate the natural-language condition into concrete gh queries
+      (e.g. "release {v} published" → gh api repos/{r}/releases/tags/{v};
+       "checks green on main" → gh api repos/{r}/commits/main/check-runs).
+      Record: resolve_run.py gate-result --step {id} --satisfied true|false --note "{evidence}"
+   c. re-run next. FOR each runnable step:
+      - resolve_run.py lease --step {id} --by "{gh_login}@{machine}"
+        (exit 3 → another session is on it; skip this step this pass)
+      - resolve_run.py update --step {id} --status running --actor-login ... 
+      - execute the step's workflow block as v2 pseudocode, scoped to step.repo
+        (headless mode → the headless projection applies per the workflow's policy)
+      - resolve_run.py update --step {id} --status done|failed --note "{summary}"
+   d. IF nothing became runnable and gates stayed unsatisfied → stop looping
+4. FINISH:
+   ├── ledger status done   → report success
+   ├── ledger status failed → report which step, record failure in poll-state
+   └── ledger status blocked-on-gate → report the open gates and STOP — the run is
+       resumable; any later session (or scheduled run) picks it up via step 2's
+       resume path. This is normal, not an error.
+5. Commit + push the ledger change when it lives in committed runs/ (the workspace
+   repo is shared state). runs/local/ ledgers are per-machine; no commit.
+6. Result recording: poll-state as usual; headless runs also write
+   workflow-run-result.yaml (repos: from the workflow's repos:).
+```
+
+### Ledger for v1/v2 runs
+
+Every run leaves a ledger record: v1/v2 runs create a single-step ledger
+(`--steps '[{"id": "run", "repo": "{repo or empty}"}]' --local`) at start and
+update it to done/failed at finish. Cheap, uniform history.
+
+### Resumption triggers
+
+- **Heartbeat:** the poll summary's `gate_blocked_runs` lists non-terminal runs
+  whose status is blocked-on-gate; gh-heartbeat offers "re-evaluate gates" which
+  re-enters the flow above at step 2's resume path.
+- **On demand:** `/gh run {workflow}` when a non-terminal ledger exists → ASK
+  resume-or-new (interactive); headless resumes automatically.
 
 ---
 

--- a/lib/pulse/scripts/poll.py
+++ b/lib/pulse/scripts/poll.py
@@ -471,6 +471,20 @@ def main() -> int:
     summary = {"stale_sections": stale_sections,
                "triggered_workflows": triggered,
                "auto_workflows": auto_workflows}
+
+    # v3 run ledger: surface gate-blocked runs so sessions can resume them
+    blocked_runs = []
+    runs_dir = config_dir / "runs"
+    for rf in sorted(runs_dir.glob("*.yaml")) + sorted(runs_dir.glob("local/*.yaml")):
+        try:
+            doc = yaml.safe_load(rf.read_text()) or {}
+        except yaml.YAMLError:
+            continue
+        if doc.get("status") == "blocked-on-gate":
+            blocked_runs.append(doc.get("run_id") or rf.stem)
+    if blocked_runs:
+        summary["gate_blocked_runs"] = blocked_runs
+
     if gold.get("project_changes"):
         summary["project_changes"] = gold["project_changes"]
 

--- a/lib/pulse/scripts/resolve_run.py
+++ b/lib/pulse/scripts/resolve_run.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Deterministic run-ledger operations. See lib/patterns/run-ledger.md.
+
+Subcommands: create, next, update, gate-result, lease.
+Exit codes: 0 ok, 1 validation/state error, 2 file missing/unparseable,
+3 lease actively held by someone else.
+"""
+import argparse
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import yaml
+
+LEDGER_VERSION = 1
+STEP_STATUSES = {"pending", "running", "blocked-on-gate", "done", "failed", "skipped"}
+TERMINAL = {"done", "failed", "skipped"}
+
+
+def now_iso():
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def parse_ts(s):
+    return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+def die(msg, code=1):
+    print(f"error: {msg}", file=sys.stderr)
+    sys.exit(code)
+
+
+def load(path):
+    p = Path(path)
+    if not p.exists():
+        die(f"file not found: {p}", 2)
+    try:
+        return yaml.safe_load(p.read_text())
+    except yaml.YAMLError as e:
+        die(f"unparseable YAML: {e}", 2)
+
+
+def save(path, doc):
+    doc["updated_at"] = now_iso()
+    Path(path).write_text(yaml.safe_dump(doc, sort_keys=False))
+
+
+def find_step(doc, sid):
+    for s in doc.get("steps", []):
+        if s.get("id") == sid:
+            return s
+    die(f"no such step: {sid}")
+
+
+def check_dag(steps):
+    ids = [s.get("id") for s in steps]
+    if len(ids) != len(set(ids)):
+        die("duplicate step ids")
+    idset = set(ids)
+    for s in steps:
+        for d in s.get("depends_on", []):
+            if d not in idset:
+                die(f"step {s['id']}: unknown dependency {d}")
+    # Kahn's algorithm
+    indeg = {s["id"]: len(s.get("depends_on", [])) for s in steps}
+    queue = [i for i, d in indeg.items() if d == 0]
+    seen = 0
+    while queue:
+        n = queue.pop()
+        seen += 1
+        for s in steps:
+            if n in s.get("depends_on", []):
+                indeg[s["id"]] -= 1
+                if indeg[s["id"]] == 0:
+                    queue.append(s["id"])
+    if seen != len(steps):
+        die("dependency cycle detected")
+
+
+def deps_met(doc, step):
+    by_id = {s["id"]: s for s in doc["steps"]}
+    return all(by_id[d]["status"] in {"done", "skipped"}
+               for d in step.get("depends_on", []))
+
+
+def classify(doc):
+    """Return (runnable_ids, blocked_list) from current step states."""
+    runnable, blocked = [], []
+    for s in doc["steps"]:
+        if s["status"] in TERMINAL or s["status"] == "running":
+            continue
+        if not deps_met(doc, s):
+            continue
+        if s.get("gate") and s.get("gate_satisfied") is not True:
+            blocked.append({"id": s["id"], "gate": s["gate"]})
+        else:
+            runnable.append(s["id"])
+    return runnable, blocked
+
+
+def recompute_status(doc):
+    steps = doc["steps"]
+    runnable, blocked = classify(doc)
+    if any(s["status"] == "running" for s in steps):
+        doc["status"] = "running"
+    elif any(s["status"] == "failed" for s in steps):
+        doc["status"] = "failed"
+    elif all(s["status"] in {"done", "skipped"} for s in steps):
+        doc["status"] = "done"
+    elif runnable:
+        doc["status"] = "running"
+    elif blocked:
+        doc["status"] = "blocked-on-gate"
+    else:
+        doc["status"] = "running"
+
+
+def cmd_create(args):
+    steps_in = json.loads(args.steps) if args.steps else [{"id": "run", "repo": ""}]
+    check_dag(steps_in)
+    steps = [{
+        "id": s["id"],
+        "repo": s.get("repo", ""),
+        "depends_on": s.get("depends_on", []),
+        "gate": s.get("gate"),
+        "gate_satisfied": None,
+        "gate_checked_at": None,
+        "status": "pending",
+        "actor": None,
+        "started_at": None,
+        "finished_at": None,
+        "lease": None,
+        "notes": [],
+    } for s in steps_in]
+    runs_dir = Path(args.runs_dir)
+    if args.local:
+        runs_dir = runs_dir / "local"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    path = runs_dir / f"{args.workflow}-{args.run_id}.yaml"
+    if path.exists():
+        die(f"ledger already exists: {path}")
+    doc = {
+        "ledger_version": LEDGER_VERSION,
+        "workflow": args.workflow,
+        "run_id": args.run_id,
+        "status": "running",
+        "created_at": now_iso(),
+        "updated_at": now_iso(),
+        "actor": {"gh_login": args.actor_login, "machine": args.actor_machine,
+                  "mode": args.mode},
+        "repos": [r for r in (args.repos or "").split(",") if r],
+        "params": json.loads(args.params) if args.params else {},
+        "state_snapshot": {},
+        "steps": steps,
+    }
+    recompute_status(doc)
+    save(path, doc)
+    print(path)
+
+
+def cmd_next(args):
+    doc = load(args.file)
+    runnable, blocked = classify(doc)
+    print(json.dumps({
+        "status": doc.get("status"),
+        "runnable": runnable,
+        "blocked": blocked,
+        "done": doc.get("status") == "done",
+    }))
+
+
+def cmd_update(args):
+    if args.status not in STEP_STATUSES:
+        die(f"invalid status: {args.status}")
+    doc = load(args.file)
+    step = find_step(doc, args.step)
+    step["status"] = args.status
+    if args.status == "running" and not step.get("started_at"):
+        step["started_at"] = now_iso()
+    if args.status in TERMINAL:
+        step["finished_at"] = now_iso()
+        step["lease"] = None
+    if args.actor_login:
+        step["actor"] = {"gh_login": args.actor_login,
+                         "machine": args.actor_machine or ""}
+    if args.note:
+        step["notes"].append(f"{now_iso()} {args.note}")
+    recompute_status(doc)
+    save(args.file, doc)
+
+
+def cmd_gate_result(args):
+    doc = load(args.file)
+    step = find_step(doc, args.step)
+    if not step.get("gate"):
+        die(f"step {args.step} has no gate")
+    satisfied = args.satisfied == "true"
+    step["gate_satisfied"] = satisfied
+    step["gate_checked_at"] = now_iso()
+    if args.note:
+        step["notes"].append(f"{now_iso()} gate: {args.note}")
+    if satisfied:
+        step["status"] = "done" if step["status"] in {"pending", "blocked-on-gate"} \
+            else step["status"]
+        step.setdefault("finished_at", None)
+        if step["status"] == "done":
+            step["finished_at"] = now_iso()
+    else:
+        step["status"] = "blocked-on-gate"
+    recompute_status(doc)
+    save(args.file, doc)
+
+
+def cmd_lease(args):
+    doc = load(args.file)
+    step = find_step(doc, args.step)
+    lease = step.get("lease")
+    ttl = timedelta(minutes=args.ttl_minutes)
+    if lease and lease.get("leased_by") != args.by:
+        age = datetime.now(timezone.utc) - parse_ts(lease["leased_at"])
+        if age < ttl:
+            print(f"error: lease held by {lease['leased_by']} "
+                  f"({int(age.total_seconds() // 60)} min old)", file=sys.stderr)
+            sys.exit(3)
+    step["lease"] = {"leased_by": args.by, "leased_at": now_iso()}
+    save(args.file, doc)
+    print(json.dumps(step["lease"]))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    c = sub.add_parser("create")
+    c.add_argument("--runs-dir", required=True)
+    c.add_argument("--workflow", required=True)
+    c.add_argument("--run-id", required=True)
+    c.add_argument("--actor-login", required=True)
+    c.add_argument("--actor-machine", required=True)
+    c.add_argument("--mode", default="interactive",
+                   choices=["interactive", "scheduled"])
+    c.add_argument("--params", default="")
+    c.add_argument("--repos", default="")
+    c.add_argument("--steps", default="")
+    c.add_argument("--local", action="store_true")
+    c.set_defaults(fn=cmd_create)
+
+    n = sub.add_parser("next")
+    n.add_argument("--file", required=True)
+    n.set_defaults(fn=cmd_next)
+
+    u = sub.add_parser("update")
+    u.add_argument("--file", required=True)
+    u.add_argument("--step", required=True)
+    u.add_argument("--status", required=True)
+    u.add_argument("--actor-login", default="")
+    u.add_argument("--actor-machine", default="")
+    u.add_argument("--note", default="")
+    u.set_defaults(fn=cmd_update)
+
+    g = sub.add_parser("gate-result")
+    g.add_argument("--file", required=True)
+    g.add_argument("--step", required=True)
+    g.add_argument("--satisfied", required=True, choices=["true", "false"])
+    g.add_argument("--note", default="")
+    g.set_defaults(fn=cmd_gate_result)
+
+    l = sub.add_parser("lease")
+    l.add_argument("--file", required=True)
+    l.add_argument("--step", required=True)
+    l.add_argument("--by", required=True)
+    l.add_argument("--ttl-minutes", type=int, default=120)
+    l.set_defaults(fn=cmd_lease)
+
+    args = ap.parse_args()
+    args.fn(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/pulse/scripts/resolve_run.py
+++ b/lib/pulse/scripts/resolve_run.py
@@ -128,6 +128,7 @@ def cmd_create(args):
         "repo": s.get("repo", ""),
         "depends_on": s.get("depends_on", []),
         "gate": s.get("gate"),
+        "has_workflow": bool(s.get("workflow")),
         "gate_satisfied": None,
         "gate_checked_at": None,
         "status": "pending",
@@ -205,10 +206,15 @@ def cmd_gate_result(args):
     if args.note:
         step["notes"].append(f"{now_iso()} gate: {args.note}")
     if satisfied:
-        step["status"] = "done" if step["status"] in {"pending", "blocked-on-gate"} \
-            else step["status"]
-        step.setdefault("finished_at", None)
-        if step["status"] == "done":
+        # A gate-only step (pure checkpoint) completes when its gate clears.
+        # A gate+workflow step must still run its workflow block: only clear the
+        # gate and leave the step non-terminal so classify()/next surfaces it as
+        # runnable — the executor then leases, runs the block, and marks it done.
+        if step.get("has_workflow"):
+            if step["status"] == "blocked-on-gate":
+                step["status"] = "pending"
+        elif step["status"] in {"pending", "blocked-on-gate"}:
+            step["status"] = "done"
             step["finished_at"] = now_iso()
     else:
         step["status"] = "blocked-on-gate"

--- a/lib/pulse/scripts/tests/fixtures/wf-bad-goto.yaml
+++ b/lib/pulse/scripts/tests/fixtures/wf-bad-goto.yaml
@@ -1,0 +1,9 @@
+name: "bad-goto"
+description: "GOTO points nowhere; state var unused"
+state:
+  items: []
+  ghost: null
+workflow: |
+  GATHER:
+    items = list things
+    GOTO REVIEW

--- a/lib/pulse/scripts/tests/fixtures/wf-bad-headless.yaml
+++ b/lib/pulse/scripts/tests/fixtures/wf-bad-headless.yaml
@@ -1,0 +1,9 @@
+name: "bad-headless"
+description: "Bad enum + allow-listed without allowlist"
+headless:
+  enabled: true
+  on_ask: ignore
+  on_mutation: allow-listed
+workflow: |
+  GATHER:
+    x = 1

--- a/lib/pulse/scripts/tests/fixtures/wf-cyclic-v3.yaml
+++ b/lib/pulse/scripts/tests/fixtures/wf-cyclic-v3.yaml
@@ -1,0 +1,11 @@
+name: "cyclic"
+description: "a <-> b"
+steps:
+  - id: a
+    repo: r
+    depends_on: [b]
+    gate: "x"
+  - id: b
+    repo: r
+    depends_on: [a]
+    gate: "y"

--- a/lib/pulse/scripts/tests/fixtures/wf-valid-v2.yaml
+++ b/lib/pulse/scripts/tests/fixtures/wf-valid-v2.yaml
@@ -1,0 +1,31 @@
+name: "demo-check"
+description: "Valid v2 workflow"
+enabled: true
+auto: false
+trigger:
+  type: session_poll
+  source: issues
+  condition: state_changed
+headless:
+  enabled: true
+  on_ask: record
+  on_mutation: allow-listed
+  mutation_allowlist: [comment]
+state:
+  items: []
+  selected: null
+workflow: |
+  GATHER:
+    items = list open issues
+    IF items is empty: STOP "nothing to do"
+
+  PRESENT:
+    SHOW items as table
+    ASK "Which item?" (choices | skip)
+    selected = answer
+    IF selected != skip: GOTO ACT
+
+  ACT:
+    comment on selected
+    GOTO PRESENT
+cooldown_minutes: 30

--- a/lib/pulse/scripts/tests/fixtures/wf-valid-v3.yaml
+++ b/lib/pulse/scripts/tests/fixtures/wf-valid-v3.yaml
@@ -1,0 +1,27 @@
+name: "mini-train"
+description: "Valid v3"
+repos: [testorg/lib, testorg/app]
+params:
+  version:
+    type: string
+    default: null
+headless:
+  enabled: true
+  on_ask: record
+  on_mutation: propose
+steps:
+  - id: tag
+    repo: testorg/lib
+    workflow: |
+      EXECUTE:
+        create release {params.version}
+  - id: verify
+    repo: testorg/lib
+    depends_on: [tag]
+    gate: "release {params.version} published"
+  - id: bump
+    repo: [testorg/app]
+    depends_on: [verify]
+    workflow: |
+      EXECUTE:
+        open bump PR

--- a/lib/pulse/scripts/tests/test_poll.py
+++ b/lib/pulse/scripts/tests/test_poll.py
@@ -96,3 +96,17 @@ def test_shared_source_triggers_both_workflows(tmp_path):
     out = json.loads(r.stdout)
     assert sorted(out["triggered_workflows"]) == ["pr-watch", "pr-watch2"]
     assert out["auto_workflows"] == ["pr-watch2"]
+
+
+def test_gate_blocked_runs_in_summary(tmp_path, monkeypatch):
+    ws, _ = make_workspace(tmp_path)       # existing helper from the P2 tests
+    runs = ws / ".hiivmind" / "github" / "runs"
+    runs.mkdir()
+    (runs / "release-train-2026-07-11-octocat-100000.yaml").write_text(
+        "ledger_version: 1\nworkflow: release-train\n"
+        "run_id: 2026-07-11-octocat-100000\nstatus: blocked-on-gate\nsteps: []\n")
+    (runs / "old-done.yaml").write_text(
+        "ledger_version: 1\nrun_id: x\nstatus: done\nsteps: []\n")
+    run_poll(ws)                            # bootstrap poll-state.yaml (first_run)
+    out = json.loads(run_poll(ws).stdout)  # existing helper
+    assert out["gate_blocked_runs"] == ["2026-07-11-octocat-100000"]

--- a/lib/pulse/scripts/tests/test_resolve_run.py
+++ b/lib/pulse/scripts/tests/test_resolve_run.py
@@ -1,0 +1,115 @@
+"""Tests for resolve_run.py — deterministic run-ledger operations."""
+import json
+import subprocess
+import sys
+
+import yaml
+
+SCRIPT = "lib/pulse/scripts/resolve_run.py"
+
+STEPS = json.dumps([
+    {"id": "tag-lib", "repo": "testorg/lib"},
+    {"id": "verify-lib", "repo": "testorg/lib", "depends_on": ["tag-lib"],
+     "gate": "release published AND checks green"},
+    {"id": "bump-consumers", "repo": ["testorg/app-a", "testorg/app-b"],
+     "depends_on": ["verify-lib"]},
+])
+
+
+def run(*args):
+    return subprocess.run([sys.executable, SCRIPT, *args],
+                          capture_output=True, text=True)
+
+
+def create(tmp_path, steps=STEPS, run_id="2026-07-11-octocat-100000"):
+    r = run("create", "--runs-dir", str(tmp_path), "--workflow", "release-train",
+            "--run-id", run_id, "--actor-login", "octocat",
+            "--actor-machine", "mba-m4", "--steps", steps,
+            "--repos", "testorg/lib,testorg/app-a,testorg/app-b",
+            "--params", '{"version": "1.2.0"}')
+    assert r.returncode == 0, r.stderr
+    return r.stdout.strip()
+
+
+def test_create_writes_ledger(tmp_path):
+    path = create(tmp_path)
+    doc = yaml.safe_load(open(path))
+    assert doc["ledger_version"] == 1
+    assert doc["status"] == "running"
+    assert doc["params"] == {"version": "1.2.0"}
+    assert [s["id"] for s in doc["steps"]] == ["tag-lib", "verify-lib", "bump-consumers"]
+    assert all(s["status"] == "pending" for s in doc["steps"])
+
+
+def test_create_refuses_overwrite(tmp_path):
+    create(tmp_path)
+    r = run("create", "--runs-dir", str(tmp_path), "--workflow", "release-train",
+            "--run-id", "2026-07-11-octocat-100000", "--actor-login", "octocat",
+            "--actor-machine", "mba-m4", "--steps", STEPS)
+    assert r.returncode == 1
+    assert "exists" in r.stderr
+
+
+def test_create_rejects_cycle(tmp_path):
+    cyclic = json.dumps([
+        {"id": "a", "repo": "r", "depends_on": ["b"]},
+        {"id": "b", "repo": "r", "depends_on": ["a"]},
+    ])
+    r = run("create", "--runs-dir", str(tmp_path), "--workflow", "w",
+            "--run-id", "x", "--actor-login", "o", "--actor-machine", "m",
+            "--steps", cyclic)
+    assert r.returncode == 1
+    assert "cycle" in r.stderr.lower()
+
+
+def test_next_initial(tmp_path):
+    path = create(tmp_path)
+    out = json.loads(run("next", "--file", path).stdout)
+    assert out["runnable"] == ["tag-lib"]
+    assert out["blocked"] == []
+    assert out["done"] is False
+
+
+def test_gate_flow(tmp_path):
+    path = create(tmp_path)
+    assert run("update", "--file", path, "--step", "tag-lib", "--status", "done",
+               "--actor-login", "octocat", "--actor-machine", "mba-m4").returncode == 0
+    out = json.loads(run("next", "--file", path).stdout)
+    assert out["runnable"] == []
+    assert out["blocked"] == [{"id": "verify-lib",
+                               "gate": "release published AND checks green"}]
+    doc = yaml.safe_load(open(path))
+    assert doc["status"] == "blocked-on-gate"
+
+    assert run("gate-result", "--file", path, "--step", "verify-lib",
+               "--satisfied", "true").returncode == 0
+    out = json.loads(run("next", "--file", path).stdout)
+    # gate-only step (no workflow block content is the executor's concern;
+    # ledger-wise a satisfied gate with no further work marks the step done)
+    assert out["runnable"] == ["bump-consumers"]
+
+
+def test_completion(tmp_path):
+    path = create(tmp_path)
+    for sid in ["tag-lib", "verify-lib", "bump-consumers"]:
+        if sid == "verify-lib":
+            run("gate-result", "--file", path, "--step", sid, "--satisfied", "true")
+        else:
+            run("update", "--file", path, "--step", sid, "--status", "done")
+    out = json.loads(run("next", "--file", path).stdout)
+    assert out["done"] is True
+    assert yaml.safe_load(open(path))["status"] == "done"
+
+
+def test_lease_conflict_and_steal(tmp_path):
+    path = create(tmp_path)
+    assert run("lease", "--file", path, "--step", "tag-lib",
+               "--by", "octocat@mba-m4").returncode == 0
+    r = run("lease", "--file", path, "--step", "tag-lib", "--by", "hubot@nuc-lab")
+    assert r.returncode == 3                       # actively held
+    r = run("lease", "--file", path, "--step", "tag-lib", "--by", "hubot@nuc-lab",
+            "--ttl-minutes", "0")                  # everything is expired at ttl 0
+    assert r.returncode == 0                       # stolen
+    doc = yaml.safe_load(open(path))
+    step = [s for s in doc["steps"] if s["id"] == "tag-lib"][0]
+    assert step["lease"]["leased_by"] == "hubot@nuc-lab"

--- a/lib/pulse/scripts/tests/test_resolve_run.py
+++ b/lib/pulse/scripts/tests/test_resolve_run.py
@@ -113,3 +113,42 @@ def test_lease_conflict_and_steal(tmp_path):
     doc = yaml.safe_load(open(path))
     step = [s for s in doc["steps"] if s["id"] == "tag-lib"][0]
     assert step["lease"]["leased_by"] == "hubot@nuc-lab"
+
+
+def test_gate_plus_workflow_step_runs_not_skipped(tmp_path):
+    # A step carrying BOTH a gate and a workflow block must still run its block
+    # after the gate clears: gate-result may not force it terminal, or its
+    # mutations are silently dropped. (Whole-branch review finding, P6.)
+    steps = json.dumps([
+        {"id": "build", "repo": "r"},
+        {"id": "gated-work", "repo": "r", "depends_on": ["build"],
+         "gate": "artifact published", "workflow": "EXECUTE:\n  do the thing"},
+    ])
+    path = create(tmp_path, steps=steps)
+    assert run("update", "--file", path, "--step", "build",
+               "--status", "done").returncode == 0
+    # gate cleared, but the step has work to do → runnable, not done
+    assert run("gate-result", "--file", path, "--step", "gated-work",
+               "--satisfied", "true").returncode == 0
+    out = json.loads(run("next", "--file", path).stdout)
+    assert out["runnable"] == ["gated-work"]
+    assert out["done"] is False
+    step = [s for s in yaml.safe_load(open(path))["steps"]
+            if s["id"] == "gated-work"][0]
+    assert step["status"] != "done"
+    # the executor then runs the block and marks it done → run completes
+    run("update", "--file", path, "--step", "gated-work", "--status", "done")
+    assert json.loads(run("next", "--file", path).stdout)["done"] is True
+
+
+def test_gate_only_step_completes_on_satisfy(tmp_path):
+    # Guard the other side: a gate-ONLY step (no workflow block) still completes
+    # when its gate clears, so downstream steps unblock (existing behavior).
+    path = create(tmp_path)  # STEPS' verify-lib is gate-only
+    run("update", "--file", path, "--step", "tag-lib", "--status", "done")
+    run("gate-result", "--file", path, "--step", "verify-lib", "--satisfied", "true")
+    out = json.loads(run("next", "--file", path).stdout)
+    assert out["runnable"] == ["bump-consumers"]
+    step = [s for s in yaml.safe_load(open(path))["steps"]
+            if s["id"] == "verify-lib"][0]
+    assert step["status"] == "done"

--- a/lib/pulse/scripts/tests/test_workflow_lint.py
+++ b/lib/pulse/scripts/tests/test_workflow_lint.py
@@ -1,0 +1,52 @@
+"""Tests for workflow_lint.py."""
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT = "lib/pulse/scripts/workflow_lint.py"
+FIXTURES = Path("lib/pulse/scripts/tests/fixtures")
+
+
+def run(*paths):
+    return subprocess.run([sys.executable, SCRIPT, *[str(p) for p in paths]],
+                          capture_output=True, text=True)
+
+
+def test_valid_v2_clean():
+    r = run(FIXTURES / "wf-valid-v2.yaml")
+    assert r.returncode == 0, r.stderr
+
+
+def test_valid_v3_clean():
+    r = run(FIXTURES / "wf-valid-v3.yaml")
+    assert r.returncode == 0, r.stderr
+
+
+def test_bad_goto_and_unused_state():
+    r = run(FIXTURES / "wf-bad-goto.yaml")
+    assert r.returncode == 1
+    assert "GOTO REVIEW" in r.stderr
+    assert "ghost" in r.stderr
+
+
+def test_bad_headless():
+    r = run(FIXTURES / "wf-bad-headless.yaml")
+    assert r.returncode == 1
+    assert "on_ask" in r.stderr
+    assert "mutation_allowlist" in r.stderr
+
+
+def test_cyclic_v3():
+    r = run(FIXTURES / "wf-cyclic-v3.yaml")
+    assert r.returncode == 1
+    assert "cycle" in r.stderr.lower()
+
+
+def test_multiple_files_aggregate():
+    r = run(FIXTURES / "wf-valid-v2.yaml", FIXTURES / "wf-bad-goto.yaml")
+    assert r.returncode == 1
+
+
+def test_missing_file_exit_2(tmp_path):
+    r = run(tmp_path / "nope.yaml")
+    assert r.returncode == 2

--- a/lib/pulse/scripts/workflow_lint.py
+++ b/lib/pulse/scripts/workflow_lint.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Lint workflow YAML files: v1/v2/v3 schema, FSM references, headless policy,
+step-DAG acyclicity. See lib/patterns/workflow-execution.md.
+
+Usage: workflow_lint.py <file.yaml> [more files...]
+
+Exit codes: 0 clean, 1 findings (one 'file: message' per line on stderr),
+2 a file was missing or unparseable.
+"""
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+TRIGGER_TYPES = {"session_poll", "post_operation", "freshness", "on_demand"}
+ON_ASK = {"record", "default", "abort"}
+ON_MUTATION = {"propose", "allow-listed", "allow"}
+PHASE_RE = re.compile(r"^([A-Z][A-Z_]*)(\([^)]*\))?:\s*$")
+GOTO_RE = re.compile(r"\bGOTO\s+([A-Z][A-Z_]*)")
+PARAM_RE = re.compile(r"\bparams\.([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def lint_headless(h, errs):
+    if not isinstance(h, dict):
+        errs.append("headless: must be a mapping")
+        return
+    if "enabled" in h and not isinstance(h["enabled"], bool):
+        errs.append("headless.enabled must be a bool")
+    if h.get("on_ask") is not None and h["on_ask"] not in ON_ASK:
+        errs.append(f"headless.on_ask invalid: {h['on_ask']}")
+    om = h.get("on_mutation")
+    if om is not None and om not in ON_MUTATION:
+        errs.append(f"headless.on_mutation invalid: {om}")
+    allow = h.get("mutation_allowlist")
+    if om == "allow-listed" and not (isinstance(allow, list) and allow):
+        errs.append("headless.on_mutation allow-listed requires a non-empty mutation_allowlist")
+    if allow is not None and not isinstance(allow, list):
+        errs.append("headless.mutation_allowlist must be a list")
+
+
+def lint_pseudocode(text, state, params, errs, ctx=""):
+    lines = text.splitlines()
+    phases = {m.group(1) for line in lines if (m := PHASE_RE.match(line))}
+    for m in GOTO_RE.finditer(text):
+        if m.group(1) not in phases:
+            errs.append(f"{ctx}GOTO {m.group(1)} has no matching phase label")
+    for var in (state or {}):
+        if not re.search(rf"\b{re.escape(str(var))}\b", text):
+            errs.append(f"{ctx}state variable never referenced: {var}")
+    declared = set(params or {})
+    for m in PARAM_RE.finditer(text):
+        if m.group(1) not in declared:
+            errs.append(f"{ctx}params.{m.group(1)} referenced but not declared")
+
+
+def lint_steps(steps, errs):
+    if not isinstance(steps, list) or not steps:
+        errs.append("steps: must be a non-empty list")
+        return
+    ids = []
+    for i, s in enumerate(steps):
+        if not isinstance(s, dict):
+            errs.append(f"steps[{i}] is not a mapping")
+            continue
+        sid = s.get("id")
+        if not isinstance(sid, str) or not sid:
+            errs.append(f"steps[{i}]: missing id")
+            continue
+        ids.append(sid)
+        if not s.get("repo"):
+            errs.append(f"step {sid}: missing repo")
+        if not s.get("workflow") and not s.get("gate"):
+            errs.append(f"step {sid}: needs workflow, gate, or both")
+        if "gate" in s and s["gate"] is not None and \
+                (not isinstance(s["gate"], str) or not s["gate"].strip()):
+            errs.append(f"step {sid}: gate must be a non-empty string")
+    if len(ids) != len(set(ids)):
+        errs.append("duplicate step ids")
+    idset = set(ids)
+    for s in steps:
+        if not isinstance(s, dict):
+            continue
+        for d in s.get("depends_on", []) or []:
+            if d not in idset:
+                errs.append(f"step {s.get('id')}: unknown dependency {d}")
+    # Kahn's for acyclicity
+    indeg = {s["id"]: len(s.get("depends_on", []) or [])
+             for s in steps if isinstance(s, dict) and s.get("id")}
+    queue = [i for i, d in indeg.items() if d == 0]
+    seen = 0
+    while queue:
+        n = queue.pop()
+        seen += 1
+        for s in steps:
+            if isinstance(s, dict) and n in (s.get("depends_on", []) or []):
+                indeg[s["id"]] -= 1
+                if indeg[s["id"]] == 0:
+                    queue.append(s["id"])
+    if seen != len(indeg):
+        errs.append("step dependency cycle detected")
+
+
+def lint_file(path: Path) -> list[str]:
+    doc = yaml.safe_load(path.read_text())
+    errs: list[str] = []
+    if not isinstance(doc, dict):
+        return ["not a mapping"]
+    if not isinstance(doc.get("name"), str) or not doc.get("name"):
+        errs.append("missing name")
+
+    bodies = [k for k in ("steps", "workflow", "actions") if k in doc]
+    if len(bodies) != 1:
+        errs.append(f"exactly one of steps/workflow/actions required, found: {bodies}")
+
+    trig = doc.get("trigger")
+    if isinstance(trig, dict) and trig.get("type") not in TRIGGER_TYPES:
+        errs.append(f"trigger.type invalid: {trig.get('type')}")
+    if "headless" in doc:
+        lint_headless(doc["headless"], errs)
+
+    params = doc.get("params") or {}
+    if "workflow" in doc and isinstance(doc["workflow"], str):
+        lint_pseudocode(doc["workflow"], doc.get("state") or {}, params, errs)
+    if "steps" in doc:
+        lint_steps(doc["steps"], errs)
+        if "repos" in doc and not (isinstance(doc["repos"], list)
+                                   and all(isinstance(r, str) for r in doc["repos"])):
+            errs.append("repos: must be a list of strings")
+        for s in doc["steps"] if isinstance(doc["steps"], list) else []:
+            if isinstance(s, dict) and isinstance(s.get("workflow"), str):
+                lint_pseudocode(s["workflow"], {}, params, errs,
+                                ctx=f"step {s.get('id')}: ")
+    return errs
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: workflow_lint.py <file.yaml> [...]", file=sys.stderr)
+        return 2
+    any_errs = False
+    for arg in sys.argv[1:]:
+        path = Path(arg)
+        if not path.exists():
+            print(f"{arg}: file not found", file=sys.stderr)
+            return 2
+        try:
+            errs = lint_file(path)
+        except yaml.YAMLError as e:
+            print(f"{arg}: unparseable YAML: {e}", file=sys.stderr)
+            return 2
+        for e in errs:
+            print(f"{arg}: {e}", file=sys.stderr)
+            any_errs = True
+    return 1 if any_errs else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/gh-heartbeat/SKILL.md
+++ b/skills/gh-heartbeat/SKILL.md
@@ -122,6 +122,14 @@ AUTO=$(echo "$HEARTBEAT_OUTPUT" | jq -r '.auto_workflows[]')
 STALE=$(echo "$HEARTBEAT_OUTPUT" | jq -r '.stale_sections[]')
 ```
 
+Also check for gate-blocked v3 runs:
+
+```bash
+BLOCKED_RUNS=$(echo "$HEARTBEAT_OUTPUT" | jq -r '.gate_blocked_runs[]? // empty')
+```
+
+If any exist, they count as "something to do" (do not report All clear).
+
 **If nothing triggered and no stale sections:**
 
 ```
@@ -253,6 +261,7 @@ Map workflow types to suggestion patterns:
 | deploy-monitor | Recent deployments | "Deployment to [env] [succeeded/failed]" |
 | release-monitor | New releases | "Release [tag] published — review notes?" |
 | dependabot-alerts | New or critical alerts | "N new dependabot alerts — review?" |
+| (any) | `gate_blocked_runs` in heartbeat output | "Run {run_id} is blocked on a gate — re-evaluate and resume? (see workflow-execution.md V3 resume)" |
 
 **Example:**
 ```

--- a/templates/workflows/release-train.yaml
+++ b/templates/workflows/release-train.yaml
@@ -1,0 +1,62 @@
+# hiivmind-pulse-gh - Release Train Workflow (v3 reference)
+# Coordinate a versioned release from a library repo into its consumers.
+# Copy to: {workspace_root}/.hiivmind/github/workflows/release-train.yaml
+# and replace the {{...}} placeholders with catalog repo names.
+
+name: "release-train"
+description: "Release a library version and roll it through consumer repos"
+enabled: true
+auto: false
+
+trigger:
+  type: on_demand
+  condition: user_requested
+
+headless:
+  enabled: true
+  on_ask: record
+  on_mutation: propose   # releases/PRs are proposed when run unattended
+
+repos:
+  - {{lib_repo}}
+  - {{consumer_repo_1}}
+  - {{consumer_repo_2}}
+
+params:
+  version:
+    description: "Version to release (e.g. 1.2.0)"
+    type: string
+    default: null   # required
+
+steps:
+  - id: tag-lib
+    repo: {{lib_repo}}
+    workflow: |
+      EXECUTE:
+        create release {params.version} on {{lib_repo}} from the default branch,
+        with generated release notes
+
+  - id: verify-lib
+    repo: {{lib_repo}}
+    depends_on: [tag-lib]
+    gate: "release {params.version} published AND checks green on the default branch"
+
+  - id: bump-consumers
+    repo: [{{consumer_repo_1}}, {{consumer_repo_2}}]
+    depends_on: [verify-lib]
+    workflow: |
+      GATHER:
+        FOR EACH consumer repo:
+          locate the pinned {{lib_repo}} version reference
+      EXECUTE:
+        FOR EACH consumer repo:
+          open a PR bumping the reference to {params.version}
+      SUMMARIZE:
+        SHOW opened PR urls
+
+  - id: verify-consumers
+    repo: [{{consumer_repo_1}}, {{consumer_repo_2}}]
+    depends_on: [bump-consumers]
+    gate: "all bump PRs merged AND checks green on consumer default branches"
+
+cooldown_minutes: 0

--- a/templates/workspace-gitignore.template
+++ b/templates/workspace-gitignore.template
@@ -7,3 +7,4 @@ project-snapshot.json
 log/
 .assignments-tmp.json
 .project-changes.json
+runs/local/


### PR DESCRIPTION
## P6 — Workflow Schema v3 (completes goal 2, code-complete)

Cross-repo, **resumable** workflows: runs persist as ledger records so a run started in one session is resumed by any later session or scheduled run. Implements spec Part 6.3 §P6 (P6.1–P6.4). Traces to `docs/superpowers/specs/2026-07-10-workspace-root-and-headless-orchestration-design.md`.

### What's in the branch

| Deliverable | Commit |
|---|---|
| **P6.1** run-ledger schema v1 (`lib/patterns/run-ledger.md`) + committed (`runs/`) vs. per-machine (`runs/local/`, gitignored) placement split | `e1e11aa` |
| **P6.2** `resolve_run.py` — deterministic ledger CLI (create/next/update/gate-result/lease), DAG validation, advisory leases; 9 tests | `d6bde60` |
| **P6.3** v3 step-DAG execution documented in `workflow-execution.md` (Format Detection steps→v3/workflow→v2/actions→v1; gates; resumability) | `d34d4b0` |
| **P6.3 / P7.4 script** `workflow_lint.py` — v1/v2/v3 schema, FSM references, headless policy, DAG acyclicity; 5 fixtures + 7 tests | `96c2f62` |
| **P6.4** `poll.py` surfaces `gate_blocked_runs` in the heartbeat summary; `gh-heartbeat` offers resume; `release-train.yaml` v3 reference template | `85ce833` |
| Close-out: spec P6.1–P6.4 ticked, §8.9 P6 `in-progress (P6.5 pending live release)`, CLAUDE.md, version **4.8.0 → 4.9.0** | `3184d17` |
| **Hardening** (whole-branch review): gate+workflow steps run their block instead of being force-completed by a cleared gate | `d578a9f` |

### Architecture

The flat v2 FSM gains a DAG layer: a v3 workflow declares `repos:` scope and `steps:` (each a v2-style pseudocode block bound to repo(s)) with `gate:` conditions between them. Run state moves out of working memory into a ledger record — deterministically created/advanced/gate-marked by `resolve_run.py`, so the LLM never hand-edits ledger YAML. The determinism split: `resolve_run.py` owns all ledger I/O and DAG readiness; the LLM evaluates gate *truth* (natural-language condition → concrete `gh` checks) and records it via `gate-result`. The heartbeat watches `runs/` so blocked releases advance as a side effect of normal session starts. Backward compatible: v1 (`actions:`) and v2 (`workflow:`) files run unchanged.

### Review outcome

Per-task reviews clean (each task independently re-run by the reviewer). Final whole-branch review (opus): **READY TO MERGE**, with one genuine composition finding invisible to per-task reviews — a step carrying **both** a gate and a workflow block was force-marked `done` when its gate cleared, silently dropping the workflow's mutations. Not reachable by anything P6 ships (all fixtures/templates use gate-only or workflow-only steps), but it contradicts the schema this branch documents. Fixed in `d578a9f` (persist `has_workflow`; satisfied gate completes a gate-only step but leaves a gate+workflow step runnable) with a regression test and a gate-only guard test.

### Testing

`uv run pytest -q` → **47 passed**. `workflow_lint.py` on the shipped templates (release-train substituted) → exit 0.

### Scope note — P6.5 deferred

**P6.5** (release-train exercised end-to-end on a real minor release) is intentionally **left open** — it performs an outward-facing release and needs a genuine version to ship. Per the maintainer's dogfood decision, this PR lands goal 2 **code-complete** at 4.9.0 with the live exercise (Task 7) to follow. The live-workspace half of Task 1 (add `runs/local/` to the workspace repo `.gitignore`) was done separately and is already merged to `hiivmind-workspace` main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

### Also in this PR: documentation refresh (`234b108`)

Folded in a README/CLAUDE.md refresh to bring the docs up to the current system:
- README: **11 skills** (7 interactive + 4 headless), the headless result contract, the workflow **v1/v2/v3** story + run ledger, the Python engine (`lib/pulse/scripts/`), the workspace-root model, and scheduled fleet maintenance.
- Fixed stale install lines (marketplace `hiivmind-pulse-gh` / plugin `gh`), the architecture tree, and the Testing section (now pytest + the separate bats repo).
- CLAUDE.md domain count corrected (**26**); `marketplace.json` version synced to **4.9.0** (was 4.0.0).
