### PR TITLE
F1: add repository profiles and scorecard core

### DIFF
--- a/lib/patterns/headless-contract.md
+++ b/lib/patterns/headless-contract.md
@@ -91,12 +91,19 @@ run_at: <ISO 8601>
 actor: { gh_login: <str>, machine: <str>, mode: <enum> }
 repos:                                # list, required (may be empty)
   - repo: <owner/name>                # str, required
+    scorecard: <scorecard id>         # str, required — grades are scorecard-specific
     score: <number>                   # int or float, required
-    total: <int>                      # required — checks counted (excl. unknown/dismissed)
+    total: <number>                   # required — weighted score denominator
     grade: A | B | C | D | F          # required enum
+    coverage_supported: <number>      # adapter-supported weight, including not-applicable checks
+    coverage_total: <number>          # all configured check weight
     checks:                           # dict, required: check_id -> result
       <check_id>:
-        status: pass | warn | fail | unknown | dismissed   # required enum
+        check_id: <check_id>          # str, required; must match the mapping key
+        adapter: <adapter id>         # str, required
+        weight: <number>              # non-negative, required
+        profile: <profile id>         # optional source profile
+        status: pass | warn | fail | unknown | not_applicable | unsupported | error
         detail: <str>                 # required
         data: {}                      # dict, required (may be empty)
         inferred: <bool>              # optional — true when LLM judgment produced it
@@ -106,6 +113,18 @@ aggregate:                            # dict, required
   grade: A | B | C | D | F
 errors: []
 ```
+
+`pass`, `warn`, and `fail` enter the weighted score denominator. `unknown`,
+`not_applicable`, `unsupported`, and `error` do not. Coverage includes every
+configured weight in `coverage_total`; only `unsupported` weight is excluded
+from `coverage_supported`, so adapter gaps remain visible without becoming
+false repository failures. A current dismissal is emitted as `not_applicable`
+with `data.dismissed: true`; the durable dismissal decision remains in
+`healthcheck.yaml`.
+
+Grades must always be presented with `scorecard`. A grade from one scorecard is
+not directly compared with a grade from another scorecard because the checks,
+weights, and applicability rules differ.
 
 ### refresh-result.yaml (written by gh-refresh-headless, P3.3)
 

--- a/lib/patterns/repository-profiles.md
+++ b/lib/patterns/repository-profiles.md
@@ -1,0 +1,78 @@
+# Pattern: Repository profiles and scorecards
+
+Repository intent is committed workspace metadata, not a conclusion silently
+written by a detector. The authoritative file is
+`.hiivmind/github/profiles.yaml`.
+
+## Authority boundary
+
+- `repository_profiles` selects the reviewed intent labels and scorecard for a
+  repository.
+- `scorecards` selects checks, adapters, weights, and applicability.
+- `adapters` records whether an adapter implementation is available.
+- Detection may emit profile proposals and `asks_recorded`, but those outputs
+  never modify this file. A profile or scorecard changes only through a merged
+  workspace-metadata change.
+
+## Schema
+
+```yaml
+repository_profiles:
+  acme/api:
+    profiles: [python, service]
+    scorecard: python-service-v1
+
+scorecards:
+  generic-v1:
+    checks:
+      - id: documentation
+        adapter: generic.docs
+        applicability: always
+        weight: 1
+  python-service-v1:
+    extends: generic-v1
+    checks:
+      - id: dependencies
+        adapter: python.lockfiles
+        applicability: profile:python
+        weight: 2
+
+adapters:
+  generic.docs:
+    state: available
+  python.lockfiles:
+    state: available
+  terraform.dependencies:
+    state: unsupported
+    reason: dependency adapter not implemented
+```
+
+All three root mappings are required. Unknown keys, scorecards, and adapters
+are configuration errors. Adapter state is `available | unsupported`; an
+unsupported adapter requires a reason and produces coverage debt rather than a
+repository failure.
+
+## Check identity and inheritance
+
+A check ID occurs once in a resolved scorecard. A child that intentionally
+changes an inherited check must set `replace: true`; accidental duplicates are
+configuration errors. Weight is a non-negative number and travels with the
+check result so scoring can be reproduced from the artifact.
+
+Applicability predicates are evaluated only after inheritance resolves:
+
+- `always`
+- `profile:<id>` against authoritative repository profiles
+- `capability:<id>` against that repository's derived evidence capabilities
+- `evidence_path:<glob>` against observed repository paths
+
+Applicability never assigns a profile. A false predicate produces
+`not_applicable`. An applicable check whose adapter is unavailable produces
+`unsupported`.
+
+## Score interpretation
+
+Grades are scorecard-specific. Reports always pair a grade with its scorecard
+ID; an `A` on one scorecard is not claimed equivalent to an `A` on another.
+`not_applicable` and `unsupported` do not enter the score denominator, while
+unsupported weight is visible as coverage debt.

--- a/lib/pulse/scripts/evaluate_checks.py
+++ b/lib/pulse/scripts/evaluate_checks.py
@@ -24,15 +24,17 @@ Usage:
                      [--relationships relationships.yaml]
                      [--dismissals healthcheck.yaml]
 
-Scoring (catalog): pass=1, warn=0.5; unknown/dismissed excluded from total.
-Grade by score/total fraction: A >= 0.90, B >= 0.72, C >= 0.54, D >= 0.36, F below.
+Scoring is weight-aware: pass=weight, warn=0.5*weight, fail=0. Unknown,
+not_applicable, unsupported, and error are excluded from the score denominator.
+Only unsupported weight is excluded from coverage_supported. Grade by score/total
+fraction: A >= 0.90, B >= 0.72, C >= 0.54, D >= 0.36, F below.
 """
 from __future__ import annotations
 
 import argparse
 import json
-import math
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
@@ -41,6 +43,59 @@ BUG_LABELS = {"bug", "defect", "error", "incident"}
 PRIORITY_HINTS = {"priority", "p0", "p1", "p2", "p3", "p4", "critical", "urgent"}
 DEP_FILES = {"dependabot.yml", "dependabot.yaml", "renovate.json", ".renovaterc",
              ".renovaterc.json"}
+RESULT_STATES = {
+    "pass",
+    "warn",
+    "fail",
+    "unknown",
+    "not_applicable",
+    "unsupported",
+    "error",
+}
+LEGACY_SCORECARD = "github-governance-v1"
+
+
+@dataclass(frozen=True)
+class ScoreSummary:
+    score: float
+    total: float
+    grade: str
+    coverage_supported: float
+    coverage_total: float
+
+
+def score_checks(checks: dict[str, dict]) -> ScoreSummary:
+    """Compute weighted health and adapter coverage from typed check results."""
+    score = 0.0
+    total = 0.0
+    coverage_supported = 0.0
+    coverage_total = 0.0
+    for check_id, check in checks.items():
+        status = check.get("status")
+        if status not in RESULT_STATES:
+            raise ValueError(f"unknown check state for {check_id}: {status}")
+        weight = check.get("weight")
+        if isinstance(weight, bool) or not isinstance(weight, (int, float)) or weight < 0:
+            raise ValueError(f"invalid check weight for {check_id}: {weight}")
+        weight = float(weight)
+        coverage_total += weight
+        if status != "unsupported":
+            coverage_supported += weight
+        if status not in {"pass", "warn", "fail"}:
+            continue
+        total += weight
+        score += {"pass": weight, "warn": weight * 0.5, "fail": 0.0}[status]
+    score = round(score, 10)
+    total = round(total, 10)
+    coverage_supported = round(coverage_supported, 10)
+    coverage_total = round(coverage_total, 10)
+    return ScoreSummary(
+        score,
+        total,
+        grade_for(score, total),
+        coverage_supported,
+        coverage_total,
+    )
 
 
 def load(data_dir: Path, name: str):
@@ -181,7 +236,7 @@ def check_secrets_scanning(d):
     return "fail", "Secret scanning not enabled"
 
 
-def grade_for(score: float, total: int) -> str:
+def grade_for(score: float, total: float) -> str:
     if total == 0:
         return "F"
     frac = score / total
@@ -237,24 +292,40 @@ def main() -> int:
     }
 
     checks: dict = {}
-    score, total = 0.0, 0
     for cid, fn in evaluators.items():
+        adapter = f"github.{cid}"
         if cid in dismissed:
             reason = (dismissed[cid] or {}).get("reason", "")
-            checks[cid] = {"status": "dismissed",
-                           "detail": f"Dismissed: {reason}", "data": {}}
+            checks[cid] = {
+                "check_id": cid,
+                "adapter": adapter,
+                "weight": 1,
+                "status": "not_applicable",
+                "detail": f"Dismissed: {reason}",
+                "data": {"dismissed": True, "reason": reason},
+            }
             continue
         status, detail = fn()
-        checks[cid] = {"status": status, "detail": detail, "data": {}}
-        if status == "unknown":
-            continue
-        total += 1
-        score += {"pass": 1.0, "warn": 0.5, "fail": 0.0}[status]
+        checks[cid] = {
+            "check_id": cid,
+            "adapter": adapter,
+            "weight": 1,
+            "status": status,
+            "detail": detail,
+            "data": {},
+        }
 
-    score = math.floor(score * 2) / 2   # keep the 0.5 granularity, no float dust
-    print(json.dumps({"repo": args.repo, "score": score, "total": total,
-                      "grade": grade_for(score, total), "checks": checks},
-                     indent=2))
+    summary = score_checks(checks)
+    print(json.dumps({
+        "repo": args.repo,
+        "scorecard": LEGACY_SCORECARD,
+        "score": summary.score,
+        "total": summary.total,
+        "grade": summary.grade,
+        "coverage_supported": summary.coverage_supported,
+        "coverage_total": summary.coverage_total,
+        "checks": checks,
+    }, indent=2))
     return 0
 
 

--- a/lib/pulse/scripts/profile_dispatch.py
+++ b/lib/pulse/scripts/profile_dispatch.py
@@ -8,6 +8,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
 
@@ -55,6 +56,33 @@ class ProfileConfig:
     repositories: dict[str, RepositoryProfile]
     scorecards: dict[str, Scorecard]
     adapters: dict[str, AdapterDefinition]
+
+
+@dataclass(frozen=True)
+class PlannedCheck:
+    definition: CheckDefinition
+    state: str | None
+    reason: str | None = None
+
+    @property
+    def check_id(self) -> str:
+        return self.definition.id
+
+    @property
+    def adapter(self) -> str:
+        return self.definition.adapter
+
+    @property
+    def weight(self) -> float:
+        return self.definition.weight
+
+
+@dataclass(frozen=True)
+class DispatchPlan:
+    repo: str
+    profiles: tuple[str, ...]
+    scorecard: str
+    checks: dict[str, PlannedCheck]
 
 
 def _mapping(value: Any, label: str) -> dict[str, Any]:
@@ -195,3 +223,103 @@ def load_profiles(path: str | Path) -> ProfileConfig:
         if repository.scorecard not in scorecards:
             raise ConfigError(f"unknown scorecard: {repository.scorecard}")
     return ProfileConfig(repositories, scorecards, adapters)
+
+
+def resolve_scorecard(
+    config: ProfileConfig,
+    scorecard_id: str,
+    _stack: tuple[str, ...] = (),
+) -> tuple[CheckDefinition, ...]:
+    """Resolve inheritance with explicit, deterministic check replacement."""
+    if scorecard_id not in config.scorecards:
+        raise ConfigError(f"unknown scorecard: {scorecard_id}")
+    if scorecard_id in _stack:
+        cycle = " -> ".join((*_stack, scorecard_id))
+        raise ConfigError(f"scorecard inheritance cycle: {cycle}")
+
+    scorecard = config.scorecards[scorecard_id]
+    resolved = list(
+        resolve_scorecard(config, scorecard.extends, (*_stack, scorecard_id))
+        if scorecard.extends is not None
+        else ()
+    )
+    positions = {check.id: index for index, check in enumerate(resolved)}
+    for check in scorecard.checks:
+        if check.id in positions:
+            if not check.replace:
+                raise ConfigError(
+                    f"duplicate check {check.id} requires replace: true"
+                )
+            resolved[positions[check.id]] = check
+            continue
+        if check.replace:
+            raise ConfigError(
+                f"check {check.id} sets replace but is not inherited"
+            )
+        positions[check.id] = len(resolved)
+        resolved.append(check)
+    return tuple(resolved)
+
+
+def _repo_evidence(snapshot: dict[str, Any], repo: str) -> dict[str, Any]:
+    if snapshot.get("repo") == repo:
+        return snapshot
+    repos = snapshot.get("repos", [])
+    if not isinstance(repos, list):
+        raise ConfigError("evidence repos must be a list")
+    matches = [entry for entry in repos if isinstance(entry, dict) and entry.get("repo") == repo]
+    if len(matches) > 1:
+        raise ConfigError(f"duplicate evidence for repository: {repo}")
+    return matches[0] if matches else {}
+
+
+def _string_set(evidence: dict[str, Any], key: str) -> set[str]:
+    values = evidence.get(key, [])
+    if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+        raise ConfigError(f"repository evidence {key} must be a list of strings")
+    return set(values)
+
+
+def _is_applicable(
+    predicate: str,
+    repository: RepositoryProfile,
+    evidence: dict[str, Any],
+) -> bool:
+    if predicate == "always":
+        return True
+    if ":" not in predicate:
+        raise ConfigError(f"unsupported applicability: {predicate}")
+    kind, value = predicate.split(":", 1)
+    if not value:
+        raise ConfigError(f"unsupported applicability: {predicate}")
+    if kind == "profile":
+        return value in repository.profiles
+    if kind == "capability":
+        return value in _string_set(evidence, "capabilities")
+    if kind == "evidence_path":
+        return any(fnmatchcase(path, value) for path in _string_set(evidence, "files"))
+    raise ConfigError(f"unsupported applicability: {predicate}")
+
+
+def dispatch(repo: str, evidence: dict[str, Any], config: ProfileConfig) -> DispatchPlan:
+    """Resolve one repository's authoritative scorecard into an execution plan."""
+    if repo not in config.repositories:
+        raise ConfigError(f"repository has no authoritative profile: {repo}")
+    repository = config.repositories[repo]
+    repo_evidence = _repo_evidence(evidence, repo)
+    checks: dict[str, PlannedCheck] = {}
+    for check in resolve_scorecard(config, repository.scorecard):
+        if not _is_applicable(check.applicability, repository, repo_evidence):
+            planned = PlannedCheck(
+                check,
+                "not_applicable",
+                f"predicate not satisfied: {check.applicability}",
+            )
+        else:
+            adapter = config.adapters[check.adapter]
+            if adapter.state == "unsupported":
+                planned = PlannedCheck(check, "unsupported", adapter.reason)
+            else:
+                planned = PlannedCheck(check, None)
+        checks[check.id] = planned
+    return DispatchPlan(repo, repository.profiles, repository.scorecard, checks)

--- a/lib/pulse/scripts/profile_dispatch.py
+++ b/lib/pulse/scripts/profile_dispatch.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Load authoritative repository profiles and dispatch scorecard checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ADAPTER_STATES = {"available", "unsupported"}
+
+
+class ConfigError(ValueError):
+    """Raised when committed profile metadata violates its schema."""
+
+
+@dataclass(frozen=True)
+class RepositoryProfile:
+    profiles: tuple[str, ...]
+    scorecard: str
+
+
+@dataclass(frozen=True)
+class CheckDefinition:
+    id: str
+    adapter: str
+    weight: float
+    applicability: str = "always"
+    replace: bool = False
+
+
+@dataclass(frozen=True)
+class Scorecard:
+    id: str
+    checks: tuple[CheckDefinition, ...]
+    extends: str | None = None
+
+
+@dataclass(frozen=True)
+class AdapterDefinition:
+    id: str
+    state: str
+    reason: str | None = None
+
+
+@dataclass(frozen=True)
+class ProfileConfig:
+    repositories: dict[str, RepositoryProfile]
+    scorecards: dict[str, Scorecard]
+    adapters: dict[str, AdapterDefinition]
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ConfigError(f"{label} must be a mapping")
+    if not all(isinstance(key, str) for key in value):
+        raise ConfigError(f"{label} keys must be strings")
+    return value
+
+
+def _list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ConfigError(f"{label} must be a list")
+    return value
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"{label} must be a non-empty string")
+    return value
+
+
+def _only_keys(data: dict[str, Any], allowed: set[str], label: str) -> None:
+    unknown = set(data) - allowed
+    if unknown:
+        raise ConfigError(f"unknown {label} key: {sorted(unknown)[0]}")
+
+
+def _load_adapters(raw: dict[str, Any]) -> dict[str, AdapterDefinition]:
+    adapters: dict[str, AdapterDefinition] = {}
+    for adapter_id, value in raw.items():
+        adapter_id = _string(adapter_id, "adapter id")
+        item = _mapping(value, f"adapter {adapter_id}")
+        _only_keys(item, {"state", "reason"}, "adapter")
+        state = _string(item.get("state"), f"adapter {adapter_id}.state")
+        if state not in ADAPTER_STATES:
+            raise ConfigError(f"invalid adapter state: {state}")
+        reason = item.get("reason")
+        if reason is not None:
+            reason = _string(reason, f"adapter {adapter_id}.reason")
+        if state == "unsupported" and reason is None:
+            raise ConfigError(f"unsupported adapter requires reason: {adapter_id}")
+        adapters[adapter_id] = AdapterDefinition(adapter_id, state, reason)
+    return adapters
+
+
+def _load_check(raw: Any, scorecard_id: str) -> CheckDefinition:
+    item = _mapping(raw, f"scorecard {scorecard_id} check")
+    _only_keys(
+        item,
+        {"id", "adapter", "weight", "applicability", "replace"},
+        "check",
+    )
+    check_id = _string(item.get("id"), f"scorecard {scorecard_id} check id")
+    adapter = _string(item.get("adapter"), f"check {check_id}.adapter")
+    weight = item.get("weight")
+    if isinstance(weight, bool) or not isinstance(weight, (int, float)) or weight < 0:
+        raise ConfigError(f"check {check_id}.weight must be a non-negative number")
+    applicability = item.get("applicability", "always")
+    applicability = _string(applicability, f"check {check_id}.applicability")
+    replace = item.get("replace", False)
+    if not isinstance(replace, bool):
+        raise ConfigError(f"check {check_id}.replace must be a boolean")
+    return CheckDefinition(check_id, adapter, float(weight), applicability, replace)
+
+
+def _load_scorecards(raw: dict[str, Any]) -> dict[str, Scorecard]:
+    scorecards: dict[str, Scorecard] = {}
+    for scorecard_id, value in raw.items():
+        scorecard_id = _string(scorecard_id, "scorecard id")
+        item = _mapping(value, f"scorecard {scorecard_id}")
+        _only_keys(item, {"extends", "checks"}, "scorecard")
+        extends = item.get("extends")
+        if extends is not None:
+            extends = _string(extends, f"scorecard {scorecard_id}.extends")
+        checks = tuple(
+            _load_check(check, scorecard_id)
+            for check in _list(item.get("checks"), f"scorecard {scorecard_id}.checks")
+        )
+        seen: set[str] = set()
+        for check in checks:
+            if check.id in seen:
+                raise ConfigError(f"duplicate check in scorecard {scorecard_id}: {check.id}")
+            seen.add(check.id)
+        scorecards[scorecard_id] = Scorecard(scorecard_id, checks, extends)
+    return scorecards
+
+
+def _load_repositories(raw: dict[str, Any]) -> dict[str, RepositoryProfile]:
+    repositories: dict[str, RepositoryProfile] = {}
+    for repo, value in raw.items():
+        repo = _string(repo, "repository name")
+        item = _mapping(value, f"repository profile {repo}")
+        _only_keys(item, {"profiles", "scorecard"}, "repository profile")
+        profiles = tuple(
+            _string(profile, f"repository {repo} profile")
+            for profile in _list(item.get("profiles"), f"repository {repo}.profiles")
+        )
+        seen: set[str] = set()
+        for profile in profiles:
+            if profile in seen:
+                raise ConfigError(f"duplicate profile: {profile}")
+            seen.add(profile)
+        scorecard = _string(item.get("scorecard"), f"repository {repo}.scorecard")
+        repositories[repo] = RepositoryProfile(profiles, scorecard)
+    return repositories
+
+
+def load_profiles(path: str | Path) -> ProfileConfig:
+    """Load and cross-validate committed profile metadata."""
+    source = Path(path)
+    try:
+        data = yaml.safe_load(source.read_text())
+    except FileNotFoundError as exc:
+        raise ConfigError(f"profile config not found: {source}") from exc
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise ConfigError(f"could not load profile config: {exc}") from exc
+    root = _mapping(data, "profile config")
+    required = {"repository_profiles", "scorecards", "adapters"}
+    _only_keys(root, required, "profile config")
+    missing = required - set(root)
+    if missing:
+        raise ConfigError(f"missing profile config key: {sorted(missing)[0]}")
+
+    adapters = _load_adapters(_mapping(root["adapters"], "adapters"))
+    scorecards = _load_scorecards(_mapping(root["scorecards"], "scorecards"))
+    repositories = _load_repositories(
+        _mapping(root["repository_profiles"], "repository_profiles")
+    )
+
+    for scorecard in scorecards.values():
+        if scorecard.extends is not None and scorecard.extends not in scorecards:
+            raise ConfigError(f"unknown scorecard: {scorecard.extends}")
+        for check in scorecard.checks:
+            if check.adapter not in adapters:
+                raise ConfigError(f"unknown adapter: {check.adapter}")
+    for repository in repositories.values():
+        if repository.scorecard not in scorecards:
+            raise ConfigError(f"unknown scorecard: {repository.scorecard}")
+    return ProfileConfig(repositories, scorecards, adapters)

--- a/lib/pulse/scripts/tests/fixtures/healthcheck-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/healthcheck-valid.yaml
@@ -8,25 +8,37 @@ actor:
   mode: interactive
 repos:
   - repo: testorg/widget
-    score: 7.5
-    total: 9
-    grade: B
+    scorecard: github-governance-v1
+    score: 1.5
+    total: 3
+    grade: D
+    coverage_supported: 3
+    coverage_total: 3
     checks:
       branch_protection:
+        check_id: branch_protection
+        adapter: github.branch_protection
+        weight: 1
         status: warn
         detail: "main: 1 required review, enforce_admins: no"
         data: {}
       releases:
+        check_id: releases
+        adapter: github.releases
+        weight: 1
         status: fail
         detail: "No releases or tags"
         data: {}
       issue_triage:
+        check_id: issue_triage
+        adapter: github.issue_triage
+        weight: 1
         status: pass
         detail: "Bug: bug, Priority: P1"
         data: {}
         inferred: false
 aggregate:
-  score: 7.5
-  total: 9
-  grade: B
+  score: 1.5
+  total: 3
+  grade: D
 errors: []

--- a/lib/pulse/scripts/tests/fixtures/profiles/evidence.yaml
+++ b/lib/pulse/scripts/tests/fixtures/profiles/evidence.yaml
@@ -1,0 +1,29 @@
+repos:
+  - repo: acme/python-lib
+    capabilities: [ci, python]
+    files: [README.md, pyproject.toml]
+    structural_signals: [src-layout]
+  - repo: acme/python-service
+    capabilities: [ci, python, service]
+    files: [README.md, pyproject.toml, Dockerfile]
+    structural_signals: [service-entrypoint]
+  - repo: acme/node-web
+    capabilities: [ci, nodejs, web]
+    files: [README.md, package.json]
+    structural_signals: [web-build]
+  - repo: acme/docs
+    capabilities: [documentation]
+    files: [README.md, mkdocs.yml]
+    structural_signals: [documentation-site]
+  - repo: acme/terraform
+    capabilities: [ci, terraform]
+    files: [README.md, main.tf]
+    structural_signals: [terraform-module]
+  - repo: acme/plugin
+    capabilities: [ci, python, claude-plugin]
+    files: [README.md, .claude-plugin/plugin.json, skills/audit/SKILL.md]
+    structural_signals: [claude-plugin-manifest, skill-directory]
+  - repo: acme/unknown
+    capabilities: []
+    files: [README.md]
+    structural_signals: []

--- a/lib/pulse/scripts/tests/fixtures/profiles/profiles.yaml
+++ b/lib/pulse/scripts/tests/fixtures/profiles/profiles.yaml
@@ -1,0 +1,120 @@
+repository_profiles:
+  acme/python-lib:
+    profiles: [python, library]
+    scorecard: python-library-v1
+  acme/python-service:
+    profiles: [python, service]
+    scorecard: python-service-v1
+  acme/node-web:
+    profiles: [nodejs, web]
+    scorecard: node-web-v1
+  acme/docs:
+    profiles: [documentation]
+    scorecard: docs-v1
+  acme/terraform:
+    profiles: [terraform, infrastructure]
+    scorecard: terraform-v1
+  acme/plugin:
+    profiles: [claude-plugin, python]
+    scorecard: claude-plugin-v1
+  acme/unknown:
+    profiles: [unclassified]
+    scorecard: generic-v1
+
+scorecards:
+  generic-v1:
+    checks:
+      - id: documentation
+        adapter: generic.docs
+        weight: 1
+      - id: ci
+        adapter: github.actions
+        applicability: capability:ci
+        weight: 1
+      - id: claude-plugin-structure
+        adapter: claude.plugin-structure
+        applicability: profile:claude-plugin
+        weight: 1
+
+  python-library-v1:
+    extends: generic-v1
+    checks:
+      - id: dependency-updates
+        adapter: python.dependencies
+        weight: 1
+      - id: package-release
+        adapter: python.package-release
+        applicability: evidence_path:pyproject.toml
+        weight: 1
+
+  python-service-v1:
+    extends: generic-v1
+    checks:
+      - id: dependency-updates
+        adapter: python.dependencies
+        weight: 1
+      - id: service-runtime
+        adapter: python.service-runtime
+        weight: 1
+
+  node-web-v1:
+    extends: generic-v1
+    checks:
+      - id: dependency-updates
+        adapter: node.dependencies
+        weight: 1
+      - id: web-build
+        adapter: node.web-build
+        applicability: evidence_path:package.json
+        weight: 1
+
+  docs-v1:
+    extends: generic-v1
+    checks:
+      - id: docs-links
+        adapter: docs.links
+        weight: 1
+
+  terraform-v1:
+    extends: generic-v1
+    checks:
+      - id: terraform-validation
+        adapter: terraform.validate
+        weight: 1
+      - id: dependency-updates
+        adapter: terraform.dependencies
+        weight: 1
+
+  claude-plugin-v1:
+    extends: generic-v1
+    checks:
+      - id: plugin-skills
+        adapter: claude.skills
+        weight: 1
+
+adapters:
+  generic.docs:
+    state: available
+  github.actions:
+    state: available
+  claude.plugin-structure:
+    state: available
+  python.dependencies:
+    state: available
+  python.package-release:
+    state: available
+  python.service-runtime:
+    state: available
+  node.dependencies:
+    state: available
+  node.web-build:
+    state: available
+  docs.links:
+    state: available
+  terraform.validate:
+    state: available
+  terraform.dependencies:
+    state: unsupported
+    reason: Terraform dependency adapter not implemented
+  claude.skills:
+    state: available

--- a/lib/pulse/scripts/tests/test_evaluate_checks.py
+++ b/lib/pulse/scripts/tests/test_evaluate_checks.py
@@ -4,6 +4,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from lib.pulse.scripts.evaluate_checks import score_checks
+
 SCRIPT = "lib/pulse/scripts/evaluate_checks.py"
 FIXTURES = Path("lib/pulse/scripts/tests/fixtures/checks")
 
@@ -57,12 +59,67 @@ def test_dismissals_honored(tmp_path):
         "      reason: Do later\n")
     r = run_checks(FIXTURES / "bare", ["--dismissals", str(dismissals)])
     out = json.loads(r.stdout)
-    assert out["checks"]["secrets_scanning"]["status"] == "dismissed"
+    assert out["checks"]["secrets_scanning"]["status"] == "not_applicable"
+    assert out["checks"]["secrets_scanning"]["data"]["dismissed"] is True
     assert out["total"] == 9   # dismissed + unknown excluded
 
 
 def test_check_shape_matches_contract():
     r = run_checks(FIXTURES / "bare")
     out = json.loads(r.stdout)
-    for c in out["checks"].values():
-        assert set(c) >= {"status", "detail", "data"}
+    assert set(out) >= {
+        "scorecard",
+        "coverage_supported",
+        "coverage_total",
+    }
+    for check_id, check in out["checks"].items():
+        assert set(check) >= {
+            "check_id",
+            "adapter",
+            "weight",
+            "status",
+            "detail",
+            "data",
+        }
+        assert check["check_id"] == check_id
+
+
+def block(status, weight):
+    return {
+        "check_id": status,
+        "adapter": "test.adapter",
+        "weight": weight,
+        "status": status,
+        "detail": "",
+        "data": {},
+    }
+
+
+def test_non_applicable_and_unsupported_do_not_enter_denominator():
+    checks = {
+        "ci": block("pass", weight=2),
+        "claude": block("not_applicable", weight=1),
+        "cargo": block("unsupported", weight=2),
+    }
+
+    result = score_checks(checks)
+
+    assert result.score == 2
+    assert result.total == 2
+    assert result.coverage_supported == 3
+    assert result.coverage_total == 5
+
+
+def test_unknown_and_error_are_unscored_but_coverage_supported():
+    checks = {
+        "known": block("warn", weight=2),
+        "unknown": block("unknown", weight=3),
+        "error": block("error", weight=4),
+    }
+
+    result = score_checks(checks)
+
+    assert result.score == 1
+    assert result.total == 2
+    assert result.coverage_supported == 9
+    assert result.coverage_total == 9

--- a/lib/pulse/scripts/tests/test_profile_acceptance.py
+++ b/lib/pulse/scripts/tests/test_profile_acceptance.py
@@ -1,0 +1,49 @@
+"""Acceptance coverage for heterogeneous repository profile dispatch."""
+
+from pathlib import Path
+
+import yaml
+
+from lib.pulse.scripts.profile_dispatch import dispatch, load_profiles
+
+
+FIXTURES = Path("lib/pulse/scripts/tests/fixtures/profiles")
+
+
+def test_heterogeneous_fleet_dispatches_by_authoritative_intent():
+    config = load_profiles(FIXTURES / "profiles.yaml")
+    evidence = yaml.safe_load((FIXTURES / "evidence.yaml").read_text())
+
+    expected_scorecards = {
+        "acme/python-lib": "python-library-v1",
+        "acme/python-service": "python-service-v1",
+        "acme/node-web": "node-web-v1",
+        "acme/docs": "docs-v1",
+        "acme/terraform": "terraform-v1",
+        "acme/plugin": "claude-plugin-v1",
+        "acme/unknown": "generic-v1",
+    }
+
+    plans = {repo: dispatch(repo, evidence, config) for repo in expected_scorecards}
+
+    assert {repo: plan.scorecard for repo, plan in plans.items()} == expected_scorecards
+
+    for repo, plan in plans.items():
+        if repo == "acme/plugin":
+            assert plan.checks["claude-plugin-structure"].state is None
+        else:
+            assert plan.checks["claude-plugin-structure"].state == "not_applicable"
+
+    terraform = plans["acme/terraform"]
+    assert terraform.checks["dependency-updates"].state == "unsupported"
+    assert "not implemented" in terraform.checks["dependency-updates"].reason
+
+    unknown = plans["acme/unknown"]
+    assert unknown.profiles == ("unclassified",)
+    assert set(unknown.checks) == {
+        "documentation",
+        "ci",
+        "claude-plugin-structure",
+    }
+    assert unknown.checks["documentation"].state is None
+    assert unknown.checks["ci"].state == "not_applicable"

--- a/lib/pulse/scripts/tests/test_profile_dispatch.py
+++ b/lib/pulse/scripts/tests/test_profile_dispatch.py
@@ -1,0 +1,115 @@
+"""Tests for authoritative repository profile and scorecard dispatch."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lib.pulse.scripts import profile_dispatch
+
+
+def write_yaml(tmp_path: Path, data) -> Path:
+    path = tmp_path / "profiles.yaml"
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path
+
+
+def minimal_config():
+    return {
+        "repository_profiles": {
+            "acme/api": {
+                "profiles": ["python", "service"],
+                "scorecard": "python-service-v1",
+            }
+        },
+        "scorecards": {
+            "python-service-v1": {
+                "checks": [
+                    {
+                        "id": "documentation",
+                        "adapter": "generic.docs",
+                        "weight": 1,
+                    }
+                ]
+            }
+        },
+        "adapters": {"generic.docs": {"state": "available"}},
+    }
+
+
+def test_loads_explicit_repo_profile(tmp_path):
+    config = profile_dispatch.load_profiles(write_yaml(tmp_path, minimal_config()))
+
+    repo = config.repositories["acme/api"]
+    assert repo.profiles == ("python", "service")
+    assert repo.scorecard == "python-service-v1"
+    check = config.scorecards[repo.scorecard].checks[0]
+    assert check.adapter == "generic.docs"
+    assert check.weight == 1
+
+
+def test_rejects_unknown_scorecard(tmp_path):
+    data = minimal_config()
+    data["repository_profiles"]["acme/api"]["scorecard"] = "missing"
+
+    with pytest.raises(profile_dispatch.ConfigError, match="unknown scorecard: missing"):
+        profile_dispatch.load_profiles(write_yaml(tmp_path, data))
+
+
+def test_rejects_unknown_adapter(tmp_path):
+    data = minimal_config()
+    data["scorecards"]["python-service-v1"]["checks"][0]["adapter"] = "missing"
+
+    with pytest.raises(profile_dispatch.ConfigError, match="unknown adapter: missing"):
+        profile_dispatch.load_profiles(write_yaml(tmp_path, data))
+
+
+def test_loads_explicitly_unsupported_adapter(tmp_path):
+    data = minimal_config()
+    data["adapters"]["terraform.dependencies"] = {
+        "state": "unsupported",
+        "reason": "adapter not implemented",
+    }
+
+    config = profile_dispatch.load_profiles(write_yaml(tmp_path, data))
+
+    adapter = config.adapters["terraform.dependencies"]
+    assert adapter.state == "unsupported"
+    assert adapter.reason == "adapter not implemented"
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda data: data.update({"profile_proposals": {}}),
+            "unknown profile config key: profile_proposals",
+        ),
+        (
+            lambda data: data["repository_profiles"]["acme/api"].update(
+                {"confidence": 0.9}
+            ),
+            "unknown repository profile key: confidence",
+        ),
+        (
+            lambda data: data["scorecards"]["python-service-v1"]["checks"][0].update(
+                {"inferred": True}
+            ),
+            "unknown check key: inferred",
+        ),
+    ],
+)
+def test_schema_is_strict(tmp_path, mutate, message):
+    data = minimal_config()
+    mutate(data)
+
+    with pytest.raises(profile_dispatch.ConfigError, match=message):
+        profile_dispatch.load_profiles(write_yaml(tmp_path, data))
+
+
+def test_rejects_duplicate_profiles(tmp_path):
+    data = minimal_config()
+    data["repository_profiles"]["acme/api"]["profiles"] = ["python", "python"]
+
+    with pytest.raises(profile_dispatch.ConfigError, match="duplicate profile: python"):
+        profile_dispatch.load_profiles(write_yaml(tmp_path, data))

--- a/lib/pulse/scripts/tests/test_profile_dispatch.py
+++ b/lib/pulse/scripts/tests/test_profile_dispatch.py
@@ -113,3 +113,178 @@ def test_rejects_duplicate_profiles(tmp_path):
 
     with pytest.raises(profile_dispatch.ConfigError, match="duplicate profile: python"):
         profile_dispatch.load_profiles(write_yaml(tmp_path, data))
+
+
+def inheritance_config(tmp_path, child_checks):
+    data = {
+        "repository_profiles": {
+            "acme/lib": {
+                "profiles": ["python", "library"],
+                "scorecard": "child",
+            }
+        },
+        "scorecards": {
+            "base": {
+                "checks": [
+                    {"id": "docs", "adapter": "generic.docs", "weight": 1},
+                    {"id": "ci", "adapter": "github.actions", "weight": 2},
+                ]
+            },
+            "child": {"extends": "base", "checks": child_checks},
+        },
+        "adapters": {
+            "generic.docs": {"state": "available"},
+            "github.actions": {"state": "available"},
+            "other.actions": {"state": "available"},
+            "terraform.dependencies": {
+                "state": "unsupported",
+                "reason": "not implemented",
+            },
+        },
+    }
+    return profile_dispatch.load_profiles(write_yaml(tmp_path, data))
+
+
+def test_child_must_explicitly_replace_parent_check(tmp_path):
+    config = inheritance_config(
+        tmp_path,
+        [{"id": "ci", "adapter": "other.actions", "weight": 3}],
+    )
+
+    with pytest.raises(
+        profile_dispatch.ConfigError,
+        match="duplicate check ci requires replace: true",
+    ):
+        profile_dispatch.resolve_scorecard(config, "child")
+
+
+def test_child_can_replace_parent_check_once(tmp_path):
+    config = inheritance_config(
+        tmp_path,
+        [
+            {
+                "id": "ci",
+                "adapter": "other.actions",
+                "weight": 3,
+                "replace": True,
+            },
+            {"id": "release", "adapter": "generic.docs", "weight": 1},
+        ],
+    )
+
+    checks = profile_dispatch.resolve_scorecard(config, "child")
+
+    assert [check.id for check in checks] == ["docs", "ci", "release"]
+    assert checks[1].adapter == "other.actions"
+    assert sum(check.id == "ci" for check in checks) == 1
+
+
+def test_replace_requires_an_inherited_check(tmp_path):
+    config = inheritance_config(
+        tmp_path,
+        [
+            {
+                "id": "release",
+                "adapter": "generic.docs",
+                "weight": 1,
+                "replace": True,
+            }
+        ],
+    )
+
+    with pytest.raises(
+        profile_dispatch.ConfigError,
+        match="check release sets replace but is not inherited",
+    ):
+        profile_dispatch.resolve_scorecard(config, "child")
+
+
+def dispatch_config(tmp_path):
+    checks = [
+        {
+            "id": "python",
+            "adapter": "generic.docs",
+            "weight": 1,
+            "applicability": "profile:python",
+        },
+        {
+            "id": "claude-context",
+            "adapter": "generic.docs",
+            "weight": 1,
+            "applicability": "profile:claude-plugin",
+        },
+        {
+            "id": "ci-capability",
+            "adapter": "github.actions",
+            "weight": 2,
+            "applicability": "capability:ci",
+        },
+        {
+            "id": "manifest",
+            "adapter": "generic.docs",
+            "weight": 1,
+            "applicability": "evidence_path:pyproject.toml",
+        },
+        {
+            "id": "terraform-dependencies",
+            "adapter": "terraform.dependencies",
+            "weight": 2,
+            "applicability": "always",
+        },
+    ]
+    return inheritance_config(tmp_path, checks)
+
+
+def repo_evidence(capabilities=("python", "ci"), files=("pyproject.toml",)):
+    return {
+        "repos": [
+            {
+                "repo": "acme/lib",
+                "capabilities": list(capabilities),
+                "files": list(files),
+                "structural_signals": [],
+            }
+        ]
+    }
+
+
+def test_dispatch_evaluates_all_supported_applicability_predicates(tmp_path):
+    config = dispatch_config(tmp_path)
+
+    plan = profile_dispatch.dispatch("acme/lib", repo_evidence(), config)
+
+    assert plan.scorecard == "child"
+    assert plan.profiles == ("python", "library")
+    assert plan.checks["docs"].state is None
+    assert plan.checks["python"].state is None
+    assert plan.checks["ci-capability"].state is None
+    assert plan.checks["manifest"].state is None
+    assert plan.checks["claude-context"].state == "not_applicable"
+    assert plan.checks["terraform-dependencies"].state == "unsupported"
+
+
+def test_applicability_excludes_absent_capability(tmp_path):
+    config = dispatch_config(tmp_path)
+
+    plan = profile_dispatch.dispatch(
+        "acme/lib", repo_evidence(capabilities=["python"]), config
+    )
+
+    assert plan.checks["ci-capability"].state == "not_applicable"
+
+
+def test_unsupported_predicate_is_configuration_error(tmp_path):
+    config = inheritance_config(
+        tmp_path,
+        [
+            {
+                "id": "bad",
+                "adapter": "generic.docs",
+                "weight": 1,
+                "applicability": "language:python",
+            }
+        ],
+    )
+
+    with pytest.raises(profile_dispatch.ConfigError, match="unsupported applicability"):
+        profile_dispatch.dispatch("acme/lib", repo_evidence(), config)

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 SCRIPT = "lib/pulse/scripts/validate_result.py"
 FIXTURES = Path("lib/pulse/scripts/tests/fixtures")
@@ -51,3 +52,53 @@ def test_unparseable_yaml_exit_2(tmp_path):
     bad.write_text("kind: [unclosed")
     r = run_validator(bad, "status")
     assert r.returncode == 2
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["pass", "warn", "fail", "unknown", "not_applicable", "unsupported", "error"],
+)
+def test_healthcheck_accepts_exact_profile_states(tmp_path, status):
+    doc = yaml.safe_load((FIXTURES / "healthcheck-valid.yaml").read_text())
+    doc["repos"][0]["checks"]["branch_protection"]["status"] = status
+    path = tmp_path / "healthcheck.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "healthcheck")
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_healthcheck_rejects_legacy_dismissed_state(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "healthcheck-valid.yaml").read_text())
+    doc["repos"][0]["checks"]["branch_protection"]["status"] = "dismissed"
+    path = tmp_path / "healthcheck.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "healthcheck")
+
+    assert result.returncode == 1
+    assert "status invalid: dismissed" in result.stderr
+
+
+def test_healthcheck_requires_scorecard_coverage_and_check_identity(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "healthcheck-valid.yaml").read_text())
+    repo = doc["repos"][0]
+    repo.pop("scorecard", None)
+    repo.pop("coverage_supported", None)
+    repo.pop("coverage_total", None)
+    for check in repo["checks"].values():
+        check.pop("check_id", None)
+        check.pop("adapter", None)
+        check.pop("weight", None)
+    path = tmp_path / "healthcheck.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "healthcheck")
+
+    assert result.returncode == 1
+    assert "scorecard" in result.stderr
+    assert "coverage_supported" in result.stderr
+    assert "check_id" in result.stderr
+    assert "adapter" in result.stderr
+    assert "weight" in result.stderr

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -102,3 +102,25 @@ def test_healthcheck_requires_scorecard_coverage_and_check_identity(tmp_path):
     assert "check_id" in result.stderr
     assert "adapter" in result.stderr
     assert "weight" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("repos", 0, "coverage_total"), True),
+        (("repos", 0, "checks", "branch_protection", "weight"), -1),
+    ],
+)
+def test_healthcheck_rejects_invalid_numeric_metadata(tmp_path, path, value):
+    doc = yaml.safe_load((FIXTURES / "healthcheck-valid.yaml").read_text())
+    target = doc
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+    result_path = tmp_path / "healthcheck.yaml"
+    result_path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(result_path, "healthcheck")
+
+    assert result.returncode == 1
+    assert "non-negative number" in result.stderr

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -20,7 +20,9 @@ from pathlib import Path
 
 SUPPORTED_VERSIONS = {1}
 ACTOR_MODES = {"interactive", "scheduled"}
-CHECK_STATUSES = {"pass", "warn", "fail", "unknown", "dismissed"}
+CHECK_STATUSES = {
+    "pass", "warn", "fail", "unknown", "not_applicable", "unsupported", "error",
+}
 GRADES = {"A", "B", "C", "D", "F"}
 REFRESH_SECTION_STATUSES = {"refreshed", "skipped", "failed"}
 OUTCOMES = {"success", "failure", "skipped-cooldown", "aborted"}
@@ -70,7 +72,7 @@ def _require_actor(data, errors):
 
 def _validate_grade_block(block, errors, ctx):
     _require(block, "score", (int, float), errors, ctx=ctx)
-    _require(block, "total", int, errors, ctx=ctx)
+    _require(block, "total", (int, float), errors, ctx=ctx)
     _require_enum(block, "grade", GRADES, errors, ctx=ctx)
 
 
@@ -113,18 +115,28 @@ def validate(data, kind: str) -> list[str]:
                 continue
             ctx = f"repos[{i}]."
             _require(r, "repo", str, errors, ctx=ctx)
+            _require(r, "scorecard", str, errors, ctx=ctx)
             _require(r, "score", (int, float), errors, ctx=ctx)
-            _require(r, "total", int, errors, ctx=ctx)
+            _require(r, "total", (int, float), errors, ctx=ctx)
             _require_enum(r, "grade", GRADES, errors, ctx=ctx)
+            _require(r, "coverage_supported", (int, float), errors, ctx=ctx)
+            _require(r, "coverage_total", (int, float), errors, ctx=ctx)
             checks = _require(r, "checks", dict, errors, ctx=ctx)
             for cid, c in (checks or {}).items():
                 cctx = f"{ctx}checks.{cid}."
                 if not isinstance(c, dict):
                     _err(errors, f"{ctx}checks.{cid} is not a mapping")
                     continue
+                check_id = _require(c, "check_id", str, errors, ctx=cctx)
+                if check_id is not None and check_id != cid:
+                    _err(errors, f"{cctx}check_id mismatch: expected {cid}, got {check_id}")
+                _require(c, "adapter", str, errors, ctx=cctx)
+                _require(c, "weight", (int, float), errors, ctx=cctx)
                 _require_enum(c, "status", CHECK_STATUSES, errors, ctx=cctx)
                 _require(c, "detail", str, errors, ctx=cctx)
                 _require(c, "data", dict, errors, ctx=cctx)
+                if "profile" in c and not isinstance(c["profile"], str):
+                    _err(errors, f"wrong type for {cctx}profile: expected str")
                 if "inferred" in c and not isinstance(c["inferred"], bool):
                     _err(errors, f"wrong type for {cctx}inferred: expected bool")
         agg = _require(data, "aggregate", dict, errors)

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -61,6 +61,15 @@ def _require_enum(data, key, allowed, errors, ctx=""):
     return val
 
 
+def _require_nonnegative_number(data, key, errors, ctx=""):
+    label = f"{ctx}{key}"
+    value = _require(data, key, (int, float), errors, ctx=ctx)
+    if value is not None and (isinstance(value, bool) or value < 0):
+        _err(errors, f"{label} must be a non-negative number")
+        return None
+    return value
+
+
 def _require_actor(data, errors):
     actor = _require(data, "actor", dict, errors)
     if actor is None:
@@ -71,8 +80,8 @@ def _require_actor(data, errors):
 
 
 def _validate_grade_block(block, errors, ctx):
-    _require(block, "score", (int, float), errors, ctx=ctx)
-    _require(block, "total", (int, float), errors, ctx=ctx)
+    _require_nonnegative_number(block, "score", errors, ctx=ctx)
+    _require_nonnegative_number(block, "total", errors, ctx=ctx)
     _require_enum(block, "grade", GRADES, errors, ctx=ctx)
 
 
@@ -116,11 +125,11 @@ def validate(data, kind: str) -> list[str]:
             ctx = f"repos[{i}]."
             _require(r, "repo", str, errors, ctx=ctx)
             _require(r, "scorecard", str, errors, ctx=ctx)
-            _require(r, "score", (int, float), errors, ctx=ctx)
-            _require(r, "total", (int, float), errors, ctx=ctx)
+            _require_nonnegative_number(r, "score", errors, ctx=ctx)
+            _require_nonnegative_number(r, "total", errors, ctx=ctx)
             _require_enum(r, "grade", GRADES, errors, ctx=ctx)
-            _require(r, "coverage_supported", (int, float), errors, ctx=ctx)
-            _require(r, "coverage_total", (int, float), errors, ctx=ctx)
+            _require_nonnegative_number(r, "coverage_supported", errors, ctx=ctx)
+            _require_nonnegative_number(r, "coverage_total", errors, ctx=ctx)
             checks = _require(r, "checks", dict, errors, ctx=ctx)
             for cid, c in (checks or {}).items():
                 cctx = f"{ctx}checks.{cid}."
@@ -131,7 +140,7 @@ def validate(data, kind: str) -> list[str]:
                 if check_id is not None and check_id != cid:
                     _err(errors, f"{cctx}check_id mismatch: expected {cid}, got {check_id}")
                 _require(c, "adapter", str, errors, ctx=cctx)
-                _require(c, "weight", (int, float), errors, ctx=cctx)
+                _require_nonnegative_number(c, "weight", errors, ctx=cctx)
                 _require_enum(c, "status", CHECK_STATUSES, errors, ctx=cctx)
                 _require(c, "detail", str, errors, ctx=cctx)
                 _require(c, "data", dict, errors, ctx=cctx)

--- a/lib/references/config-schema.md
+++ b/lib/references/config-schema.md
@@ -553,6 +553,33 @@ cache:
 
 ---
 
+## Schema: profiles.yaml (repository intent and scorecards)
+
+**File:** `.hiivmind/github/profiles.yaml`
+
+**Purpose:** Authoritative repository profiles, scorecard selection, and adapter
+availability. This file is team-shared and committed.
+
+| Path | Type | Description |
+|------|------|-------------|
+| `.repository_profiles.{owner/repo}` | object | Reviewed intent for one repository |
+| `.repository_profiles.{owner/repo}.profiles[]` | string | Intent/capability labels such as `python`, `service`, or `claude-plugin` |
+| `.repository_profiles.{owner/repo}.scorecard` | string | Scorecard ID selected for the repository |
+| `.scorecards.{id}.extends` | string | Optional parent scorecard ID |
+| `.scorecards.{id}.checks[]` | array | Ordered check definitions |
+| `.scorecards.{id}.checks[].id` | string | Stable check identity |
+| `.scorecards.{id}.checks[].adapter` | string | Adapter ID from `.adapters` |
+| `.scorecards.{id}.checks[].weight` | number | Non-negative score and coverage weight |
+| `.scorecards.{id}.checks[].applicability` | string | Optional applicability predicate; default `always` |
+| `.scorecards.{id}.checks[].replace` | boolean | Required when replacing an inherited check ID |
+| `.adapters.{id}.state` | string | `available` or `unsupported` |
+| `.adapters.{id}.reason` | string | Required explanation when unsupported |
+
+The file requires all three root mappings: `repository_profiles`, `scorecards`,
+and `adapters`. It never stores detector proposals. See
+`lib/patterns/repository-profiles.md` for inheritance, applicability, scoring,
+and authority rules.
+
 ## Schema: relationships.yaml (Phase 5)
 
 Cross-repository relationships and project links. Single workspace-level file documenting all relationships.

--- a/lib/references/healthcheck-checks.md
+++ b/lib/references/healthcheck-checks.md
@@ -204,7 +204,11 @@ Each check defines:
 | D | 4-5 / 11 | Significant gaps |
 | F | 0-3 / 11 | Critical governance gaps |
 
-**Scoring:** `pass` = 1 point, `warn` = 0.5 points (rounded down for grade), `fail` = 0 points, `unknown` = excluded from total.
+**Scoring:** Each scorecard supplies the check weight. `pass` earns the full
+weight, `warn` half, and `fail` zero. `unknown`, `not_applicable`,
+`unsupported`, and `error` are excluded from the score denominator. Only
+`unsupported` reduces adapter coverage. Use `evaluate_checks.py::score_checks`
+for arithmetic; do not reimplement scoring in a skill.
 
 ---
 

--- a/skills/gh-healthcheck-headless/SKILL.md
+++ b/skills/gh-healthcheck-headless/SKILL.md
@@ -118,7 +118,9 @@ uv run "${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/evaluate_checks.py" \
 
 1. Aggregate: `score` = sum of repo scores, `total` = sum of repo totals, `grade` from
    score/total fraction — A ≥ 0.90, B ≥ 0.72, C ≥ 0.54, D ≥ 0.36, F below (same table
-   evaluate_checks.py uses; total 0 → F).
+   evaluate_checks.py uses; total 0 → F). This top-level aggregate is a legacy
+   compatibility field. When results contain more than one scorecard ID, do not present
+   its grade as a comparable fleet grade; report per-repository scorecards instead.
 2. Write RESULT_PATH:
 
 ```yaml

--- a/skills/gh-healthcheck-headless/SKILL.md
+++ b/skills/gh-healthcheck-headless/SKILL.md
@@ -127,7 +127,8 @@ kind: healthcheck
 workspace: {LOGIN}
 run_at: "{RUN_AT}"    # quote: an unquoted ISO-8601 value parses as a YAML datetime; the contract requires a string
 actor: { gh_login: {GH_LOGIN}, machine: {MACHINE}, mode: {MODE} }
-repos: {REPO_RESULTS}          # each: {repo, score, total, grade, checks}
+repos: {REPO_RESULTS}          # each includes repo, scorecard, score, total, grade,
+                               # coverage_supported, coverage_total, checks
 aggregate: { score: {sum}, total: {sum}, grade: {computed} }
 errors: {ERRORS}
 ```
@@ -148,9 +149,10 @@ uv run "${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py" "$RESULT_PAT
 2. Set `last_run`: `timestamp: RUN_AT`, `scope:` comma-joined short names (or `fleet`
    when the whole catalog ran), `aggregate_score / aggregate_total / aggregate_grade`.
 3. For each repo result, write `repos.{short-name}` (short name = part after `/`):
-   `score`, `total`, `grade`, and each check with `status`, `detail`, `data`, plus
-   `last_evaluated: RUN_AT` (the governance record keeps timestamps; the result file
-   does not need them).
+   `scorecard`, `score`, `total`, `grade`, `coverage_supported`, `coverage_total`, and
+   each check with `check_id`, `profile`, `adapter`, `weight`, `status`, `detail`, and
+   `data`, plus `last_evaluated: RUN_AT` (the governance record keeps timestamps; the
+   result file does not need them).
 4. **Preserve `dismissals:` untouched** — merge, never overwrite. Repos not evaluated
    this run keep their existing blocks.
 5. Do NOT commit or push — the orchestrator (P5) owns the commit/PR step.

--- a/skills/gh-healthcheck/SKILL.md
+++ b/skills/gh-healthcheck/SKILL.md
@@ -249,14 +249,15 @@ Show aggregate first, then per-repo breakdown:
 | repo-a | python-library-v1 | B | 9/11 | 11/11 | codeowners, security_policy |
 | repo-b | node-web-v1 | C | 7/10 | 8/10 | ci_cd, releases, documentation |
 
-Aggregate: B (16/22)
+Fleet grade: not reported — multiple scorecards are present
 
 ---
 
 [Per-repo details follow]
 ```
 
-Grades are comparable only within the same scorecard revision. Compare coverage separately from
+Grades are comparable only within the same scorecard revision. Group any aggregate display by
+scorecard; never sum different scorecards into a fleet grade. Compare coverage separately from
 score so unsupported tooling is visible rather than silently lowering or inflating maturity.
 
 ---

--- a/skills/gh-healthcheck/SKILL.md
+++ b/skills/gh-healthcheck/SKILL.md
@@ -166,7 +166,11 @@ Execute checks in catalog order. For each check:
 FOR check IN healthcheck_catalog:
   # 1. Check dismissal
   IF is_dismissed(repo, check.id) AND NOT dismissal_expired(repo, check.id):
-    results[check.id] = {status: "dismissed", detail: "Dismissed: {reason}"}
+    results[check.id] = {
+      status: "not_applicable",
+      detail: "Dismissed: {reason}",
+      data: {dismissed: true, reason: reason}
+    }
     CONTINUE
 
   # 2. Evaluate
@@ -177,7 +181,7 @@ FOR check IN healthcheck_catalog:
 
   # 3. Record
   results[check.id] = {
-    status: result.status,      # pass | warn | fail | unknown
+    status: result.status,      # pass | warn | fail | unknown | not_applicable | unsupported | error
     detail: result.detail,
     last_evaluated: now(),
     data: result.raw_data       # optional structured data for future reference
@@ -219,7 +223,9 @@ Grade: {grade} ({score}/{total})
 | Dependency Mgmt | ✅ pass | Renovate configured |
 | Secrets Scanning | ✅ pass | Scanning: enabled, Push protection: enabled |
 
-{dismissed_count} check(s) dismissed — not counted in score.
+Scorecard: {scorecard_id}
+Coverage: {coverage_supported}/{coverage_total} supported
+{dismissed_count} check(s) dismissed — reported as not_applicable and not counted in score.
 ```
 
 **Status icons:**
@@ -227,7 +233,9 @@ Grade: {grade} ({score}/{total})
 - `warn` → ⚠️
 - `fail` → ❌
 - `unknown` → ❓
-- `dismissed` → ⏭️
+- `not_applicable` → ⏭️
+- `unsupported` → 🚫
+- `error` → 💥
 
 ### Multi-Repo Report
 
@@ -236,10 +244,10 @@ Show aggregate first, then per-repo breakdown:
 ```
 ## Healthcheck Summary
 
-| Repository | Grade | Score | Failing |
-|------------|-------|-------|---------|
-| repo-a | B | 9/11 | codeowners, security_policy |
-| repo-b | C | 7/11 | ci_cd, releases, codeowners, documentation |
+| Repository | Scorecard | Grade | Score | Coverage | Failing |
+|------------|-----------|-------|-------|----------|---------|
+| repo-a | python-library-v1 | B | 9/11 | 11/11 | codeowners, security_policy |
+| repo-b | node-web-v1 | C | 7/10 | 8/10 | ci_cd, releases, documentation |
 
 Aggregate: B (16/22)
 
@@ -247,6 +255,9 @@ Aggregate: B (16/22)
 
 [Per-repo details follow]
 ```
+
+Grades are comparable only within the same scorecard revision. Compare coverage separately from
+score so unsupported tooling is visible rather than silently lowering or inflating maturity.
 
 ---
 

--- a/templates/healthcheck.yaml.template
+++ b/templates/healthcheck.yaml.template
@@ -18,11 +18,18 @@ repos:
   #
   # Example:
   # hiivmind-pulse-gh:
+  #   scorecard: python-library-v1
   #   score: 8
   #   total: 11
   #   grade: B
+  #   coverage_supported: 11
+  #   coverage_total: 11
   #   checks:
   #     branch_protection:
+  #       check_id: branch_protection
+  #       profile: python-library
+  #       adapter: github-branch-protection
+  #       weight: 1
   #       status: pass
   #       last_evaluated: "2026-02-21T14:30:00Z"
   #       detail: "main: 1 required review"

--- a/templates/profiles.yaml.template
+++ b/templates/profiles.yaml.template
@@ -1,0 +1,22 @@
+# Authoritative repository intent and scorecard selection.
+# Detectors propose changes; only reviewed workspace commits edit this file.
+
+repository_profiles: {}
+
+scorecards:
+  generic-v1:
+    checks:
+      - id: documentation
+        adapter: generic.docs
+        applicability: always
+        weight: 1
+      - id: ci
+        adapter: github.actions
+        applicability: capability:ci
+        weight: 1
+
+adapters:
+  generic.docs:
+    state: available
+  github.actions:
+    state: available


### PR DESCRIPTION
## What changed

- add strict authoritative repository profile, scorecard, and adapter metadata
- resolve scorecard inheritance with explicit replacement and deterministic applicability dispatch
- introduce exact healthcheck states, weighted score calculation, and adapter coverage debt
- preserve scorecard/check identity in result and governance contracts
- add a heterogeneous fleet acceptance matrix covering Python library/service, Node web, docs, Terraform, Claude plugin, and unclassified repositories

## Why

Fleet healthchecks previously encoded one implicit repository shape and could blur generic governance, language-specific checks, and plugin dogfooding. F1 makes repository intent explicit and keeps plugin-specific behavior opt-in while giving later phases a stable dispatch and scoring core.

## Impact

- grades are identified by scorecard and must not be compared across different scorecards
- `not_applicable` and `unsupported` no longer distort score denominators
- unsupported adapters remain visible as coverage debt
- durable dismissals emit as `not_applicable` with dismissal metadata
- malformed or negative scorecard result metadata is rejected

## Validation

- `uv run pytest -q` — 75 passed
- `git diff --check develop...HEAD`

## Dependency

This PR targets `develop` and builds on the F0 Nave evidence boundary already proposed separately.
