### PR TITLE
F2: reconcile fleet membership and propose profiles

### DIFF
--- a/lib/patterns/headless-contract.md
+++ b/lib/patterns/headless-contract.md
@@ -10,6 +10,7 @@ retained for human-readable logs only — orchestrators MUST read the file.
 |------|------|--------------|
 | status | status-result.yaml | `{workspace_root}/.hiivmind/github/status-result.yaml` |
 | healthcheck | healthcheck-result.yaml | `{workspace_root}/.hiivmind/github/healthcheck-result.yaml` |
+| fleet-membership | fleet-membership-result.yaml | `{workspace_root}/.hiivmind/github/fleet-membership-result.yaml` |
 | refresh | refresh-result.yaml | `{workspace_root}/.hiivmind/github/refresh-result.yaml` |
 | workflow-run | workflow-run-result.yaml | `{workspace_root}/.hiivmind/github/workflow-run-result.yaml` |
 
@@ -31,7 +32,7 @@ not kinds they were not asked to validate.
 
 ```yaml
 contract_version: 1                   # int, required
-kind: status | healthcheck | refresh | workflow-run
+kind: status | healthcheck | fleet-membership | refresh | workflow-run
 workspace: <login>                    # str, required — org/user login
 run_at: <ISO 8601 timestamp>          # str, required
 actor:                                # required on ALL kinds (I4)
@@ -49,6 +50,7 @@ profiles, and machines: identity-sensitive logic resolves against the
 
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py status-result.yaml --kind status
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py healthcheck-result.yaml --kind healthcheck
+    uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py fleet-membership-result.yaml --kind fleet-membership
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py refresh-result.yaml --kind refresh
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py workflow-run-result.yaml --kind workflow-run
 
@@ -125,6 +127,42 @@ with `data.dismissed: true`; the durable dismissal decision remains in
 Grades must always be presented with `scorecard`. A grade from one scorecard is
 not directly compared with a grade from another scorecard because the checks,
 weights, and applicability rules differ.
+
+### fleet-membership-result.yaml (written by gh-fleet-membership-headless, F2)
+
+```yaml
+contract_version: 1
+kind: fleet-membership
+workspace: <login>
+run_at: <ISO 8601>
+actor: { gh_login: <str>, machine: <str>, mode: <enum> }
+org_repos: [<owner/name>, ...]        # live repositories included by discovery policy
+catalog_repos: [<owner/name>, ...]    # repositories present after any catalog patch
+catalog_updated: <bool>               # true only when apply_catalog changed config.yaml
+profile_proposals:                    # non-authoritative, evidence-backed suggestions
+  - repo: <owner/name>
+    candidates:
+      - profile: <profile id>
+        confidence: <0..1>
+        evidence: [<observed fact>, ...]
+        rule_ids: [<proposal rule id>, ...]
+    evidence: {}                      # normalized evidence summary used for proposal
+    explanation: <str>                # optional inferred prose; cannot alter candidates
+    inferred: true                    # required when explanation is inferred
+findings:
+  - kind: <str>
+    repo: <owner/name>
+    severity: low | medium | high
+    detail: <str>
+proposed_actions: []                  # catalog/profile changes requiring a PR or confirmation
+asks_recorded: []                     # profile confirmations deferred by headless execution
+errors: []
+```
+
+Catalog registration and profile confirmation are separate operations. A
+membership result may record both, but `catalog_updated: true` means only stable
+repository facts were written to `config.yaml`; it never means profiles or
+profile-dependent onboarding actions were applied.
 
 ### refresh-result.yaml (written by gh-refresh-headless, P3.3)
 

--- a/lib/patterns/repository-profiles.md
+++ b/lib/patterns/repository-profiles.md
@@ -75,6 +75,26 @@ annotate a completed proposal, but cannot add, remove, or reorder candidates.
 An evidence set that matches no rule produces an empty candidate list rather
 than a guessed fallback profile.
 
+### Confirmation boundary
+
+Confirmation is an explicit compare-and-swap patch of workspace metadata:
+
+```bash
+uv run "${PLUGIN_ROOT}/lib/pulse/scripts/profile_proposals.py" confirm \
+  --profiles .hiivmind/github/profiles.yaml \
+  --repo acme/widget \
+  --expected-scorecard generic-v1 \
+  --profiles-list python,library \
+  --scorecard python-library-v1
+```
+
+Use `--expected-scorecard absent` when the repository has no authoritative
+entry. A mismatched expected scorecard is a conflict and leaves the file
+unchanged. Repeating an already-applied target is idempotent even when the
+original expected base is now stale. The script atomically patches only
+`repository_profiles`; it never commits, pushes, opens a PR, or runs onboarding
+actions. The caller owns the workspace metadata PR.
+
 ## Check identity and inheritance
 
 A check ID occurs once in a resolved scorecard. A child that intentionally

--- a/lib/patterns/repository-profiles.md
+++ b/lib/patterns/repository-profiles.md
@@ -73,7 +73,9 @@ Matching rules create ordered candidates with observed evidence and rule IDs.
 They never edit `repository_profiles`. Optional inferred explanation may
 annotate a completed proposal, but cannot add, remove, or reorder candidates.
 An evidence set that matches no rule produces an empty candidate list rather
-than a guessed fallback profile.
+than a guessed fallback profile. A repository with authoritative profiles is
+omitted when every detected candidate is already assigned; only additive or
+conflicting evidence returns it for renewed review.
 
 ### Confirmation boundary
 

--- a/lib/patterns/repository-profiles.md
+++ b/lib/patterns/repository-profiles.md
@@ -10,6 +10,8 @@ written by a detector. The authoritative file is
   repository.
 - `scorecards` selects checks, adapters, weights, and applicability.
 - `adapters` records whether an adapter implementation is available.
+- `proposal_rules` optionally records deterministic evidence-to-profile
+  suggestions. It is detection policy, never authoritative assignment.
 - Detection may emit profile proposals and `asks_recorded`, but those outputs
   never modify this file. A profile or scorecard changes only through a merged
   workspace-metadata change.
@@ -45,12 +47,33 @@ adapters:
   terraform.dependencies:
     state: unsupported
     reason: dependency adapter not implemented
+
+proposal_rules:
+  python-pyproject:
+    profile: python
+    confidence: 0.95
+    priority: 10
+    any_paths: [pyproject.toml]
 ```
 
-All three root mappings are required. Unknown keys, scorecards, and adapters
-are configuration errors. Adapter state is `available | unsupported`; an
+The first three root mappings are required; `proposal_rules` is optional.
+Unknown keys, scorecards, adapters, and proposal-rule fields are configuration
+errors. Adapter state is `available | unsupported`; an
 unsupported adapter requires a reason and produces coverage debt rather than a
 repository failure.
+
+## Profile proposals
+
+A proposal rule declares `profile`, rule-defined `confidence`, optional
+non-negative `priority` (default 100), and at least one selector:
+`any_paths`, `all_paths`, `capabilities`, or `structural_signals`. Path
+selectors use shell-style glob matching against normalized F0 evidence.
+
+Matching rules create ordered candidates with observed evidence and rule IDs.
+They never edit `repository_profiles`. Optional inferred explanation may
+annotate a completed proposal, but cannot add, remove, or reorder candidates.
+An evidence set that matches no rule produces an empty candidate list rather
+than a guessed fallback profile.
 
 ## Check identity and inheritance
 

--- a/lib/pulse/scripts/fleet_membership.py
+++ b/lib/pulse/scripts/fleet_membership.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -228,13 +230,49 @@ def _load(path: Path) -> Any:
         raise MembershipError(f"could not load {path}: {exc}") from exc
 
 
+def _apply_catalog(path: Path, config: dict[str, Any], repositories: list[dict]) -> bool:
+    if config.get("repositories", []) == repositories:
+        return False
+    updated = dict(config)
+    updated["repositories"] = repositories
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_name = handle.name
+            yaml.safe_dump(updated, handle, sort_keys=False, allow_unicode=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    except OSError as exc:
+        if temporary_name:
+            try:
+                Path(temporary_name).unlink()
+            except OSError:
+                pass
+        raise MembershipError(f"could not apply catalog patch: {exc}") from exc
+    return True
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--org-repos", required=True, type=Path)
     parser.add_argument("--config", required=True, type=Path)
+    parser.add_argument("--apply-catalog", action="store_true")
     args = parser.parse_args()
     try:
-        result = reconcile_membership(_load(args.org_repos), _load(args.config))
+        config = _load(args.config)
+        result = reconcile_membership(_load(args.org_repos), config)
+        result["catalog_updated"] = (
+            _apply_catalog(args.config, config, result["catalog_patch"])
+            if args.apply_catalog
+            else False
+        )
     except MembershipError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/lib/pulse/scripts/fleet_membership.py
+++ b/lib/pulse/scripts/fleet_membership.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Diff a live GitHub repository set against the workspace catalog."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+STABLE_FIELDS = (
+    "name",
+    "id",
+    "full_name",
+    "default_branch",
+    "is_public",
+    "archived",
+    "fork",
+    "mirror_url",
+)
+DEFAULT_DISCOVERY = {
+    "include_archived": True,
+    "include_forks": False,
+    "include_mirrors": False,
+}
+
+
+class MembershipError(ValueError):
+    """Raised when membership inputs cannot be reconciled safely."""
+
+
+def _repo_id(repo: dict[str, Any]) -> str | None:
+    value = repo.get("node_id") or repo.get("id")
+    return value if isinstance(value, str) and value else None
+
+
+def _full_name(repo: dict[str, Any]) -> str:
+    value = repo.get("full_name")
+    if not isinstance(value, str) or "/" not in value:
+        raise MembershipError("repository full_name must be owner/name")
+    return value
+
+
+def _stable_facts(repo: dict[str, Any]) -> dict[str, Any]:
+    full_name = _full_name(repo)
+    node_id = _repo_id(repo)
+    if node_id is None:
+        raise MembershipError(f"live repository has no node ID: {full_name}")
+    visibility = repo.get("visibility")
+    if visibility is not None:
+        is_public = visibility == "public"
+    else:
+        is_public = not bool(repo.get("private", False))
+    return {
+        "name": full_name.split("/", 1)[1],
+        "id": node_id,
+        "full_name": full_name,
+        "default_branch": repo.get("default_branch") or "main",
+        "is_public": is_public,
+        "archived": bool(repo.get("archived", False)),
+        "fork": bool(repo.get("fork", False)),
+        "mirror_url": repo.get("mirror_url"),
+    }
+
+
+def _finding(kind: str, repo: str, detail: str, **extra: Any) -> dict[str, Any]:
+    finding = {
+        "kind": kind,
+        "repo": repo,
+        "severity": "medium",
+        "detail": detail,
+    }
+    finding.update(extra)
+    return finding
+
+
+def _discovery_policy(config: dict[str, Any]) -> dict[str, bool]:
+    raw = ((config.get("fleet_membership") or {}).get("discovery") or {})
+    if not isinstance(raw, dict):
+        raise MembershipError("fleet_membership.discovery must be a mapping")
+    unknown = set(raw) - set(DEFAULT_DISCOVERY)
+    if unknown:
+        raise MembershipError(f"unknown discovery policy: {sorted(unknown)[0]}")
+    policy = dict(DEFAULT_DISCOVERY)
+    for key, value in raw.items():
+        if not isinstance(value, bool):
+            raise MembershipError(f"discovery policy {key} must be boolean")
+        policy[key] = value
+    return policy
+
+
+def _excluded_reason(repo: dict[str, Any], policy: dict[str, bool]) -> str | None:
+    if repo.get("fork") and not policy["include_forks"]:
+        return "fork excluded by discovery policy"
+    if repo.get("mirror_url") and not policy["include_mirrors"]:
+        return "mirror excluded by discovery policy"
+    if repo.get("archived") and not policy["include_archived"]:
+        return "archived repository excluded by discovery policy"
+    return None
+
+
+def _unique_index(
+    repositories: list[dict[str, Any]],
+    key_fn,
+    label: str,
+) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for repo in repositories:
+        value = key_fn(repo)
+        if value is None:
+            continue
+        if value in index:
+            raise MembershipError(f"duplicate {label}: {value}")
+        index[value] = repo
+    return index
+
+
+def reconcile_membership(
+    org_repos: list[dict[str, Any]],
+    config: dict[str, Any],
+) -> dict[str, Any]:
+    """Return a deterministic desired catalog and identity-aware findings."""
+    if not isinstance(org_repos, list) or not all(isinstance(r, dict) for r in org_repos):
+        raise MembershipError("org repositories must be a list of mappings")
+    catalog = config.get("repositories", [])
+    if not isinstance(catalog, list) or not all(isinstance(r, dict) for r in catalog):
+        raise MembershipError("config repositories must be a list of mappings")
+
+    policy = _discovery_policy(config)
+    catalog_by_id = _unique_index(catalog, _repo_id, "catalog node ID")
+    catalog_by_name = _unique_index(catalog, _full_name, "catalog full_name")
+    _unique_index(org_repos, _repo_id, "live node ID")
+
+    findings: list[dict[str, Any]] = []
+    desired: list[dict[str, Any]] = []
+    matched_catalog: set[int] = set()
+    included_names: list[str] = []
+
+    for live in sorted(org_repos, key=_full_name):
+        full_name = _full_name(live)
+        node_id = _repo_id(live)
+        reason = _excluded_reason(live, policy)
+        existing = catalog_by_id.get(node_id) if node_id else None
+        if existing is None:
+            existing = catalog_by_name.get(full_name)
+        if reason is not None:
+            if existing is not None:
+                matched_catalog.add(id(existing))
+            findings.append(_finding("repository-excluded", full_name, reason))
+            continue
+
+        facts = _stable_facts(live)
+        included_names.append(full_name)
+        desired.append(facts)
+        existing_by_id = catalog_by_id.get(facts["id"])
+        existing_by_name = catalog_by_name.get(full_name)
+
+        if existing_by_id is not None:
+            matched_catalog.add(id(existing_by_id))
+            old_name = _full_name(existing_by_id)
+            if old_name != full_name:
+                old_owner = old_name.split("/", 1)[0]
+                new_owner = full_name.split("/", 1)[0]
+                kind = "repository-renamed" if old_owner == new_owner else "repository-transferred"
+                findings.append(_finding(
+                    kind,
+                    full_name,
+                    f"repository identity moved from {old_name} to {full_name}",
+                    before=old_name,
+                    after=full_name,
+                ))
+            if not bool(existing_by_id.get("archived", False)) and facts["archived"]:
+                findings.append(_finding(
+                    "repository-archived",
+                    full_name,
+                    "repository is now archived",
+                ))
+            continue
+
+        if existing_by_name is not None and _repo_id(existing_by_name) is None:
+            matched_catalog.add(id(existing_by_name))
+            findings.append(_finding(
+                "repository-identity-backfilled",
+                full_name,
+                f"catalog entry gained GitHub node ID {facts['id']}",
+            ))
+            continue
+
+        findings.append(_finding(
+            "repository-created",
+            full_name,
+            "repository is present in GitHub but absent from the catalog",
+        ))
+
+    for existing in sorted(catalog, key=_full_name):
+        if id(existing) in matched_catalog:
+            continue
+        full_name = _full_name(existing)
+        findings.append(_finding(
+            "repository-missing",
+            full_name,
+            "catalog repository is absent from the live organization set",
+        ))
+
+    desired.sort(key=lambda repo: repo["full_name"])
+    return {
+        "findings": findings,
+        "catalog_patch": desired,
+        "org_repos": sorted(included_names),
+        "catalog_repos": [repo["full_name"] for repo in desired],
+    }
+
+
+def _load(path: Path) -> Any:
+    try:
+        return yaml.safe_load(path.read_text())
+    except FileNotFoundError as exc:
+        raise MembershipError(f"input not found: {path}") from exc
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise MembershipError(f"could not load {path}: {exc}") from exc
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--org-repos", required=True, type=Path)
+    parser.add_argument("--config", required=True, type=Path)
+    args = parser.parse_args()
+    try:
+        result = reconcile_membership(_load(args.org_repos), _load(args.config))
+    except MembershipError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/pulse/scripts/fleet_membership.py
+++ b/lib/pulse/scripts/fleet_membership.py
@@ -56,19 +56,29 @@ def _stable_facts(repo: dict[str, Any]) -> dict[str, Any]:
     node_id = _repo_id(repo)
     if node_id is None:
         raise MembershipError(f"live repository has no node ID: {full_name}")
+    default_branch = repo.get("default_branch")
+    if not isinstance(default_branch, str) or not default_branch:
+        raise MembershipError(f"live repository missing stable fact default_branch: {full_name}")
     visibility = repo.get("visibility")
-    if visibility is not None:
+    if isinstance(visibility, str):
         is_public = visibility == "public"
+    elif isinstance(repo.get("private"), bool):
+        is_public = not repo["private"]
     else:
-        is_public = not bool(repo.get("private", False))
+        raise MembershipError(f"live repository missing stable fact visibility: {full_name}")
+    for key in ("archived", "fork"):
+        if not isinstance(repo.get(key), bool):
+            raise MembershipError(f"live repository missing stable fact {key}: {full_name}")
+    if "mirror_url" not in repo or not isinstance(repo["mirror_url"], (str, type(None))):
+        raise MembershipError(f"live repository missing stable fact mirror_url: {full_name}")
     return {
         "name": full_name.split("/", 1)[1],
         "id": node_id,
         "full_name": full_name,
-        "default_branch": repo.get("default_branch") or "main",
+        "default_branch": default_branch,
         "is_public": is_public,
-        "archived": bool(repo.get("archived", False)),
-        "fork": bool(repo.get("fork", False)),
+        "archived": repo["archived"],
+        "fork": repo["fork"],
         "mirror_url": repo.get("mirror_url"),
     }
 

--- a/lib/pulse/scripts/fleet_membership.py
+++ b/lib/pulse/scripts/fleet_membership.py
@@ -125,6 +125,26 @@ def _unique_index(
     return index
 
 
+def _normalized_catalog(
+    catalog: list[dict[str, Any]],
+    config: dict[str, Any],
+) -> list[dict[str, Any]]:
+    workspace = config.get("workspace") or {}
+    owner = workspace.get("login") if isinstance(workspace, dict) else None
+    normalized = []
+    for repository in catalog:
+        item = dict(repository)
+        if not item.get("full_name"):
+            name = item.get("name")
+            if not isinstance(owner, str) or not owner or not isinstance(name, str) or not name:
+                raise MembershipError(
+                    "legacy catalog entry requires workspace.login and repository name"
+                )
+            item["full_name"] = f"{owner}/{name}"
+        normalized.append(item)
+    return normalized
+
+
 def reconcile_membership(
     org_repos: list[dict[str, Any]],
     config: dict[str, Any],
@@ -132,9 +152,10 @@ def reconcile_membership(
     """Return a deterministic desired catalog and identity-aware findings."""
     if not isinstance(org_repos, list) or not all(isinstance(r, dict) for r in org_repos):
         raise MembershipError("org repositories must be a list of mappings")
-    catalog = config.get("repositories", [])
-    if not isinstance(catalog, list) or not all(isinstance(r, dict) for r in catalog):
+    raw_catalog = config.get("repositories", [])
+    if not isinstance(raw_catalog, list) or not all(isinstance(r, dict) for r in raw_catalog):
         raise MembershipError("config repositories must be a list of mappings")
+    catalog = _normalized_catalog(raw_catalog, config)
 
     policy = _discovery_policy(config)
     catalog_by_id = _unique_index(catalog, _repo_id, "catalog node ID")
@@ -217,7 +238,7 @@ def reconcile_membership(
         "findings": findings,
         "catalog_patch": desired,
         "org_repos": sorted(included_names),
-        "catalog_repos": [repo["full_name"] for repo in desired],
+        "catalog_repos": sorted(_full_name(repo) for repo in catalog),
     }
 
 
@@ -273,6 +294,10 @@ def main() -> int:
             if args.apply_catalog
             else False
         )
+        if args.apply_catalog:
+            result["catalog_repos"] = [
+                repository["full_name"] for repository in result["catalog_patch"]
+            ]
     except MembershipError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/lib/pulse/scripts/poll.py
+++ b/lib/pulse/scripts/poll.py
@@ -46,7 +46,7 @@ def now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def gh_api(path: str, graphql_query: str | None = None):
+def gh_api(path: str, graphql_query: str | None = None, paginate: bool = False):
     """Single network seam. Returns parsed JSON or None on any failure."""
     fixtures = os.environ.get("PULSE_GH_FIXTURES")
     if fixtures:
@@ -57,6 +57,8 @@ def gh_api(path: str, graphql_query: str | None = None):
         return json.loads(f.read_text())
     if graphql_query:
         cmd = ["gh", "api", "graphql", "-f", f"query={graphql_query}"]
+    elif paginate:
+        cmd = ["gh", "api", "--paginate", "--slurp", path]
     else:
         cmd = ["gh", "api", path]
     try:
@@ -160,6 +162,42 @@ def check_deployments(repo: str, state: dict) -> bool:
     return False
 
 
+def check_org_repos(config: dict, state: dict) -> bool:
+    """Store only a rename-stable signature; first observation is a baseline."""
+    workspace = config.get("workspace") or {}
+    if workspace.get("type") != "organization":
+        return False
+    login = workspace.get("login")
+    if not isinstance(login, str) or not login:
+        return False
+    path = f"/orgs/{login}/repos?per_page=100&type=all&sort=full_name&direction=asc"
+    response = gh_api(path, paginate=True)
+    if not isinstance(response, list):
+        return False
+    pages = response if response and all(isinstance(page, list) for page in response) else [response]
+    repos = [repo for page in pages for repo in page if isinstance(repo, dict)]
+    signature_rows = []
+    for repo in repos:
+        signature_rows.append({
+            "id": repo.get("node_id") or repo.get("id"),
+            "full_name": repo.get("full_name"),
+            "default_branch": repo.get("default_branch"),
+            "visibility": repo.get("visibility"),
+            "private": repo.get("private"),
+            "archived": bool(repo.get("archived", False)),
+            "fork": bool(repo.get("fork", False)),
+            "mirror_url": repo.get("mirror_url"),
+        })
+    signature_rows.sort(key=lambda row: (str(row["id"] or ""), str(row["full_name"] or "")))
+    signature = hashlib.sha256(
+        json.dumps(signature_rows, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()
+    slot = state.setdefault("org_repos", {})
+    previous = slot.get("signature")
+    slot["signature"] = signature
+    return isinstance(previous, str) and previous != signature
+
+
 REPO_CHECKS = {
     "pull_requests": check_pull_requests,
     "issues": check_issues,
@@ -183,6 +221,8 @@ def evaluate_source(source: str, repo: str, config: dict, config_dir: Path,
             changed = REPO_CHECKS[source](repo, state)
     elif source == "projects":
         changed = check_projects(config, config_dir, state, gold)
+    elif source == "org_repos":
+        changed = check_org_repos(config, state)
     cache[source] = changed
     return changed
 

--- a/lib/pulse/scripts/profile_dispatch.py
+++ b/lib/pulse/scripts/profile_dispatch.py
@@ -52,10 +52,23 @@ class AdapterDefinition:
 
 
 @dataclass(frozen=True)
+class ProposalRule:
+    id: str
+    profile: str
+    confidence: float
+    priority: int
+    any_paths: tuple[str, ...] = ()
+    all_paths: tuple[str, ...] = ()
+    capabilities: tuple[str, ...] = ()
+    structural_signals: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class ProfileConfig:
     repositories: dict[str, RepositoryProfile]
     scorecards: dict[str, Scorecard]
     adapters: dict[str, AdapterDefinition]
+    proposal_rules: dict[str, ProposalRule]
 
 
 @dataclass(frozen=True)
@@ -191,6 +204,59 @@ def _load_repositories(raw: dict[str, Any]) -> dict[str, RepositoryProfile]:
     return repositories
 
 
+def _optional_strings(item: dict[str, Any], key: str, label: str) -> tuple[str, ...]:
+    values = item.get(key, [])
+    return tuple(
+        _string(value, f"{label}.{key}")
+        for value in _list(values, f"{label}.{key}")
+    )
+
+
+def _load_proposal_rules(raw: dict[str, Any]) -> dict[str, ProposalRule]:
+    rules: dict[str, ProposalRule] = {}
+    selector_keys = {"any_paths", "all_paths", "capabilities", "structural_signals"}
+    for rule_id, value in raw.items():
+        rule_id = _string(rule_id, "proposal rule id")
+        item = _mapping(value, f"proposal rule {rule_id}")
+        _only_keys(
+            item,
+            {"profile", "confidence", "priority", *selector_keys},
+            "proposal rule",
+        )
+        profile = _string(item.get("profile"), f"proposal rule {rule_id}.profile")
+        confidence = item.get("confidence")
+        if (
+            isinstance(confidence, bool)
+            or not isinstance(confidence, (int, float))
+            or not 0 <= confidence <= 1
+        ):
+            raise ConfigError(
+                f"proposal rule {rule_id}.confidence must be between 0 and 1"
+            )
+        priority = item.get("priority", 100)
+        if isinstance(priority, bool) or not isinstance(priority, int) or priority < 0:
+            raise ConfigError(
+                f"proposal rule {rule_id}.priority must be a non-negative integer"
+            )
+        selectors = {
+            key: _optional_strings(item, key, f"proposal rule {rule_id}")
+            for key in selector_keys
+        }
+        if not any(selectors.values()):
+            raise ConfigError(f"proposal rule {rule_id} requires an evidence selector")
+        rules[rule_id] = ProposalRule(
+            rule_id,
+            profile,
+            float(confidence),
+            priority,
+            selectors["any_paths"],
+            selectors["all_paths"],
+            selectors["capabilities"],
+            selectors["structural_signals"],
+        )
+    return rules
+
+
 def load_profiles(path: str | Path) -> ProfileConfig:
     """Load and cross-validate committed profile metadata."""
     source = Path(path)
@@ -202,7 +268,7 @@ def load_profiles(path: str | Path) -> ProfileConfig:
         raise ConfigError(f"could not load profile config: {exc}") from exc
     root = _mapping(data, "profile config")
     required = {"repository_profiles", "scorecards", "adapters"}
-    _only_keys(root, required, "profile config")
+    _only_keys(root, required | {"proposal_rules"}, "profile config")
     missing = required - set(root)
     if missing:
         raise ConfigError(f"missing profile config key: {sorted(missing)[0]}")
@@ -211,6 +277,9 @@ def load_profiles(path: str | Path) -> ProfileConfig:
     scorecards = _load_scorecards(_mapping(root["scorecards"], "scorecards"))
     repositories = _load_repositories(
         _mapping(root["repository_profiles"], "repository_profiles")
+    )
+    proposal_rules = _load_proposal_rules(
+        _mapping(root.get("proposal_rules", {}), "proposal_rules")
     )
 
     for scorecard in scorecards.values():
@@ -222,7 +291,7 @@ def load_profiles(path: str | Path) -> ProfileConfig:
     for repository in repositories.values():
         if repository.scorecard not in scorecards:
             raise ConfigError(f"unknown scorecard: {repository.scorecard}")
-    return ProfileConfig(repositories, scorecards, adapters)
+    return ProfileConfig(repositories, scorecards, adapters, proposal_rules)
 
 
 def resolve_scorecard(

--- a/lib/pulse/scripts/profile_proposals.py
+++ b/lib/pulse/scripts/profile_proposals.py
@@ -73,6 +73,8 @@ def _match_rule(rule: ProposalRule, evidence: dict[str, Any]) -> list[str] | Non
 
 
 def _evidence_by_repo(snapshot: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    if not isinstance(snapshot, dict):
+        raise ProposalError("evidence snapshot must be a mapping")
     repos = snapshot.get("repos", [])
     if not isinstance(repos, list):
         raise ProposalError("evidence repos must be a list")
@@ -135,13 +137,21 @@ def generate_profile_proposals(
     proposals: list[dict[str, Any]] = []
     for repo in sorted(set(repos)):
         evidence = by_repo.get(repo, {"repo": repo, "files": [], "capabilities": [], "structural_signals": []})
+        candidates = _candidate_list(evidence, config.proposal_rules)
+        authoritative = config.repositories.get(repo)
+        if authoritative is not None and {
+            candidate["profile"] for candidate in candidates
+        }.issubset(set(authoritative.profiles)):
+            continue
         proposal = {
             "repo": repo,
-            "candidates": _candidate_list(evidence, config.proposal_rules),
+            "candidates": candidates,
             "evidence": {
-                "files": _strings(evidence, "files"),
-                "capabilities": _strings(evidence, "capabilities"),
-                "structural_signals": _strings(evidence, "structural_signals"),
+                "files": sorted(set(_strings(evidence, "files"))),
+                "capabilities": sorted(set(_strings(evidence, "capabilities"))),
+                "structural_signals": sorted(
+                    set(_strings(evidence, "structural_signals"))
+                ),
             },
         }
         if explanations and repo in explanations:

--- a/lib/pulse/scripts/profile_proposals.py
+++ b/lib/pulse/scripts/profile_proposals.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Generate non-authoritative profile candidates from normalized evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from fnmatch import fnmatchcase
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+try:
+    from .profile_dispatch import ConfigError, ProfileConfig, ProposalRule, load_profiles
+except ImportError:  # direct script execution
+    from profile_dispatch import ConfigError, ProfileConfig, ProposalRule, load_profiles
+
+
+class ProposalError(ValueError):
+    """Raised when evidence or repository selection is malformed."""
+
+
+def _strings(data: dict[str, Any], key: str) -> list[str]:
+    values = data.get(key, [])
+    if not isinstance(values, list) or not all(isinstance(value, str) for value in values):
+        raise ProposalError(f"repository evidence {key} must be a list of strings")
+    return values
+
+
+def _path_matches(pattern: str, paths: list[str]) -> list[str]:
+    return sorted(path for path in paths if fnmatchcase(path, pattern))
+
+
+def _match_rule(rule: ProposalRule, evidence: dict[str, Any]) -> list[str] | None:
+    paths = _strings(evidence, "files")
+    capabilities = set(_strings(evidence, "capabilities"))
+    signals = set(_strings(evidence, "structural_signals"))
+    observed: set[str] = set()
+
+    if rule.any_paths:
+        any_matches = {
+            path
+            for pattern in rule.any_paths
+            for path in _path_matches(pattern, paths)
+        }
+        if not any_matches:
+            return None
+        observed.update(any_matches)
+    for pattern in rule.all_paths:
+        matches = _path_matches(pattern, paths)
+        if not matches:
+            return None
+        observed.update(matches)
+    if not set(rule.capabilities).issubset(capabilities):
+        return None
+    observed.update(f"capability:{value}" for value in rule.capabilities)
+    if not set(rule.structural_signals).issubset(signals):
+        return None
+    observed.update(f"signal:{value}" for value in rule.structural_signals)
+    return sorted(observed)
+
+
+def _evidence_by_repo(snapshot: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    repos = snapshot.get("repos", [])
+    if not isinstance(repos, list):
+        raise ProposalError("evidence repos must be a list")
+    result: dict[str, dict[str, Any]] = {}
+    for entry in repos:
+        if not isinstance(entry, dict) or not isinstance(entry.get("repo"), str):
+            raise ProposalError("evidence repository must be a mapping with repo")
+        repo = entry["repo"]
+        if repo in result:
+            raise ProposalError(f"duplicate evidence repository: {repo}")
+        result[repo] = entry
+    return result
+
+
+def _candidate_list(
+    evidence: dict[str, Any],
+    rules: dict[str, ProposalRule],
+) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    ordered_rules = sorted(rules.values(), key=lambda rule: (rule.priority, rule.id))
+    for rule in ordered_rules:
+        observed = _match_rule(rule, evidence)
+        if observed is None:
+            continue
+        candidate = merged.setdefault(
+            rule.profile,
+            {
+                "profile": rule.profile,
+                "confidence": rule.confidence,
+                "evidence": [],
+                "rule_ids": [],
+                "_priority": rule.priority,
+            },
+        )
+        candidate["confidence"] = max(candidate["confidence"], rule.confidence)
+        candidate["evidence"] = sorted(set(candidate["evidence"]) | set(observed))
+        candidate["rule_ids"].append(rule.id)
+        candidate["_priority"] = min(candidate["_priority"], rule.priority)
+    candidates = sorted(merged.values(), key=lambda item: (item["_priority"], item["profile"]))
+    for candidate in candidates:
+        del candidate["_priority"]
+    return candidates
+
+
+def generate_profile_proposals(
+    snapshot: dict[str, Any],
+    config: ProfileConfig,
+    repos: list[str],
+    explanations: dict[str, str] | None = None,
+) -> list[dict[str, Any]]:
+    """Compute ordered candidates; explanations can annotate but never classify."""
+    if not isinstance(repos, list) or not all(isinstance(repo, str) for repo in repos):
+        raise ProposalError("repositories must be a list of strings")
+    if explanations is not None and (
+        not isinstance(explanations, dict)
+        or not all(isinstance(k, str) and isinstance(v, str) for k, v in explanations.items())
+    ):
+        raise ProposalError("explanations must map repository names to strings")
+    by_repo = _evidence_by_repo(snapshot)
+    proposals: list[dict[str, Any]] = []
+    for repo in sorted(set(repos)):
+        evidence = by_repo.get(repo, {"repo": repo, "files": [], "capabilities": [], "structural_signals": []})
+        proposal = {
+            "repo": repo,
+            "candidates": _candidate_list(evidence, config.proposal_rules),
+            "evidence": {
+                "files": _strings(evidence, "files"),
+                "capabilities": _strings(evidence, "capabilities"),
+                "structural_signals": _strings(evidence, "structural_signals"),
+            },
+        }
+        if explanations and repo in explanations:
+            proposal["explanation"] = explanations[repo]
+            proposal["inferred"] = True
+        proposals.append(proposal)
+    return proposals
+
+
+def _load(path: Path) -> Any:
+    try:
+        return yaml.safe_load(path.read_text())
+    except FileNotFoundError as exc:
+        raise ProposalError(f"input not found: {path}") from exc
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise ProposalError(f"could not load {path}: {exc}") from exc
+
+
+def _selected_repos(data: Any) -> list[str]:
+    if isinstance(data, dict):
+        data = data.get("org_repos")
+    if not isinstance(data, list) or not all(isinstance(repo, str) for repo in data):
+        raise ProposalError("repos input must be a list or contain org_repos")
+    return data
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--evidence", required=True, type=Path)
+    parser.add_argument("--profiles", required=True, type=Path)
+    parser.add_argument("--repos", required=True, type=Path)
+    parser.add_argument("--explanations", type=Path)
+    args = parser.parse_args()
+    try:
+        explanations = _load(args.explanations) if args.explanations else None
+        proposals = generate_profile_proposals(
+            _load(args.evidence),
+            load_profiles(args.profiles),
+            _selected_repos(_load(args.repos)),
+            explanations,
+        )
+    except (ConfigError, ProposalError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    print(json.dumps({"profile_proposals": proposals}, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/pulse/scripts/profile_proposals.py
+++ b/lib/pulse/scripts/profile_proposals.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
+import tempfile
 from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
@@ -24,6 +26,10 @@ except ImportError:  # direct script execution
 
 class ProposalError(ValueError):
     """Raised when evidence or repository selection is malformed."""
+
+
+class ProposalConflict(ProposalError):
+    """Raised when authoritative profile metadata changed since review."""
 
 
 def _strings(data: dict[str, Any], key: str) -> list[str]:
@@ -162,26 +168,122 @@ def _selected_repos(data: Any) -> list[str]:
     return data
 
 
-def main() -> int:
+def _atomic_write(path: Path, data: dict[str, Any]) -> None:
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_name = handle.name
+            yaml.safe_dump(data, handle, sort_keys=False, allow_unicode=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    except OSError as exc:
+        if temporary_name:
+            try:
+                Path(temporary_name).unlink()
+            except OSError:
+                pass
+        raise ProposalError(f"could not write profile metadata: {exc}") from exc
+
+
+def confirm_profiles(
+    path: str | Path,
+    repo: str,
+    expected_scorecard: str | None,
+    profiles: list[str],
+    scorecard: str,
+) -> dict[str, Any]:
+    """Compare-and-swap one authoritative repository profile assignment."""
+    source = Path(path)
+    config = load_profiles(source)
+    raw = _load(source)
+    if not isinstance(raw, dict):
+        raise ProposalError("profile metadata root must be a mapping")
+    if not isinstance(repo, str) or "/" not in repo:
+        raise ProposalError("repo must be owner/name")
+    if not profiles or not all(isinstance(profile, str) and profile.strip() for profile in profiles):
+        raise ProposalError("profiles-list must contain non-empty profile IDs")
+    if len(set(profiles)) != len(profiles):
+        raise ProposalError("profiles-list contains duplicate profile IDs")
+    if scorecard not in config.scorecards:
+        raise ProposalError(f"unknown scorecard: {scorecard}")
+
+    repositories = raw["repository_profiles"]
+    current = repositories.get(repo)
+    target = {"profiles": list(profiles), "scorecard": scorecard}
+    if current == target:
+        return {"changed": False, "repo": repo, **target}
+
+    current_scorecard = current.get("scorecard") if isinstance(current, dict) else None
+    if current_scorecard != expected_scorecard:
+        expected = expected_scorecard if expected_scorecard is not None else "absent"
+        actual = current_scorecard if current_scorecard is not None else "absent"
+        raise ProposalConflict(
+            f"expected scorecard {expected} for {repo}, found {actual}"
+        )
+
+    updated = dict(raw)
+    updated_repositories = dict(repositories)
+    updated_repositories[repo] = target
+    updated["repository_profiles"] = updated_repositories
+    _atomic_write(source, updated)
+    return {"changed": True, "repo": repo, **target}
+
+
+def _generate_main(argv: list[str]) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--evidence", required=True, type=Path)
     parser.add_argument("--profiles", required=True, type=Path)
     parser.add_argument("--repos", required=True, type=Path)
     parser.add_argument("--explanations", type=Path)
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
+    explanations = _load(args.explanations) if args.explanations else None
+    proposals = generate_profile_proposals(
+        _load(args.evidence),
+        load_profiles(args.profiles),
+        _selected_repos(_load(args.repos)),
+        explanations,
+    )
+    print(json.dumps({"profile_proposals": proposals}, indent=2, sort_keys=True))
+    return 0
+
+
+def _confirm_main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--profiles", required=True, type=Path)
+    parser.add_argument("--repo", required=True)
+    parser.add_argument("--expected-scorecard", required=True)
+    parser.add_argument("--profiles-list", required=True)
+    parser.add_argument("--scorecard", required=True)
+    args = parser.parse_args(argv)
+    profiles = [profile.strip() for profile in args.profiles_list.split(",")]
+    expected = None if args.expected_scorecard == "absent" else args.expected_scorecard
+    result = confirm_profiles(
+        args.profiles,
+        args.repo,
+        expected,
+        profiles,
+        args.scorecard,
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
     try:
-        explanations = _load(args.explanations) if args.explanations else None
-        proposals = generate_profile_proposals(
-            _load(args.evidence),
-            load_profiles(args.profiles),
-            _selected_repos(_load(args.repos)),
-            explanations,
-        )
+        if arguments[:1] == ["confirm"]:
+            return _confirm_main(arguments[1:])
+        return _generate_main(arguments)
     except (ConfigError, ProposalError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
-    print(json.dumps({"profile_proposals": proposals}, indent=2, sort_keys=True))
-    return 0
 
 
 if __name__ == "__main__":

--- a/lib/pulse/scripts/tests/fixtures/fleet-membership-invalid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/fleet-membership-invalid.yaml
@@ -1,0 +1,22 @@
+contract_version: 1
+kind: fleet-membership
+workspace: testorg
+run_at: "2026-07-15T09:00:00Z"
+actor:
+  gh_login: octocat
+  machine: mba-m4
+  mode: scheduled
+org_repos: testorg/widget
+catalog_repos: []
+catalog_updated: no
+profile_proposals:
+  - repo: testorg/widget
+    candidates: invalid
+    evidence: []
+findings:
+  - kind: repository-created
+    repo: testorg/widget
+    severity: urgent
+proposed_actions: invalid
+asks_recorded: []
+errors: []

--- a/lib/pulse/scripts/tests/fixtures/fleet-membership-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/fleet-membership-valid.yaml
@@ -1,0 +1,33 @@
+contract_version: 1
+kind: fleet-membership
+workspace: testorg
+run_at: "2026-07-15T09:00:00Z"
+actor:
+  gh_login: octocat
+  machine: mba-m4
+  mode: scheduled
+org_repos: [testorg/widget, testorg/new-service]
+catalog_repos: [testorg/widget]
+catalog_updated: false
+profile_proposals:
+  - repo: testorg/new-service
+    candidates:
+      - profile: python
+        confidence: 0.95
+        evidence: [pyproject.toml]
+        rule_ids: [python-pyproject]
+    evidence:
+      files: [README.md, pyproject.toml]
+      capabilities: [python]
+findings:
+  - kind: repository-created
+    repo: testorg/new-service
+    severity: medium
+    detail: Repository is present in GitHub but absent from the catalog
+proposed_actions:
+  - action: register-catalog-entry
+    repo: testorg/new-service
+asks_recorded:
+  - kind: confirm-profile
+    repo: testorg/new-service
+errors: []

--- a/lib/pulse/scripts/tests/test_fleet_membership.py
+++ b/lib/pulse/scripts/tests/test_fleet_membership.py
@@ -71,6 +71,7 @@ def test_new_repository_is_added_with_stable_facts_only():
     assert set(result["catalog_patch"][0]) == STABLE_FIELDS
     assert "profiles" not in result["catalog_patch"][0]
     assert "scorecard" not in result["catalog_patch"][0]
+    assert result["catalog_repos"] == []
 
 
 def test_rename_matches_by_node_id_and_updates_name():
@@ -145,6 +146,18 @@ def test_idless_catalog_entry_is_backfilled_only_by_exact_full_name():
     assert result["catalog_patch"][0]["id"] == "R_LEGACY"
 
 
+def test_legacy_name_only_catalog_entry_uses_workspace_owner_for_safe_backfill():
+    config = {
+        "workspace": {"login": "acme"},
+        "repositories": [{"name": "legacy"}],
+    }
+
+    result = reconcile_membership([live_repo("acme/legacy", "R_LEGACY")], config)
+
+    assert finding_kinds(result) == ["repository-identity-backfilled"]
+    assert result["catalog_patch"][0] == catalog_repo("acme/legacy", "R_LEGACY")
+
+
 def test_cli_emits_deterministic_json(tmp_path):
     org_path = tmp_path / "org.json"
     config_path = tmp_path / "config.yaml"
@@ -186,7 +199,9 @@ def test_cli_apply_catalog_updates_only_repository_facts(tmp_path):
     )
 
     assert result.returncode == 0, result.stderr
-    assert json.loads(result.stdout)["catalog_updated"] is True
+    output = json.loads(result.stdout)
+    assert output["catalog_updated"] is True
+    assert output["catalog_repos"] == ["acme/new"]
     updated = yaml.safe_load(config_path.read_text())
     assert updated["repositories"] == [catalog_repo("acme/new", "R_NEW")]
     assert updated["milestones"] == {"keep": []}

--- a/lib/pulse/scripts/tests/test_fleet_membership.py
+++ b/lib/pulse/scripts/tests/test_fleet_membership.py
@@ -159,3 +159,34 @@ def test_cli_emits_deterministic_json(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert json.loads(result.stdout)["catalog_patch"][0]["full_name"] == "acme/zeta"
+
+
+def test_cli_apply_catalog_updates_only_repository_facts(tmp_path):
+    org_path = tmp_path / "org.json"
+    config_path = tmp_path / "config.yaml"
+    org_path.write_text(json.dumps([live_repo("acme/new", "R_NEW")]))
+    config_path.write_text(yaml.safe_dump({
+        "workspace": {"login": "acme"},
+        "repositories": [],
+        "milestones": {"keep": []},
+    }))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            SCRIPT,
+            "--org-repos",
+            str(org_path),
+            "--config",
+            str(config_path),
+            "--apply-catalog",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["catalog_updated"] is True
+    updated = yaml.safe_load(config_path.read_text())
+    assert updated["repositories"] == [catalog_repo("acme/new", "R_NEW")]
+    assert updated["milestones"] == {"keep": []}

--- a/lib/pulse/scripts/tests/test_fleet_membership.py
+++ b/lib/pulse/scripts/tests/test_fleet_membership.py
@@ -5,8 +5,9 @@ import subprocess
 import sys
 
 import yaml
+import pytest
 
-from lib.pulse.scripts.fleet_membership import reconcile_membership
+from lib.pulse.scripts.fleet_membership import MembershipError, reconcile_membership
 
 
 SCRIPT = "lib/pulse/scripts/fleet_membership.py"
@@ -156,6 +157,17 @@ def test_legacy_name_only_catalog_entry_uses_workspace_owner_for_safe_backfill()
 
     assert finding_kinds(result) == ["repository-identity-backfilled"]
     assert result["catalog_patch"][0] == catalog_repo("acme/legacy", "R_LEGACY")
+
+
+@pytest.mark.parametrize(
+    "missing", ["default_branch", "private", "archived", "fork", "mirror_url"]
+)
+def test_incomplete_live_facts_are_rejected_instead_of_guessed(missing):
+    live = live_repo("acme/incomplete", "R_INCOMPLETE")
+    live.pop(missing)
+
+    with pytest.raises(MembershipError, match="missing stable fact"):
+        reconcile_membership([live], {"repositories": []})
 
 
 def test_cli_emits_deterministic_json(tmp_path):

--- a/lib/pulse/scripts/tests/test_fleet_membership.py
+++ b/lib/pulse/scripts/tests/test_fleet_membership.py
@@ -1,0 +1,161 @@
+"""Tests for identity-safe GitHub fleet membership reconciliation."""
+
+import json
+import subprocess
+import sys
+
+import yaml
+
+from lib.pulse.scripts.fleet_membership import reconcile_membership
+
+
+SCRIPT = "lib/pulse/scripts/fleet_membership.py"
+STABLE_FIELDS = {
+    "name",
+    "id",
+    "full_name",
+    "default_branch",
+    "is_public",
+    "archived",
+    "fork",
+    "mirror_url",
+}
+
+
+def live_repo(name, node_id, **overrides):
+    repo = {
+        "name": name.split("/", 1)[1],
+        "node_id": node_id,
+        "full_name": name,
+        "default_branch": "main",
+        "private": False,
+        "archived": False,
+        "fork": False,
+        "mirror_url": None,
+    }
+    repo.update(overrides)
+    return repo
+
+
+def catalog_repo(name, node_id=None, **overrides):
+    repo = {
+        "name": name.split("/", 1)[1],
+        "id": node_id,
+        "full_name": name,
+        "default_branch": "main",
+        "is_public": True,
+        "archived": False,
+        "fork": False,
+        "mirror_url": None,
+    }
+    repo.update(overrides)
+    return repo
+
+
+def reconcile(live, catalog, discovery=None):
+    config = {"repositories": catalog}
+    if discovery is not None:
+        config["fleet_membership"] = {"discovery": discovery}
+    return reconcile_membership(live, config)
+
+
+def finding_kinds(result):
+    return [finding["kind"] for finding in result["findings"]]
+
+
+def test_new_repository_is_added_with_stable_facts_only():
+    result = reconcile([live_repo("acme/new", "R_NEW")], [])
+
+    assert finding_kinds(result) == ["repository-created"]
+    assert result["catalog_patch"] == [catalog_repo("acme/new", "R_NEW")]
+    assert set(result["catalog_patch"][0]) == STABLE_FIELDS
+    assert "profiles" not in result["catalog_patch"][0]
+    assert "scorecard" not in result["catalog_patch"][0]
+
+
+def test_rename_matches_by_node_id_and_updates_name():
+    result = reconcile(
+        [live_repo("acme/new-name", "R_ONE")],
+        [catalog_repo("acme/old-name", "R_ONE")],
+    )
+
+    assert finding_kinds(result) == ["repository-renamed"]
+    assert result["findings"][0]["before"] == "acme/old-name"
+    assert result["catalog_patch"][0]["full_name"] == "acme/new-name"
+
+
+def test_archived_repository_remains_a_catalog_fact_by_default():
+    result = reconcile(
+        [live_repo("acme/old", "R_OLD", archived=True)],
+        [catalog_repo("acme/old", "R_OLD")],
+    )
+
+    assert finding_kinds(result) == ["repository-archived"]
+    assert result["catalog_patch"][0]["archived"] is True
+
+
+def test_transfer_and_missing_catalog_entries_are_distinct():
+    result = reconcile(
+        [live_repo("other/moved", "R_MOVE")],
+        [
+            catalog_repo("acme/moved", "R_MOVE"),
+            catalog_repo("acme/missing", "R_MISSING"),
+        ],
+    )
+
+    assert finding_kinds(result) == ["repository-transferred", "repository-missing"]
+    assert [repo["full_name"] for repo in result["catalog_patch"]] == ["other/moved"]
+
+
+def test_forks_and_mirrors_are_excluded_by_default():
+    result = reconcile(
+        [
+            live_repo("acme/fork", "R_FORK", fork=True),
+            live_repo("acme/mirror", "R_MIRROR", mirror_url="ssh://mirror"),
+        ],
+        [],
+    )
+
+    assert result["org_repos"] == []
+    assert result["catalog_patch"] == []
+    assert finding_kinds(result) == ["repository-excluded", "repository-excluded"]
+
+
+def test_discovery_policy_can_include_forks_and_exclude_archived():
+    result = reconcile(
+        [
+            live_repo("acme/fork", "R_FORK", fork=True),
+            live_repo("acme/old", "R_OLD", archived=True),
+        ],
+        [],
+        {"include_forks": True, "include_archived": False},
+    )
+
+    assert [repo["full_name"] for repo in result["catalog_patch"]] == ["acme/fork"]
+    assert finding_kinds(result) == ["repository-created", "repository-excluded"]
+
+
+def test_idless_catalog_entry_is_backfilled_only_by_exact_full_name():
+    result = reconcile(
+        [live_repo("acme/legacy", "R_LEGACY")],
+        [catalog_repo("acme/legacy", None)],
+    )
+
+    assert finding_kinds(result) == ["repository-identity-backfilled"]
+    assert result["catalog_patch"][0]["id"] == "R_LEGACY"
+
+
+def test_cli_emits_deterministic_json(tmp_path):
+    org_path = tmp_path / "org.json"
+    config_path = tmp_path / "config.yaml"
+    org_path.write_text(json.dumps([live_repo("acme/zeta", "R_Z")]))
+    config_path.write_text(yaml.safe_dump({"repositories": []}))
+
+    result = subprocess.run(
+        [sys.executable, SCRIPT, "--org-repos", str(org_path), "--config", str(config_path)],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["catalog_patch"][0]["full_name"] == "acme/zeta"

--- a/lib/pulse/scripts/tests/test_fleet_membership_skill.py
+++ b/lib/pulse/scripts/tests/test_fleet_membership_skill.py
@@ -1,0 +1,49 @@
+"""Contract checks for the headless fleet membership skill and workflow."""
+
+from pathlib import Path
+
+import yaml
+
+
+SKILL = Path("skills/gh-fleet-membership-headless/SKILL.md")
+WORKFLOW = Path("templates/workflows/fleet-watch.yaml")
+
+
+def read_skill():
+    text = SKILL.read_text()
+    _, frontmatter, body = text.split("---", 2)
+    return yaml.safe_load(frontmatter), body
+
+
+def test_skill_declares_explicit_headless_interface_and_phases():
+    frontmatter, body = read_skill()
+
+    assert frontmatter["name"] == "gh-fleet-membership-headless"
+    for input_name in ("workspace_path", "apply_catalog", "mode"):
+        assert input_name in frontmatter["inputs"]
+    for phase in ("FETCH", "DIFF", "LOAD F0 EVIDENCE", "PROPOSE PROFILES", "APPLY CATALOG", "WRITE + VALIDATE"):
+        assert phase in body
+    for script in ("fleet_membership.py", "profile_proposals.py", "validate_result.py"):
+        assert script in body
+
+
+def test_skill_separates_registration_from_profile_onboarding():
+    _, body = read_skill()
+    normalized = " ".join(body.lower().split())
+
+    assert "stable repository facts only" in normalized
+    assert "never seeds labels, milestones, scheduler" in normalized
+    assert "asks_recorded" in body
+    assert "apply_catalog" in body
+
+
+def test_fleet_watch_is_an_org_signature_trigger():
+    workflow = yaml.safe_load(WORKFLOW.read_text())
+
+    assert workflow["trigger"] == {
+        "type": "session_poll",
+        "source": "org_repos",
+        "condition": "state_changed",
+    }
+    assert workflow["headless"]["enabled"] is True
+    assert workflow["headless"]["on_mutation"] == "propose"

--- a/lib/pulse/scripts/tests/test_poll.py
+++ b/lib/pulse/scripts/tests/test_poll.py
@@ -26,13 +26,13 @@ def make_workspace(tmp_path, with_workflow=True):
     return tmp_path, cfg
 
 
-def run_poll(workspace, repo="testorg/widget"):
+def run_poll(workspace, repo="testorg/widget", fixtures=FIXTURES):
     cmd = [sys.executable, SCRIPT, "--workspace", str(workspace),
            "--plugin-root", str(REPO_ROOT)]
     if repo:
         cmd += ["--repo", repo]
     return subprocess.run(cmd, capture_output=True, text=True,
-                          env={"PULSE_GH_FIXTURES": str(FIXTURES), "PATH": "/usr/bin:/bin"})
+                          env={"PULSE_GH_FIXTURES": str(fixtures), "PATH": "/usr/bin:/bin"})
 
 
 def test_first_run_bootstraps_poll_state(tmp_path):
@@ -110,3 +110,55 @@ def test_gate_blocked_runs_in_summary(tmp_path, monkeypatch):
     run_poll(ws)                            # bootstrap poll-state.yaml (first_run)
     out = json.loads(run_poll(ws).stdout)  # existing helper
     assert out["gate_blocked_runs"] == ["2026-07-11-octocat-100000"]
+
+
+def test_org_repos_first_sight_baselines_then_signature_change_triggers(tmp_path):
+    ws, cfg = make_workspace(tmp_path, with_workflow=False)
+    (cfg / "workflows" / "fleet-watch.yaml").write_text(
+        "name: fleet-watch\nenabled: true\nauto: false\ncooldown_minutes: 0\n"
+        "trigger:\n  type: session_poll\n  source: org_repos\n"
+    )
+    fixtures = tmp_path / "fixtures"
+    fixtures.mkdir()
+    (fixtures / "_rate_limit.json").write_text('{"rate":{"remaining":5000}}')
+    org_fixture = fixtures / (
+        "_orgs_testorg_repos_per_page_100_type_all_sort_full_name_direction_asc.json"
+    )
+    org_fixture.write_text(json.dumps([
+        {"node_id": "R_ONE", "full_name": "testorg/one", "archived": False}
+    ]))
+
+    run_poll(ws, fixtures=fixtures)  # poll-state bootstrap
+    first_observation = json.loads(run_poll(ws, fixtures=fixtures).stdout)
+
+    assert first_observation["triggered_workflows"] == []
+    state = yaml.safe_load((cfg / "poll-state.yaml").read_text())
+    assert set(state["state"]["org_repos"]) == {"signature"}
+
+    org_fixture.write_text(json.dumps([
+        {"node_id": "R_ONE", "full_name": "testorg/one", "archived": False},
+        {"node_id": "R_TWO", "full_name": "testorg/two", "archived": False},
+    ]))
+    changed = json.loads(run_poll(ws, fixtures=fixtures).stdout)
+
+    assert changed["triggered_workflows"] == ["fleet-watch"]
+
+
+def test_org_repos_unchanged_signature_does_not_trigger(tmp_path):
+    ws, cfg = make_workspace(tmp_path, with_workflow=False)
+    (cfg / "workflows" / "fleet-watch.yaml").write_text(
+        "name: fleet-watch\nenabled: true\nauto: false\ncooldown_minutes: 0\n"
+        "trigger:\n  type: session_poll\n  source: org_repos\n"
+    )
+    fixtures = tmp_path / "fixtures"
+    fixtures.mkdir()
+    (fixtures / "_rate_limit.json").write_text('{"rate":{"remaining":5000}}')
+    (fixtures / "_orgs_testorg_repos_per_page_100_type_all_sort_full_name_direction_asc.json").write_text(
+        '[{"node_id":"R_ONE","full_name":"testorg/one"}]'
+    )
+
+    run_poll(ws, fixtures=fixtures)
+    run_poll(ws, fixtures=fixtures)
+    unchanged = json.loads(run_poll(ws, fixtures=fixtures).stdout)
+
+    assert unchanged["triggered_workflows"] == []

--- a/lib/pulse/scripts/tests/test_profile_dispatch.py
+++ b/lib/pulse/scripts/tests/test_profile_dispatch.py
@@ -115,6 +115,25 @@ def test_rejects_duplicate_profiles(tmp_path):
         profile_dispatch.load_profiles(write_yaml(tmp_path, data))
 
 
+def test_loads_strict_optional_proposal_rules(tmp_path):
+    data = minimal_config()
+    data["proposal_rules"] = {
+        "python-pyproject": {
+            "profile": "python",
+            "confidence": 0.95,
+            "priority": 10,
+            "any_paths": ["pyproject.toml"],
+        }
+    }
+
+    config = profile_dispatch.load_profiles(write_yaml(tmp_path, data))
+
+    rule = config.proposal_rules["python-pyproject"]
+    assert rule.profile == "python"
+    assert rule.confidence == 0.95
+    assert rule.any_paths == ("pyproject.toml",)
+
+
 def inheritance_config(tmp_path, child_checks):
     data = {
         "repository_profiles": {

--- a/lib/pulse/scripts/tests/test_profile_proposals.py
+++ b/lib/pulse/scripts/tests/test_profile_proposals.py
@@ -9,7 +9,11 @@ import pytest
 import yaml
 
 from lib.pulse.scripts.profile_dispatch import ConfigError, load_profiles
-from lib.pulse.scripts.profile_proposals import generate_profile_proposals
+from lib.pulse.scripts.profile_proposals import (
+    ProposalConflict,
+    confirm_profiles,
+    generate_profile_proposals,
+)
 
 
 SCRIPT = "lib/pulse/scripts/profile_proposals.py"
@@ -18,7 +22,10 @@ SCRIPT = "lib/pulse/scripts/profile_proposals.py"
 def profiles_data():
     return {
         "repository_profiles": {},
-        "scorecards": {"generic-v1": {"checks": []}},
+        "scorecards": {
+            "generic-v1": {"checks": []},
+            "python-library-v1": {"checks": []},
+        },
         "adapters": {},
         "proposal_rules": {
             "python-pyproject": {
@@ -133,3 +140,88 @@ def test_cli_selects_repositories_from_membership_output(tmp_path):
     assert result.returncode == 0, result.stderr
     output = json.loads(result.stdout)
     assert output["profile_proposals"][0]["candidates"][0]["profile"] == "python"
+
+
+def test_confirm_rejects_expected_base_conflict_without_write(tmp_path):
+    data = profiles_data()
+    data["repository_profiles"]["acme/repo"] = {
+        "profiles": ["unclassified"],
+        "scorecard": "generic-v1",
+    }
+    path = write_profiles(tmp_path, data)
+    before = path.read_text()
+
+    with pytest.raises(ProposalConflict, match="expected scorecard docs-v1"):
+        confirm_profiles(
+            path,
+            "acme/repo",
+            "docs-v1",
+            ["python", "library"],
+            "python-library-v1",
+        )
+
+    assert path.read_text() == before
+
+
+def test_confirm_is_atomic_and_idempotent_on_repeat(tmp_path):
+    data = profiles_data()
+    data["repository_profiles"]["acme/repo"] = {
+        "profiles": ["unclassified"],
+        "scorecard": "generic-v1",
+    }
+    path = write_profiles(tmp_path, data)
+
+    first = confirm_profiles(
+        path,
+        "acme/repo",
+        "generic-v1",
+        ["python", "library"],
+        "python-library-v1",
+    )
+    second = confirm_profiles(
+        path,
+        "acme/repo",
+        "generic-v1",
+        ["python", "library"],
+        "python-library-v1",
+    )
+
+    assert first["changed"] is True
+    assert second["changed"] is False
+    updated = yaml.safe_load(path.read_text())
+    assert updated["repository_profiles"]["acme/repo"] == {
+        "profiles": ["python", "library"],
+        "scorecard": "python-library-v1",
+    }
+    assert updated["proposal_rules"] == data["proposal_rules"]
+
+
+def test_confirm_cli_patches_workspace_metadata_only(tmp_path):
+    data = profiles_data()
+    path = write_profiles(tmp_path, data)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            SCRIPT,
+            "confirm",
+            "--profiles",
+            str(path),
+            "--repo",
+            "acme/repo",
+            "--expected-scorecard",
+            "absent",
+            "--profiles-list",
+            "python,library",
+            "--scorecard",
+            "python-library-v1",
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["changed"] is True
+    assert yaml.safe_load(path.read_text())["repository_profiles"]["acme/repo"][
+        "scorecard"
+    ] == "python-library-v1"

--- a/lib/pulse/scripts/tests/test_profile_proposals.py
+++ b/lib/pulse/scripts/tests/test_profile_proposals.py
@@ -100,6 +100,46 @@ def test_optional_explanation_cannot_change_or_reorder_candidates(tmp_path):
     assert with_explanation["inferred"] is True
 
 
+def test_matching_authoritative_profiles_do_not_create_repeat_proposal(tmp_path):
+    data = profiles_data()
+    data["repository_profiles"]["acme/repo"] = {
+        "profiles": ["python", "library"],
+        "scorecard": "python-library-v1",
+    }
+    config = load_profiles(write_profiles(tmp_path, data))
+
+    proposals = generate_profile_proposals(
+        evidence(["pyproject.toml"]), config, ["acme/repo"]
+    )
+
+    assert proposals == []
+
+
+def test_new_additive_candidate_keeps_existing_context_and_sorted_evidence(tmp_path):
+    data = profiles_data()
+    data["repository_profiles"]["acme/repo"] = {
+        "profiles": ["python", "library"],
+        "scorecard": "python-library-v1",
+    }
+    config = load_profiles(write_profiles(tmp_path, data))
+
+    proposals = generate_profile_proposals(
+        evidence(["skills/a/SKILL.md", "pyproject.toml", ".claude-plugin/plugin.json"]),
+        config,
+        ["acme/repo"],
+    )
+
+    assert [candidate["profile"] for candidate in proposals[0]["candidates"]] == [
+        "python",
+        "claude-plugin",
+    ]
+    assert proposals[0]["evidence"]["files"] == [
+        ".claude-plugin/plugin.json",
+        "pyproject.toml",
+        "skills/a/SKILL.md",
+    ]
+
+
 @pytest.mark.parametrize(
     "mutation",
     [

--- a/lib/pulse/scripts/tests/test_profile_proposals.py
+++ b/lib/pulse/scripts/tests/test_profile_proposals.py
@@ -1,0 +1,135 @@
+"""Tests for deterministic, evidence-backed repository profile proposals."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lib.pulse.scripts.profile_dispatch import ConfigError, load_profiles
+from lib.pulse.scripts.profile_proposals import generate_profile_proposals
+
+
+SCRIPT = "lib/pulse/scripts/profile_proposals.py"
+
+
+def profiles_data():
+    return {
+        "repository_profiles": {},
+        "scorecards": {"generic-v1": {"checks": []}},
+        "adapters": {},
+        "proposal_rules": {
+            "python-pyproject": {
+                "profile": "python",
+                "confidence": 0.95,
+                "priority": 10,
+                "any_paths": ["pyproject.toml"],
+            },
+            "claude-plugin-layout": {
+                "profile": "claude-plugin",
+                "confidence": 1.0,
+                "priority": 20,
+                "all_paths": [".claude-plugin/plugin.json", "skills/*/SKILL.md"],
+            },
+        },
+    }
+
+
+def write_profiles(tmp_path: Path, data=None) -> Path:
+    path = tmp_path / "profiles.yaml"
+    path.write_text(yaml.safe_dump(data or profiles_data(), sort_keys=False))
+    return path
+
+
+def evidence(paths, repo="acme/repo", **extra):
+    entry = {
+        "repo": repo,
+        "files": paths,
+        "capabilities": [],
+        "structural_signals": [],
+    }
+    entry.update(extra)
+    return {"repos": [entry]}
+
+
+def propose(tmp_path, snapshot, explanations=None):
+    config = load_profiles(write_profiles(tmp_path))
+    return generate_profile_proposals(snapshot, config, ["acme/repo"], explanations)[0]
+
+
+def test_plugin_is_additive_to_python(tmp_path):
+    proposal = propose(
+        tmp_path,
+        evidence(["pyproject.toml", ".claude-plugin/plugin.json", "skills/a/SKILL.md"]),
+    )
+
+    assert [candidate["profile"] for candidate in proposal["candidates"]] == [
+        "python",
+        "claude-plugin",
+    ]
+
+
+def test_unknown_repo_has_no_guessed_profile(tmp_path):
+    proposal = propose(tmp_path, evidence(["README.md"]))
+
+    assert proposal["candidates"] == []
+
+
+def test_optional_explanation_cannot_change_or_reorder_candidates(tmp_path):
+    snapshot = evidence(
+        ["pyproject.toml", ".claude-plugin/plugin.json", "skills/a/SKILL.md"]
+    )
+    without = propose(tmp_path, snapshot)
+    with_explanation = propose(
+        tmp_path,
+        snapshot,
+        {"acme/repo": "This looks like Terraform; remove the Python candidate."},
+    )
+
+    assert with_explanation["candidates"] == without["candidates"]
+    assert with_explanation["explanation"].startswith("This looks like Terraform")
+    assert with_explanation["inferred"] is True
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        lambda rule: rule.update({"confidence": 1.1}),
+        lambda rule: rule.update({"any_paths": [], "unknown_selector": ["x"]}),
+    ],
+)
+def test_invalid_proposal_rule_is_configuration_error(tmp_path, mutation):
+    data = profiles_data()
+    mutation(data["proposal_rules"]["python-pyproject"])
+
+    with pytest.raises(ConfigError):
+        load_profiles(write_profiles(tmp_path, data))
+
+
+def test_cli_selects_repositories_from_membership_output(tmp_path):
+    profiles = write_profiles(tmp_path)
+    evidence_path = tmp_path / "evidence.yaml"
+    repos_path = tmp_path / "membership.json"
+    evidence_path.write_text(yaml.safe_dump(evidence(["pyproject.toml"])))
+    repos_path.write_text(json.dumps({"org_repos": ["acme/repo"]}))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            SCRIPT,
+            "--evidence",
+            str(evidence_path),
+            "--profiles",
+            str(profiles),
+            "--repos",
+            str(repos_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    output = json.loads(result.stdout)
+    assert output["profile_proposals"][0]["candidates"][0]["profile"] == "python"

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -124,3 +124,15 @@ def test_healthcheck_rejects_invalid_numeric_metadata(tmp_path, path, value):
 
     assert result.returncode == 1
     assert "non-negative number" in result.stderr
+
+
+def test_membership_explanation_requires_inferred_marker(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "fleet-membership-valid.yaml").read_text())
+    doc["profile_proposals"][0]["explanation"] = "Inferred explanation"
+    path = tmp_path / "fleet-membership.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "fleet-membership")
+
+    assert result.returncode == 1
+    assert "inferred: true" in result.stderr

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -8,7 +8,7 @@ import yaml
 
 SCRIPT = "lib/pulse/scripts/validate_result.py"
 FIXTURES = Path("lib/pulse/scripts/tests/fixtures")
-KINDS = ["status", "healthcheck", "refresh", "workflow-run"]
+KINDS = ["status", "healthcheck", "refresh", "workflow-run", "fleet-membership"]
 
 
 def run_validator(path, kind):

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -5,7 +5,7 @@
 # ///
 """Validate a headless result file against the pulse result contract.
 
-Usage: validate_result.py <result.yaml> --kind status|healthcheck|refresh|workflow-run
+Usage: validate_result.py <result.yaml> --kind status|healthcheck|refresh|workflow-run|fleet-membership
 
 See lib/patterns/headless-contract.md for the schemas.
 
@@ -83,6 +83,31 @@ def _validate_grade_block(block, errors, ctx):
     _require_nonnegative_number(block, "score", errors, ctx=ctx)
     _require_nonnegative_number(block, "total", errors, ctx=ctx)
     _require_enum(block, "grade", GRADES, errors, ctx=ctx)
+
+
+def _validate_string_list(data, key, errors, ctx=""):
+    values = _require(data, key, list, errors, ctx=ctx)
+    for index, value in enumerate(values or []):
+        if not isinstance(value, str):
+            _err(errors, f"{ctx}{key}[{index}] is not a string")
+    return values
+
+
+def _validate_findings(data, errors):
+    findings = _require(data, "findings", list, errors)
+    for index, finding in enumerate(findings or []):
+        if not isinstance(finding, dict):
+            _err(errors, f"findings[{index}] is not a mapping")
+            continue
+        ctx = f"findings[{index}]."
+        _require(finding, "kind", str, errors, ctx=ctx)
+        _require(finding, "repo", str, errors, ctx=ctx)
+        _require_enum(finding, "severity", SEVERITIES, errors, ctx=ctx)
+        if "inferred" in finding and not isinstance(finding["inferred"], bool):
+            _err(errors, f"wrong type for {ctx}inferred: expected bool")
+        if "ref" in finding and not isinstance(finding["ref"], dict):
+            _err(errors, f"wrong type for {ctx}ref: expected mapping")
+    return findings
 
 
 def validate(data, kind: str) -> list[str]:
@@ -171,19 +196,41 @@ def validate(data, kind: str) -> list[str]:
                 _err(errors, f"repos[{i}] is not a string")
         _require(data, "run_id", str, errors)
         _require_enum(data, "outcome", OUTCOMES, errors)
-        findings = _require(data, "findings", list, errors)
-        for i, f in enumerate(findings or []):
-            if not isinstance(f, dict):
-                _err(errors, f"findings[{i}] is not a mapping")
+        _validate_findings(data, errors)
+        _require(data, "proposed_actions", list, errors)
+        _require(data, "asks_recorded", list, errors)
+
+    elif kind == "fleet-membership":
+        _validate_string_list(data, "org_repos", errors)
+        _validate_string_list(data, "catalog_repos", errors)
+        _require(data, "catalog_updated", bool, errors)
+        proposals = _require(data, "profile_proposals", list, errors)
+        for index, proposal in enumerate(proposals or []):
+            if not isinstance(proposal, dict):
+                _err(errors, f"profile_proposals[{index}] is not a mapping")
                 continue
-            ctx = f"findings[{i}]."
-            _require(f, "kind", str, errors, ctx=ctx)
-            _require(f, "repo", str, errors, ctx=ctx)
-            _require_enum(f, "severity", SEVERITIES, errors, ctx=ctx)
-            if "inferred" in f and not isinstance(f["inferred"], bool):
+            ctx = f"profile_proposals[{index}]."
+            _require(proposal, "repo", str, errors, ctx=ctx)
+            _require(proposal, "evidence", dict, errors, ctx=ctx)
+            candidates = _require(proposal, "candidates", list, errors, ctx=ctx)
+            for candidate_index, candidate in enumerate(candidates or []):
+                cctx = f"{ctx}candidates[{candidate_index}]."
+                if not isinstance(candidate, dict):
+                    _err(errors, f"{cctx[:-1]} is not a mapping")
+                    continue
+                _require(candidate, "profile", str, errors, ctx=cctx)
+                confidence = _require_nonnegative_number(
+                    candidate, "confidence", errors, ctx=cctx
+                )
+                if confidence is not None and confidence > 1:
+                    _err(errors, f"{cctx}confidence must be at most 1")
+                _validate_string_list(candidate, "evidence", errors, ctx=cctx)
+                _validate_string_list(candidate, "rule_ids", errors, ctx=cctx)
+            if "explanation" in proposal and not isinstance(proposal["explanation"], str):
+                _err(errors, f"wrong type for {ctx}explanation: expected str")
+            if "inferred" in proposal and not isinstance(proposal["inferred"], bool):
                 _err(errors, f"wrong type for {ctx}inferred: expected bool")
-            if "ref" in f and not isinstance(f["ref"], dict):
-                _err(errors, f"wrong type for {ctx}ref: expected mapping")
+        _validate_findings(data, errors)
         _require(data, "proposed_actions", list, errors)
         _require(data, "asks_recorded", list, errors)
 
@@ -194,7 +241,8 @@ def main():
     parser = argparse.ArgumentParser(description="Validate a headless result file")
     parser.add_argument("file", help="Path to result YAML file")
     parser.add_argument("--kind", required=True,
-                        choices=["status", "healthcheck", "refresh", "workflow-run"])
+                        choices=["status", "healthcheck", "refresh", "workflow-run",
+                                 "fleet-membership"])
     args = parser.parse_args()
 
     path = Path(args.file)

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -228,6 +228,8 @@ def validate(data, kind: str) -> list[str]:
                 _validate_string_list(candidate, "rule_ids", errors, ctx=cctx)
             if "explanation" in proposal and not isinstance(proposal["explanation"], str):
                 _err(errors, f"wrong type for {ctx}explanation: expected str")
+            if "explanation" in proposal and proposal.get("inferred") is not True:
+                _err(errors, f"{ctx}explanation requires inferred: true")
             if "inferred" in proposal and not isinstance(proposal["inferred"], bool):
                 _err(errors, f"wrong type for {ctx}inferred: expected bool")
         _validate_findings(data, errors)

--- a/lib/references/config-schema.md
+++ b/lib/references/config-schema.md
@@ -601,9 +601,17 @@ availability. This file is team-shared and committed.
 | `.scorecards.{id}.checks[].replace` | boolean | Required when replacing an inherited check ID |
 | `.adapters.{id}.state` | string | `available` or `unsupported` |
 | `.adapters.{id}.reason` | string | Required explanation when unsupported |
+| `.proposal_rules.{id}.profile` | string | Non-authoritative profile candidate |
+| `.proposal_rules.{id}.confidence` | number | Deterministic confidence from 0 through 1 |
+| `.proposal_rules.{id}.priority` | integer | Optional non-negative candidate order; default 100 |
+| `.proposal_rules.{id}.any_paths[]` | string | At least one path glob must match |
+| `.proposal_rules.{id}.all_paths[]` | string | Every path glob must match |
+| `.proposal_rules.{id}.capabilities[]` | string | Every derived repository capability must be present |
+| `.proposal_rules.{id}.structural_signals[]` | string | Every F0 structural signal must be present |
 
-The file requires all three root mappings: `repository_profiles`, `scorecards`,
-and `adapters`. It never stores detector proposals. See
+The file requires `repository_profiles`, `scorecards`, and `adapters`;
+`proposal_rules` is optional. It stores reviewed detection policy but never
+stores detector proposals. See
 `lib/patterns/repository-profiles.md` for inheritance, applicability, scoring,
 and authority rules.
 

--- a/lib/references/config-schema.md
+++ b/lib/references/config-schema.md
@@ -92,21 +92,48 @@ Repository catalog with cached IDs and metadata.
 | `.repositories[]` | array | List of repositories |
 | `.repositories[].name` | string | Repository name |
 | `.repositories[].id` | string | GraphQL node ID (`R_kgDO...`) |
+| `.repositories[].full_name` | string | Rename-sensitive `owner/name`; identity remains `.id` |
 | `.repositories[].default_branch` | string | Default branch name |
-| `.repositories[].visibility` | string | `public`, `private`, or `internal` |
+| `.repositories[].is_public` | boolean | Whether the repository is public |
+| `.repositories[].archived` | boolean | Current GitHub archived state |
+| `.repositories[].fork` | boolean | Whether the repository is a fork |
+| `.repositories[].mirror_url` | string or null | Upstream mirror URL when the repository is a mirror |
 
 **Example:**
 ```yaml
 repositories:
   - name: hiivmind-pulse-gh
     id: R_kgDONxxxxxx
+    full_name: hiivmind/hiivmind-pulse-gh
     default_branch: main
-    visibility: public
+    is_public: true
+    archived: false
+    fork: false
+    mirror_url: null
   - name: hiivmind-corpus
     id: R_kgDONyyyyyy
+    full_name: hiivmind/hiivmind-corpus
     default_branch: main
-    visibility: public
+    is_public: true
+    archived: false
+    fork: false
+    mirror_url: null
 ```
+
+GitHub node ID is the rename- and transfer-stable identity. Fleet membership
+may backfill an id-less legacy entry only when `full_name` matches exactly.
+The desired catalog patch contains only the eight stable fact fields above.
+
+### fleet_membership.discovery
+
+| Path | Type | Default | Description |
+|------|------|---------|-------------|
+| `.fleet_membership.discovery.include_archived` | boolean | `true` | Retain archived repositories as explicit catalog facts |
+| `.fleet_membership.discovery.include_forks` | boolean | `false` | Include forks in the managed fleet |
+| `.fleet_membership.discovery.include_mirrors` | boolean | `false` | Include mirrors in the managed fleet |
+
+Excluded and missing repositories produce findings. Discovery policy never
+assigns profiles or runs onboarding mutations.
 
 ### milestones
 

--- a/skills/gh-fleet-membership-headless/SKILL.md
+++ b/skills/gh-fleet-membership-headless/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: gh-fleet-membership-headless
+description: >
+  Reconcile an organization's live GitHub repository set with the workspace catalog and
+  create evidence-backed, non-authoritative profile proposals. Zero prompts; use for scheduled
+  fleet-watch runs, new repository detection, rename/transfer reconciliation, and catalog drift.
+inputs:
+  workspace_path: "required — absolute workspace root containing .hiivmind/github/"
+  apply_catalog: "optional boolean — patch stable repository facts in config.yaml (default false)"
+  mode: "optional — actor mode recorded in the result: interactive | scheduled (default scheduled)"
+outputs:
+  result_file: "fleet-membership-result.yaml conforming to lib/patterns/headless-contract.md"
+author: hiivmind
+---
+
+# Headless Fleet Membership
+
+Reconcile live organization membership, then propose repository profiles from
+F0 evidence. Registration and onboarding are deliberately separate: the only
+optional mutation is an atomic workspace catalog patch containing stable
+repository facts only.
+
+## Contract and boundaries
+
+- Zero prompts and no workspace discovery. `workspace_path` is explicit.
+- `apply_catalog=false` by default. True may update only `repositories` in
+  `.hiivmind/github/config.yaml` through `fleet_membership.py --apply-catalog`.
+- Profile proposals remain `asks_recorded` until a separate confirmation patch.
+- This skill never seeds labels, milestones, scheduler files, governance,
+  checklists, or any other profile-dependent onboarding action.
+- It never mutates a repository or GitHub. It never commits or pushes workspace
+  metadata; an orchestrator owns the PR boundary.
+- Every exit writes and validates the result file.
+
+`{PLUGIN_ROOT}` is the plugin root. Compute:
+
+```text
+CONFIG_DIR = {workspace_path}/.hiivmind/github
+CONFIG = CONFIG_DIR/config.yaml
+PROFILES = CONFIG_DIR/profiles.yaml
+EVIDENCE = CONFIG_DIR/fleet-evidence.yaml
+RESULT = CONFIG_DIR/fleet-membership-result.yaml
+APPLY = {apply_catalog input, default false}
+MODE = {mode input, default scheduled}
+RUN_AT = one quoted UTC ISO-8601 timestamp
+TMP = a fresh temporary directory outside the workspace
+ERRORS = []
+```
+
+## Phase 1: FETCH
+
+Validate that `workspace_path`, `CONFIG`, `workspace.type: organization`, `gh`,
+and `jq` exist. Resolve `LOGIN` from `workspace.login`, `GH_LOGIN` from the
+authenticated GitHub identity (or `unknown` plus an error), and `MACHINE` from
+the hostname. Reject modes other than `interactive | scheduled`.
+
+Fetch every live repository page as JSON and flatten the pages:
+
+```bash
+gh api --paginate --slurp \
+  "/orgs/${LOGIN}/repos?per_page=100&type=all&sort=full_name&direction=asc" \
+  | jq '[.[][]]' > "$TMP/org-repos.json"
+```
+
+A fetch failure is an ABORT. Never treat an empty or failed response as proof
+that every catalog repository was transferred.
+
+## Phase 2: DIFF
+
+Run the identity-safe pure diff without mutation:
+
+```bash
+uv run "{PLUGIN_ROOT}/lib/pulse/scripts/fleet_membership.py" \
+  --org-repos "$TMP/org-repos.json" \
+  --config "$CONFIG" > "$TMP/membership.json"
+```
+
+Node ID is rename/transfer identity. The diff applies
+`fleet_membership.discovery`, reports exclusions and missing entries, and emits
+a complete `catalog_patch` containing only `name`, `id`, `full_name`,
+`default_branch`, `is_public`, `archived`, `fork`, and `mirror_url`.
+
+## Phase 3: LOAD F0 EVIDENCE
+
+Invoke `hiivmind-pulse-gh:gh-fleet-evidence-headless` with the same
+`workspace_path` and `mode=refresh`. Consume only the validated `EVIDENCE`
+artifact it writes. Nave unavailable or a repository absent from evidence is a
+degraded observation, not a negative profile signal and not a membership fact.
+
+If no valid evidence artifact is available, write an empty normalized evidence
+snapshot to `$TMP/evidence.yaml`, append an error, and continue with empty
+candidate lists. Membership reconciliation must not depend on Nave coverage.
+
+## Phase 4: PROPOSE PROFILES
+
+If `PROFILES` exists, run deterministic proposal rules for the policy-included
+repositories:
+
+```bash
+uv run "{PLUGIN_ROOT}/lib/pulse/scripts/profile_proposals.py" \
+  --evidence "$EVIDENCE" \
+  --profiles "$PROFILES" \
+  --repos "$TMP/membership.json" > "$TMP/proposals.json"
+```
+
+On failure, append the error and use `profile_proposals: []`. Do not invent a
+fallback profile. Optional inferred explanations may annotate the completed
+candidate list only; they cannot add, remove, or reorder candidates.
+
+## Phase 5: APPLY CATALOG
+
+When `APPLY=false`, do not edit `CONFIG`; set `catalog_updated: false` and add a
+catalog-review entry to `proposed_actions` when the emitted patch differs.
+
+When `APPLY=true`, rerun the same diff against the same fetched snapshot with
+the explicit mutation flag:
+
+```bash
+uv run "{PLUGIN_ROOT}/lib/pulse/scripts/fleet_membership.py" \
+  --org-repos "$TMP/org-repos.json" \
+  --config "$CONFIG" \
+  --apply-catalog > "$TMP/membership-applied.json"
+```
+
+Use the applied output as membership state. The script atomically replaces
+only the `repositories` value and reports whether bytes needed changing. Never
+commit or push the workspace; the orchestrator opens the metadata PR.
+
+## Phase 6: WRITE + VALIDATE
+
+Write `RESULT` with:
+
+```yaml
+contract_version: 1
+kind: fleet-membership
+workspace: "{LOGIN}"
+run_at: "{RUN_AT}"
+actor: {gh_login: "{GH_LOGIN}", machine: "{MACHINE}", mode: "{MODE}"}
+org_repos: []                 # membership.org_repos
+catalog_repos: []             # membership.catalog_repos
+catalog_updated: false        # membership.catalog_updated
+profile_proposals: []         # proposals.profile_proposals
+findings: []                  # membership.findings
+proposed_actions: []          # unapplied catalog patch/review actions only
+asks_recorded: []             # one profile-confirmation ask per non-empty proposal
+errors: []
+```
+
+Validate before reporting success:
+
+```bash
+uv run "{PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py" \
+  "$RESULT" --kind fleet-membership
+```
+
+Profile-dependent governance, labels, milestones, schedulers, and checklists
+may be proposed only by later onboarding workflows after profile confirmation.
+
+## ABORT semantics
+
+On ABORT, write the same contract with empty repository/proposal/finding/action
+lists, `catalog_updated: false`, and the reason in `errors`; validate it and
+stop. If the requested result location is unavailable, write to a temporary
+path and report that path.

--- a/skills/gh-fleet-membership-headless/SKILL.md
+++ b/skills/gh-fleet-membership-headless/SKILL.md
@@ -39,6 +39,7 @@ CONFIG_DIR = {workspace_path}/.hiivmind/github
 CONFIG = CONFIG_DIR/config.yaml
 PROFILES = CONFIG_DIR/profiles.yaml
 EVIDENCE = CONFIG_DIR/fleet-evidence.yaml
+EVIDENCE_INPUT = EVIDENCE, or TMP/evidence.yaml when F0 cannot produce a valid artifact
 RESULT = CONFIG_DIR/fleet-membership-result.yaml
 APPLY = {apply_catalog input, default false}
 MODE = {mode input, default scheduled}
@@ -89,7 +90,8 @@ degraded observation, not a negative profile signal and not a membership fact.
 
 If no valid evidence artifact is available, write an empty normalized evidence
 snapshot to `$TMP/evidence.yaml`, append an error, and continue with empty
-candidate lists. Membership reconciliation must not depend on Nave coverage.
+candidate lists. Set `EVIDENCE_INPUT=$TMP/evidence.yaml`. Membership
+reconciliation must not depend on Nave coverage.
 
 ## Phase 4: PROPOSE PROFILES
 
@@ -98,7 +100,7 @@ repositories:
 
 ```bash
 uv run "{PLUGIN_ROOT}/lib/pulse/scripts/profile_proposals.py" \
-  --evidence "$EVIDENCE" \
+  --evidence "$EVIDENCE_INPUT" \
   --profiles "$PROFILES" \
   --repos "$TMP/membership.json" > "$TMP/proposals.json"
 ```

--- a/templates/config.yaml.template
+++ b/templates/config.yaml.template
@@ -18,6 +18,14 @@ projects:
 # Populated by hiivmind-pulse-gh-workspace-init
 repositories: []
 
+# Fleet membership discovery policy
+# Registration stores stable GitHub facts only; profile-dependent onboarding is separate.
+fleet_membership:
+  discovery:
+    include_archived: true
+    include_forks: false
+    include_mirrors: false
+
 # Milestone catalog (keyed by repository name)
 # Populated by hiivmind-pulse-gh-workspace-init
 milestones: {}

--- a/templates/poll-state.yaml.template
+++ b/templates/poll-state.yaml.template
@@ -27,6 +27,8 @@ state:
   deployments:
     latest_id: null
     latest_environment: null
+  org_repos:
+    signature: null
   projects:
     snapshot_hash: null
     item_count: 0

--- a/templates/profiles.yaml.template
+++ b/templates/profiles.yaml.template
@@ -20,3 +20,31 @@ adapters:
     state: available
   github.actions:
     state: available
+
+# Non-authoritative detection policy. Matching rules create review proposals only.
+proposal_rules:
+  python-pyproject:
+    profile: python
+    confidence: 0.95
+    priority: 10
+    any_paths: [pyproject.toml]
+  node-package-json:
+    profile: nodejs
+    confidence: 0.95
+    priority: 10
+    any_paths: [package.json]
+  terraform-files:
+    profile: terraform
+    confidence: 0.9
+    priority: 10
+    any_paths: ["*.tf", "**/*.tf"]
+  documentation-site:
+    profile: documentation
+    confidence: 0.85
+    priority: 10
+    any_paths: [mkdocs.yml, "docs/**"]
+  claude-plugin-layout:
+    profile: claude-plugin
+    confidence: 1.0
+    priority: 20
+    all_paths: [.claude-plugin/plugin.json, "skills/*/SKILL.md"]

--- a/templates/workflows/fleet-watch.yaml
+++ b/templates/workflows/fleet-watch.yaml
@@ -1,0 +1,32 @@
+# Reconcile live organization membership with the workspace catalog.
+name: fleet-watch
+description: Detect repository creation, rename, transfer, archival, and profile proposals
+enabled: true
+auto: false
+
+headless:
+  enabled: true
+  on_ask: record
+  on_mutation: propose
+
+trigger:
+  type: session_poll
+  source: org_repos
+  condition: state_changed
+
+params:
+  apply_catalog:
+    description: Apply stable repository facts to workspace config
+    type: boolean
+    default: false
+
+state: {}
+
+workflow: |
+  RECONCILE:
+    INVOKE skill hiivmind-pulse-gh:gh-fleet-membership-headless
+      WITH workspace_path=workspace_root,
+           apply_catalog=params.apply_catalog,
+           mode=scheduled
+
+cooldown_minutes: 60


### PR DESCRIPTION
## What changed

- add the `fleet-membership` headless result contract and validator support
- reconcile live organization repositories with the workspace catalog by GitHub node ID
- detect creation, rename, transfer, archival, exclusion, missing repositories, and legacy identity backfills
- add conservative discovery policy for archived repositories, forks, and mirrors
- add declarative evidence-to-profile proposal rules without changing authoritative profiles
- add an organization membership signature source to session polling and a `fleet-watch` workflow
- add the zero-prompt fleet membership skill with an explicit catalog-only apply boundary
- add conflict-safe, atomic profile confirmation through expected-scorecard compare-and-swap

## Why

Every fleet workflow inherits the workspace repository catalog. Without generic membership reconciliation, a new, renamed, archived, or transferred repository silently falls outside later audits. Classification also needs to remain evidence-backed and reviewable so Python, Node, infrastructure, documentation, and plugin repositories are not forced through one dogfooding model.

## Safety and architecture

- GitHub node ID is the rename/transfer-stable identity
- incomplete API records fail instead of inventing catalog facts
- catalog application writes only stable repository metadata and never profile guesses
- forks and mirrors are excluded by default; archived repositories remain explicit facts by default
- profile candidates are deterministic, rule-defined, and non-authoritative
- inferred explanations cannot alter candidate membership or order
- labels, milestones, schedulers, governance, and checklists remain outside F2
- profile confirmation is atomic, idempotent, and conflict-detecting; callers own commits and PRs

## Validation

- `uv run pytest -q` — 141 passed
- strict load of `templates/profiles.yaml.template`
- `git diff --check develop...HEAD`

## Base

Targets `develop`, which already contains merged F0 Nave evidence and F1 profile/scorecard foundations.
