### PR TITLE
F5: generic impact bindings and branch currency

### DIFF
--- a/lib/patterns/headless-contract.md
+++ b/lib/patterns/headless-contract.md
@@ -272,7 +272,8 @@ edges:                                 # list, required (may be empty) — one e
     remote_head: <str or null>        # required key, nullable — resolved watch_branch head, null if unreachable
     changed_paths: [<str>, ...]       # list, required (may be empty) — watch_paths hits between tested_sha and remote_head
 findings:                             # list, required (may be empty) — typed data, not prose
-  - kind: <str>                       # required, e.g. integration-drift, unconfigured_edge
+  - kind: <str>                       # required, e.g. integration-drift, unconfigured_edge,
+                                       #   empty_watch_paths
     repo: <owner/name>                # str, required
     severity: low | medium | high     # required enum
     detail: <str>                     # optional human-readable
@@ -302,6 +303,12 @@ on the machine running the audit. A missing or unreachable
 `integration_tested_sha` (edge points at a SHA the audit cannot resolve)
 blocks closed as `state: unknown`, not `current` — an unauditable edge is
 never silently treated as safe.
+
+An object edge with an empty or missing `watch_paths[]` is the same kind of
+unauditable-by-construction edge: no path evidence can ever mark it stale,
+so it blocks closed too — `state: unknown` plus an `empty_watch_paths`
+finding (`severity: low`) — rather than defaulting to `current` for lack of
+any hits to report.
 
 ## Related patterns
 

--- a/lib/patterns/headless-contract.md
+++ b/lib/patterns/headless-contract.md
@@ -13,6 +13,7 @@ retained for human-readable logs only — orchestrators MUST read the file.
 | fleet-membership | fleet-membership-result.yaml | `{workspace_root}/.hiivmind/github/fleet-membership-result.yaml` |
 | refresh | refresh-result.yaml | `{workspace_root}/.hiivmind/github/refresh-result.yaml` |
 | workflow-run | workflow-run-result.yaml | `{workspace_root}/.hiivmind/github/workflow-run-result.yaml` |
+| impact | impact-result.yaml | `{workspace_root}/.hiivmind/github/impact-result.yaml` |
 
 Result files are per-machine transient run artifacts (never authority — see
 `workspace-detection.md` § Multi-machine topology). The workspace repo's
@@ -32,7 +33,7 @@ not kinds they were not asked to validate.
 
 ```yaml
 contract_version: 1                   # int, required
-kind: status | healthcheck | fleet-membership | refresh | workflow-run
+kind: status | healthcheck | fleet-membership | refresh | workflow-run | impact
 workspace: <login>                    # str, required — org/user login
 run_at: <ISO 8601 timestamp>          # str, required
 actor:                                # required on ALL kinds (I4)
@@ -53,6 +54,7 @@ profiles, and machines: identity-sensitive logic resolves against the
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py fleet-membership-result.yaml --kind fleet-membership
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py refresh-result.yaml --kind refresh
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py workflow-run-result.yaml --kind workflow-run
+    uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py impact-result.yaml --kind impact
 
 Orchestrators validate before consuming and treat exit 1/2 as a failed run
 (report, do not commit). Exit codes: 0 valid, 1 invalid (errors on stderr),
@@ -242,6 +244,64 @@ errors: []
 `inferred: true`, `proposed_actions`, and `asks_recorded` are the items
 needing human judgment — orchestrators surface them under a "Needs attention"
 heading (P5.4) instead of burying them in logs.
+
+### impact-result.yaml (written by the impact audit, F5)
+
+Reports path-scoped integration currency over `repo_dependencies` object
+edges (`lib/references/config-schema.md` § depends_on edges). Currency is
+`git diff integration_tested_sha..<watch_branch head> -- watch_paths`,
+computed deterministically by `impact.py`; only *severity* (breaking vs.
+additive) is LLM-judged, as an `inferred: true` finding — inference never
+changes an edge's `state`.
+
+```yaml
+contract_version: 1
+kind: impact
+workspace: <login>
+run_at: <ISO 8601>
+actor: { gh_login: <str>, machine: <str>, mode: <enum> }
+edges_checked: <int>                  # required — must equal len(edges)
+edges_stale: <int>                    # required — must equal count of edges with state: stale
+markers_updated: <int>                # required, non-negative — integration_tested_sha markers rewritten this run
+edges:                                 # list, required (may be empty) — one entry per configured object edge
+  - dependent: <owner/name>           # str, required — the repo carrying the depends_on entry
+    upstream: <owner/name>            # str, required — the repo field of the edge
+    watch_branch: <str>               # str, required
+    state: current | stale | unknown  # required enum — unknown covers missing/unreachable baseline
+    tested_sha: <str or null>         # required key, nullable — the edge's integration_tested_sha
+    remote_head: <str or null>        # required key, nullable — resolved watch_branch head, null if unreachable
+    changed_paths: [<str>, ...]       # list, required (may be empty) — watch_paths hits between tested_sha and remote_head
+findings:                             # list, required (may be empty) — typed data, not prose
+  - kind: <str>                       # required, e.g. integration-drift, unconfigured_edge
+    repo: <owner/name>                # str, required
+    severity: low | medium | high     # required enum
+    detail: <str>                     # optional human-readable
+    ref: { type: <str>, id: <any>, url: <str> }   # optional locator
+    inferred: <bool>                  # optional — true when severity was LLM-judged
+proposed_actions: [<str>, ...]        # list, required — tracking issues/dispatches a headless run declined to apply directly
+asks_recorded: [<str>, ...]           # list, required — ASKs that had no user
+errors: []
+```
+
+Duplicate `(dependent, upstream, watch_branch)` identities are rejected —
+each configured edge contributes exactly one `edges[]` entry per run.
+`edges_checked` and `edges_stale` are reconciled against the `edges` list the
+same way healthcheck reconciles repo score/grade against `checks`; a result
+cannot forge a stale count that disagrees with its own evidence.
+
+Legacy plain-string `depends_on` entries (pre-F5 shape, no watch metadata)
+are not audited for currency — they never produce an `edges[]` entry.
+Instead, each one surfaces as an `unconfigured_edge` finding on the
+dependent repo (`severity: low`) so unmigrated edges stay visible without
+blocking the audit or fabricating a current/stale verdict for data the
+edge doesn't carry.
+
+Local working-tree content is never a binding side: both `tested_sha` and
+`remote_head` are committed/remote-published refs, never uncommitted state
+on the machine running the audit. A missing or unreachable
+`integration_tested_sha` (edge points at a SHA the audit cannot resolve)
+blocks closed as `state: unknown`, not `current` — an unauditable edge is
+never silently treated as safe.
 
 ## Related patterns
 

--- a/lib/patterns/run-ledger.md
+++ b/lib/patterns/run-ledger.md
@@ -81,8 +81,24 @@ next        --file LEDGER                   → JSON {status, runnable[], blocke
 update      --file LEDGER --step ID --status S
             [--actor-login L --actor-machine M] [--note TEXT]
 gate-result --file LEDGER --step ID --satisfied true|false [--note TEXT]
+check-gate  --file LEDGER --step ID --result FILE --gate-type TYPE
+                                             → deterministic evaluator counterpart to
+                                               gate-result: reads a headless result file
+                                               (lib/patterns/headless-contract.md), fails
+                                               closed on missing/malformed/non-conforming
+                                               evidence, records the verdict the same way,
+                                               prints JSON {satisfied, detail}
 lease       --file LEDGER --step ID --by WHO [--ttl-minutes 120]
 ```
+
+`gate-result` is for prose gates a human/LLM adjudicates against live GitHub
+state. `check-gate` is for gates a registered evaluator can compute
+deterministically from an already-validated result file — e.g.
+`binding_edges_current` (F5) reads an `impact-result.yaml` and is satisfied
+only when it validates as kind `impact` with `edges_stale == 0` and no edge
+in state `unknown`. New evaluators register by name in `resolve_run.py`'s
+`GATE_EVALUATORS`; `--gate-type` naming an evaluator that isn't registered is
+a usage error (exit 1), never silently treated as satisfied.
 
 Exit codes: 0 ok, 1 validation/state error, 2 file missing/unparseable,
 3 lease actively held by someone else.

--- a/lib/patterns/workflow-execution.md
+++ b/lib/patterns/workflow-execution.md
@@ -355,6 +355,53 @@ UTC `HHMMSS` at run start — actor-embedded so concurrent machines cannot colli
 
 ---
 
+## Marker Advancement from Workflow-Run Evidence (F5)
+
+`repo_dependencies.*.depends_on[]` object edges (`lib/references/config-schema.md`
+§ depends_on edges) may configure `integration_workflow`: the name of the
+workflow whose **successful run** is the dependent's evidence that it has
+validated against the upstream repo's current state. Closing that loop —
+turning a successful run into an `integration_tested_sha` marker update — is
+`lib/pulse/scripts/impact.py`'s `propose_marks()` / `apply_proposals()`, not
+this executor. This section states the contract so callers know when to
+invoke it; it does not re-describe execution steps (see Single Executor,
+above).
+
+**Dispatch alone never advances a marker.** Triggering `integration_workflow`
+— via a workflow's `proposed_actions` dispatch proposal, a headless run, or
+an interactive one — is not evidence of anything; only a subsequent
+*successful* run is. A `headless: on_mutation: propose` workflow that
+proposes dispatching `integration_workflow` (as `gh-impact-audit-headless`
+does, per Task 4) is explicitly not a marker write, and must not be treated
+as one by any caller.
+
+**How a caller closes the loop:**
+
+1. Obtain run evidence for the configured `integration_workflow` — e.g. from
+   `workflow-run-result.yaml` (`lib/patterns/headless-contract.md` §
+   workflow-run-result.yaml) after that workflow runs, or from any other
+   source of `{workflow, repo, outcome, head_sha, tested_at}` records (see
+   `propose_marks()`'s docstring for the exact evidence item shape — `repo`
+   and `head_sha` are per-repo since a run's `repos:` list can span more than
+   one).
+2. Call `propose_marks(relationships, run_evidence)`. It joins each
+   configured edge's `integration_workflow`/`repo` against the evidence and
+   proposes an advancement **only** when the matching evidence item's
+   `outcome == "success"` — `failure`, `aborted`, and `skipped-cooldown` all
+   propose nothing, and an edge with no `integration_workflow` configured (or
+   a legacy string edge) is never eligible regardless of evidence.
+3. Call `apply_proposals(relationships_path, proposals)` (or `mark()`
+   directly per proposal) to write. Each write is expected-base guarded and
+   idempotent per `mark()`'s existing contract — a proposal built from a
+   stale in-memory view surfaces as `conflict`, not a silent overwrite.
+
+Severity inference (breaking vs. additive, `lib/patterns/headless-contract.md`
+§ impact-result.yaml) is orthogonal and out of scope here: it may annotate an
+edge's findings but never changes `state`, and has no bearing on whether a
+marker advances.
+
+---
+
 ## Cooldown Check
 
 Before executing any workflow (skip when the context has `enforce_cooldown: false`):

--- a/lib/pulse/scripts/impact.py
+++ b/lib/pulse/scripts/impact.py
@@ -334,6 +334,109 @@ def mark(path: Path | str, dependent: str, upstream: str, expected_sha: str,
 
 
 # --------------------------------------------------------------------------
+# propose_marks() / apply_proposals() — close the validation loop
+# --------------------------------------------------------------------------
+#
+# Dispatch alone is never evidence of currency (see Task 4 report and
+# `lib/patterns/workflow-execution.md` § Marker Advancement from Workflow-Run
+# Evidence). Only a SUCCESSFUL run of the edge's *configured*
+# `integration_workflow`, evaluated against the edge's *upstream repo*,
+# proposes marker advancement. Everything else — failure, in-progress/aborted,
+# cooldown-skipped, an unrelated workflow, an edge with no
+# `integration_workflow` configured, or a legacy string edge — proposes
+# nothing.
+#
+# `run_evidence` items are grounded in the workflow-run-result.yaml contract
+# (`lib/patterns/headless-contract.md` § workflow-run-result.yaml): `workflow`
+# and `outcome` reuse that contract's field names and `outcome` enum
+# (success | failure | skipped-cooldown | aborted) verbatim. `repos` on that
+# contract is a list (a run can span repos); a proposal is evaluated per
+# upstream repo, so evidence here is per-repo: `repo` (one entry of that
+# list) and `head_sha` (the commit on `repo` that the run validated — not a
+# field the workflow-run contract carries today, since it has no per-repo SHA
+# concept; a caller adapting a workflow-run-result.yaml into evidence supplies
+# it from the run's known head). `tested_at` carries through to the proposal
+# and, ultimately, to `mark()`'s `tested_at` argument.
+#
+#   run_evidence item shape:
+#     {
+#       "workflow": <str>,     # workflow identifier, e.g. "ci.yml"
+#       "repo": <str>,         # owner/name of the repo the run validated
+#       "outcome": <str>,      # success | failure | skipped-cooldown | aborted
+#       "head_sha": <str>,     # commit on `repo` validated by this run
+#       "tested_at": <str>,    # ISO 8601 timestamp
+#     }
+
+@dataclass(frozen=True)
+class MarkProposal:
+    dependent: str
+    upstream: str
+    expected_sha: str | None
+    new_sha: str
+    tested_at: str
+
+
+def propose_marks(relationships: dict, run_evidence: list[dict]) -> list[MarkProposal]:
+    """Join configured object edges to workflow-run evidence and propose
+    exact expected-base `mark` calls. Pure: no I/O, no mutation — a proposal
+    only becomes a write via `apply_proposals`/`mark`.
+
+    An edge proposes advancement only when ALL hold:
+      - the edge is an object edge (legacy string edges carry no
+        `integration_workflow` and are never proposed)
+      - the edge configures `integration_workflow`
+      - a `run_evidence` item's `workflow` matches that configured value
+      - that same item's `repo` matches the edge's upstream `repo`
+      - that same item's `outcome` == "success" (failure, aborted, and
+        skipped-cooldown are all non-evidence — dispatch/attempt alone never
+        advances a marker)
+
+    `expected_sha` is the edge's *current* `integration_tested_sha` at
+    proposal time (the exact base `mark()` must still see for the write to
+    apply) and `new_sha` is the evidence's validated `head_sha`.
+    """
+    proposals: list[MarkProposal] = []
+    repo_dependencies = (relationships or {}).get("repo_dependencies") or {}
+
+    for dependent, entry in repo_dependencies.items():
+        for depends_on in (entry or {}).get("depends_on") or []:
+            if not isinstance(depends_on, dict):
+                continue  # legacy string edge: no watch/workflow metadata
+            configured_workflow = depends_on.get("integration_workflow")
+            if not configured_workflow:
+                continue
+            upstream = depends_on.get("repo")
+            for evidence in run_evidence:
+                if evidence.get("outcome") != "success":
+                    continue
+                if evidence.get("workflow") != configured_workflow:
+                    continue
+                if evidence.get("repo") != upstream:
+                    continue
+                proposals.append(MarkProposal(
+                    dependent=dependent,
+                    upstream=upstream,
+                    expected_sha=depends_on.get("integration_tested_sha"),
+                    new_sha=evidence["head_sha"],
+                    tested_at=evidence["tested_at"],
+                ))
+
+    return proposals
+
+
+def apply_proposals(path: Path | str, proposals: list[MarkProposal]) -> list[MarkerResult]:
+    """Apply each proposal via `mark()`, in order. Each call is independently
+    expected-base guarded and idempotent — a conflict or not_found on one
+    proposal does not block the rest. Returns one `MarkerResult` per
+    proposal, in the same order."""
+    return [
+        mark(path, proposal.dependent, proposal.upstream,
+             proposal.expected_sha, proposal.new_sha, proposal.tested_at)
+        for proposal in proposals
+    ]
+
+
+# --------------------------------------------------------------------------
 # CLI (thin — orchestration lives in the calling skill/script)
 # --------------------------------------------------------------------------
 

--- a/lib/pulse/scripts/impact.py
+++ b/lib/pulse/scripts/impact.py
@@ -24,6 +24,11 @@ Binding rules (see F5 phase doc for the full rationale):
     metadata) produce an `unconfigured_edge` finding (severity low)
     instead of an edges[] verdict — the audit cannot determine their
     currency.
+  - An object edge with an empty or missing `watch_paths[]` is
+    misconfigured the same way: no path evidence can ever mark it stale,
+    so it must not silently classify as `current`. It still produces an
+    `edges[]` entry (state `unknown`), plus an `empty_watch_paths`
+    finding (severity low) — misconfiguration fails closed, not open.
   - Severity inference (breaking vs. additive) is out of scope for this
     module: findings default to a deterministic severity and
     `inferred: False`. An LLM-judgment pass may annotate `severity` and set
@@ -181,16 +186,31 @@ def _branch_snapshot(snapshot: dict, repo: str, branch: str) -> dict | None:
     return repo_snap.get(branch)
 
 
-def _audit_edge(dependent: str, edge_config: dict, snapshot: dict) -> EdgeResult:
+def _audit_edge(dependent: str, edge_config: dict,
+                 snapshot: dict) -> tuple[EdgeResult, Finding | None]:
     upstream = edge_config["repo"]
     watch_branch = edge_config["watch_branch"]
     watch_paths = edge_config.get("watch_paths") or []
     tested_sha = edge_config.get("integration_tested_sha")
 
+    if not watch_paths:
+        finding = Finding(
+            kind="empty_watch_paths",
+            repo=dependent,
+            severity="low",
+            detail=(
+                f"depends_on edge to '{upstream}' on branch '{watch_branch}' has no "
+                "watch_paths configured; impact audit cannot determine currency"
+            ),
+            inferred=False,
+        )
+        return EdgeResult(dependent, upstream, watch_branch, "unknown",
+                           tested_sha, None, []), finding
+
     branch_snap = _branch_snapshot(snapshot, upstream, watch_branch)
     if branch_snap is None:
         return EdgeResult(dependent, upstream, watch_branch, "unknown",
-                           tested_sha, None, [])
+                           tested_sha, None, []), None
 
     remote_head = branch_snap.get("head")
     changed_files_by_base = branch_snap.get("changed_files_by_base") or {}
@@ -203,12 +223,12 @@ def _audit_edge(dependent: str, edge_config: dict, snapshot: dict) -> EdgeResult
         or tested_sha not in changed_files_by_base
     ):
         return EdgeResult(dependent, upstream, watch_branch, "unknown",
-                           tested_sha, remote_head, [])
+                           tested_sha, remote_head, []), None
 
     changed_paths = _matched_paths(changed_files_by_base[tested_sha], watch_paths)
     state = "stale" if changed_paths else "current"
     return EdgeResult(dependent, upstream, watch_branch, state,
-                       tested_sha, remote_head, changed_paths)
+                       tested_sha, remote_head, changed_paths), None
 
 
 def audit(relationships: dict, snapshot: dict) -> ImpactReport:
@@ -235,7 +255,10 @@ def audit(relationships: dict, snapshot: dict) -> ImpactReport:
                     inferred=False,
                 ))
                 continue
-            edges.append(_audit_edge(dependent, depends_on, snapshot))
+            edge_result, empty_watch_paths_finding = _audit_edge(dependent, depends_on, snapshot)
+            edges.append(edge_result)
+            if empty_watch_paths_finding is not None:
+                findings.append(empty_watch_paths_finding)
 
     return ImpactReport(edges=edges, findings=findings)
 

--- a/lib/pulse/scripts/impact.py
+++ b/lib/pulse/scripts/impact.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Pure path-scoped integration-currency audit (F5).
+
+No network, no git commands here — this module consumes a pre-collected
+`snapshot` data structure (built by a separate collector, see F5 Task 3) and
+the `repo_dependencies` section of a relationships config, and classifies
+each configured object edge (`lib/references/config-schema.md` § depends_on
+edges) as `current`, `stale`, or `unknown`. See
+`lib/patterns/headless-contract.md` § impact-result.yaml for the result
+shape `ImpactReport.edges` maps onto.
+
+Binding rules (see F5 phase doc for the full rationale):
+  - Currency is `git diff tested_sha..remote_head -- watch_paths`, computed
+    here from pre-collected changed-file evidence, never git directly.
+  - `integration_tested_sha` is committed shared state; local working-tree
+    content is never a binding side.
+  - A missing or unreachable baseline blocks closed: `state: unknown`,
+    never `current`.
+  - Legacy string `depends_on[]` entries (bare repo name, no watch
+    metadata) produce an `unconfigured_edge` finding (severity low)
+    instead of an edges[] verdict — the audit cannot determine their
+    currency.
+  - Severity inference (breaking vs. additive) is out of scope for this
+    module: findings default to a deterministic severity and
+    `inferred: False`. An LLM-judgment pass may annotate `severity` and set
+    `inferred: True` later, but must never change `state`.
+
+Snapshot shape (produced by the F5 Task 3 collector, consumed verbatim
+here):
+
+    {
+      "<repo>": {
+        "<branch>": {
+          "head": "<sha>" | None,             # resolved branch head
+          "changed_files_by_base": {
+            "<base_sha>": ["<path>", ...],     # files changed base..head
+          },
+          "base_missing": ["<base_sha>", ...], # bases that could not be
+                                                # resolved/diffed (e.g. the
+                                                # commit doesn't exist on
+                                                # the remote)
+        }
+      }
+    }
+
+A base is treated as unreachable/missing — and the edge as `unknown` — if
+it is absent from `changed_files_by_base` entirely, or listed in
+`base_missing`, or the repo/branch itself is absent from the snapshot.
+
+Watch-path glob semantics (`watch_paths[]`, matched against snapshot
+changed-file paths, POSIX-style forward-slash paths):
+  - `?` matches exactly one character, never `/`.
+  - `*` matches zero or more characters within a single path segment
+    (never crosses a `/`).
+  - `**/` matches zero or more whole path segments, so `lib/**/*.py`
+    matches both `lib/a/b/c.py` and (zero segments) `lib/top.py`. A
+    trailing `/**` likewise matches zero or more trailing segments. A
+    bare `**` watch_path matches every path — i.e. "watch the whole
+    tree".
+  - All other characters match literally.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+# --------------------------------------------------------------------------
+# Watch-path glob matching
+# --------------------------------------------------------------------------
+
+_GLOB_CACHE: dict[str, re.Pattern] = {}
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern:
+    """Translate a watch_paths glob (see module docstring) to a compiled
+    regex. `**/` matches zero or more whole path segments (so it also
+    matches zero segments — `a/**/b` matches both `a/b` and `a/x/y/b`);
+    a trailing `/**` similarly matches zero or more trailing segments; a
+    bare `**` (standalone, or a run not anchored by `/` on either side)
+    matches any run of characters including `/`. `*` matches within a
+    single path segment (never crosses `/`); `?` matches one
+    non-separator character; everything else is literal."""
+    if pattern in _GLOB_CACHE:
+        return _GLOB_CACHE[pattern]
+    parts: list[str] = []
+    i = 0
+    n = len(pattern)
+    while i < n:
+        if pattern[i:i + 3] == "**/":
+            parts.append("(?:.*/)?")
+            i += 3
+            continue
+        if pattern[i:i + 3] == "/**" and i + 3 == n:
+            parts.append("(?:/.*)?")
+            i += 3
+            continue
+        if pattern[i:i + 2] == "**":
+            parts.append(".*")
+            i += 2
+            continue
+        c = pattern[i]
+        if c == "*":
+            parts.append("[^/]*")
+            i += 1
+        elif c == "?":
+            parts.append("[^/]")
+            i += 1
+        else:
+            parts.append(re.escape(c))
+            i += 1
+    compiled = re.compile("^" + "".join(parts) + "$")
+    _GLOB_CACHE[pattern] = compiled
+    return compiled
+
+
+def _matches_any(path: str, watch_paths: list[str]) -> bool:
+    return any(_glob_to_regex(pattern).match(path) for pattern in watch_paths)
+
+
+def _matched_paths(changed_files: list[str], watch_paths: list[str]) -> list[str]:
+    """Deterministic file evidence: sorted, deduplicated matches."""
+    hits = {path for path in changed_files if _matches_any(path, watch_paths)}
+    return sorted(hits)
+
+
+# --------------------------------------------------------------------------
+# audit()
+# --------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class EdgeResult:
+    dependent: str
+    upstream: str
+    watch_branch: str
+    state: str  # current | stale | unknown
+    tested_sha: str | None
+    remote_head: str | None
+    changed_paths: list[str] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    repo: str
+    severity: str  # low | medium | high
+    detail: str | None = None
+    ref: dict | None = None
+    inferred: bool = False
+
+
+@dataclass(frozen=True)
+class ImpactReport:
+    edges: list[EdgeResult] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def edges_checked(self) -> int:
+        return len(self.edges)
+
+    @property
+    def edges_stale(self) -> int:
+        return sum(1 for e in self.edges if e.state == "stale")
+
+
+def _branch_snapshot(snapshot: dict, repo: str, branch: str) -> dict | None:
+    repo_snap = snapshot.get(repo)
+    if not repo_snap:
+        return None
+    return repo_snap.get(branch)
+
+
+def _audit_edge(dependent: str, edge_config: dict, snapshot: dict) -> EdgeResult:
+    upstream = edge_config["repo"]
+    watch_branch = edge_config["watch_branch"]
+    watch_paths = edge_config.get("watch_paths") or []
+    tested_sha = edge_config.get("integration_tested_sha")
+
+    branch_snap = _branch_snapshot(snapshot, upstream, watch_branch)
+    if branch_snap is None:
+        return EdgeResult(dependent, upstream, watch_branch, "unknown",
+                           tested_sha, None, [])
+
+    remote_head = branch_snap.get("head")
+    changed_files_by_base = branch_snap.get("changed_files_by_base") or {}
+    base_missing = set(branch_snap.get("base_missing") or [])
+
+    if (
+        remote_head is None
+        or tested_sha is None
+        or tested_sha in base_missing
+        or tested_sha not in changed_files_by_base
+    ):
+        return EdgeResult(dependent, upstream, watch_branch, "unknown",
+                           tested_sha, remote_head, [])
+
+    changed_paths = _matched_paths(changed_files_by_base[tested_sha], watch_paths)
+    state = "stale" if changed_paths else "current"
+    return EdgeResult(dependent, upstream, watch_branch, state,
+                       tested_sha, remote_head, changed_paths)
+
+
+def audit(relationships: dict, snapshot: dict) -> ImpactReport:
+    """Classify every configured `depends_on[]` object edge as
+    current/stale/unknown from pre-collected snapshot evidence. Pure: no
+    network, no git commands. Legacy string edges produce an
+    `unconfigured_edge` finding instead of an edges[] verdict."""
+    edges: list[EdgeResult] = []
+    findings: list[Finding] = []
+
+    repo_dependencies = (relationships or {}).get("repo_dependencies") or {}
+    for dependent, entry in repo_dependencies.items():
+        for depends_on in (entry or {}).get("depends_on") or []:
+            if isinstance(depends_on, str):
+                findings.append(Finding(
+                    kind="unconfigured_edge",
+                    repo=dependent,
+                    severity="low",
+                    detail=(
+                        f"legacy string depends_on edge to '{depends_on}' "
+                        "carries no watch metadata; impact audit cannot "
+                        "determine currency"
+                    ),
+                    inferred=False,
+                ))
+                continue
+            edges.append(_audit_edge(dependent, depends_on, snapshot))
+
+    return ImpactReport(edges=edges, findings=findings)
+
+
+# --------------------------------------------------------------------------
+# mark()
+# --------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class MarkerResult:
+    status: str  # updated | noop | conflict | not_found
+    dependent: str
+    upstream: str
+    previous_sha: str | None
+    new_sha: str | None
+    detail: str | None = None
+
+
+def _find_edge(config: dict, dependent: str, upstream: str) -> dict | None:
+    entry = ((config.get("repo_dependencies") or {}).get(dependent)) or {}
+    for depends_on in entry.get("depends_on") or []:
+        if isinstance(depends_on, dict) and depends_on.get("repo") == upstream:
+            return depends_on
+    return None
+
+
+def _atomic_write_yaml(path: Path, data: dict) -> None:
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_name = handle.name
+            yaml.safe_dump(data, handle, sort_keys=False, allow_unicode=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_name, path)
+    except OSError:
+        if temporary_name:
+            try:
+                Path(temporary_name).unlink()
+            except OSError:
+                pass
+        raise
+
+
+def mark(path: Path | str, dependent: str, upstream: str, expected_sha: str,
+          new_sha: str, tested_at: str) -> MarkerResult:
+    """Patch `integration_tested_sha` (and `tested_at`) on the
+    `repo_dependencies.<dependent>.depends_on[]` edge whose `repo` ==
+    `upstream`, atomically (write temp + rename) and expected-base guarded:
+
+      - current marker == expected_sha  -> apply, status "updated".
+      - current marker == new_sha already (the update was already applied,
+        e.g. a repeated call with the same arguments) -> no write,
+        status "noop". This is what makes repeat calls with the same
+        arguments idempotent.
+      - anything else (current marker differs from both expected_sha and
+        new_sha) -> conflict, no write.
+      - dependent/upstream edge not found, or matched entry is a legacy
+        string edge -> not_found, no write.
+
+    Comment/structure preservation: this rewrites the file via
+    yaml.safe_load/yaml.safe_dump, the same approach `fleet_membership.py`
+    uses for its config patches — PyYAML does not round-trip comments, and
+    no comment-preserving YAML library (e.g. ruamel.yaml) is a dependency
+    elsewhere in this codebase, so a full structural rewrite (not an
+    in-place comment-preserving edit) is the consistent choice here.
+    """
+    path = Path(path)
+    config = yaml.safe_load(path.read_text()) or {}
+
+    edge = _find_edge(config, dependent, upstream)
+    if edge is None:
+        return MarkerResult("not_found", dependent, upstream, None, None,
+                             detail=f"no object depends_on edge {dependent} -> {upstream}")
+
+    current_sha = edge.get("integration_tested_sha")
+
+    if current_sha == new_sha:
+        return MarkerResult("noop", dependent, upstream, current_sha, new_sha,
+                             detail="marker already at new_sha; no write")
+
+    if current_sha != expected_sha:
+        return MarkerResult("conflict", dependent, upstream, current_sha, new_sha,
+                             detail=f"expected base {expected_sha!r} but found {current_sha!r}")
+
+    edge["integration_tested_sha"] = new_sha
+    edge["tested_at"] = tested_at
+    _atomic_write_yaml(path, config)
+    return MarkerResult("updated", dependent, upstream, current_sha, new_sha)
+
+
+# --------------------------------------------------------------------------
+# CLI (thin — orchestration lives in the calling skill/script)
+# --------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    audit_p = sub.add_parser("audit", help="Audit relationships against a snapshot")
+    audit_p.add_argument("--relationships", required=True, type=Path)
+    audit_p.add_argument("--snapshot", required=True, type=Path)
+
+    mark_p = sub.add_parser("mark", help="Patch an integration_tested_sha marker")
+    mark_p.add_argument("--relationships", required=True, type=Path)
+    mark_p.add_argument("--dependent", required=True)
+    mark_p.add_argument("--upstream", required=True)
+    mark_p.add_argument("--expected-sha", required=True)
+    mark_p.add_argument("--new-sha", required=True)
+    mark_p.add_argument("--tested-at", required=True)
+
+    args = parser.parse_args()
+
+    if args.command == "audit":
+        relationships = yaml.safe_load(args.relationships.read_text()) or {}
+        snapshot = json.loads(args.snapshot.read_text())
+        report = audit(relationships, snapshot)
+        print(json.dumps({
+            "edges_checked": report.edges_checked,
+            "edges_stale": report.edges_stale,
+            "edges": [vars(e) for e in report.edges],
+            "findings": [vars(f) for f in report.findings],
+        }, indent=2))
+    elif args.command == "mark":
+        result = mark(args.relationships, args.dependent, args.upstream,
+                       args.expected_sha, args.new_sha, args.tested_at)
+        print(json.dumps(vars(result), indent=2))
+        if result.status in ("conflict", "not_found"):
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/pulse/scripts/impact_snapshot.py
+++ b/lib/pulse/scripts/impact_snapshot.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Remote-evidence collector for the F5 impact audit (F5 Task 3).
+
+Builds the `snapshot` data structure `impact.py::audit()` consumes verbatim
+— see that module's docstring for the exact shape. This module is the only
+place that touches git/network for the impact audit; `impact.py` itself
+stays pure.
+
+Binding rules (mirrors the F5 phase doc; see impact.py for the audit side):
+  - Currency evidence comes from remote refs only. Local working-tree
+    content is never a binding side — this collector never reads a local
+    checkout's working tree, only bare/partial clones of the *remote*
+    branch and base commits.
+  - git is the collector's default and its fallback: branch heads are
+    resolved via `git ls-remote`, and changed-path evidence via a
+    filtered (`--filter=blob:none`) temporary bare fetch plus
+    `git diff --name-only <tested_sha> <head>`. An optional pre-supplied
+    `known_heads` evidence map (e.g. from a cheaper cached source, such as
+    the F0 Nave evidence layer or poll.py's `branch_heads` trigger state)
+    may short-circuit the `git ls-remote` head-resolution round trip, but
+    never substitutes for the git diff itself — changed-path evidence is
+    always computed by this module, never trusted from an external source.
+  - A tested SHA that cannot be fetched/resolved on the remote is recorded
+    in `base_missing` for that repo/branch, never guessed or omitted
+    silently.
+
+All git invocations go through an injectable `runner(argv, cwd) ->
+CompletedProcess-like` seam (`.returncode`, `.stdout`, `.stderr`), so tests
+can run hermetically against a fake runner — no real git process, no
+network. The default runner shells out to the real `git` binary.
+"""
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Callable
+
+import yaml
+
+Runner = Callable[..., "subprocess.CompletedProcess[str] | object"]
+
+
+# --------------------------------------------------------------------------
+# runner
+# --------------------------------------------------------------------------
+
+def default_runner(argv: list[str], cwd: str | Path | None = None):
+    """Real git invocation. Never called from tests — those inject a fake
+    runner instead."""
+    return subprocess.run(
+        argv,
+        cwd=str(cwd) if cwd is not None else None,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+def _failed(result) -> bool:
+    return getattr(result, "returncode", 1) != 0
+
+
+def _lines(result) -> list[str]:
+    stdout = getattr(result, "stdout", "") or ""
+    return [line for line in stdout.splitlines() if line.strip()]
+
+
+# --------------------------------------------------------------------------
+# relationships -> watched edges
+# --------------------------------------------------------------------------
+
+def _edges(relationships: dict):
+    """Yield (upstream_repo, watch_branch, integration_tested_sha) for every
+    object depends_on edge (F5 Task 1 shape). Legacy string edges carry no
+    watch metadata and are skipped — they never resolve to a currency
+    verdict (see impact.py's `unconfigured_edge` finding)."""
+    repo_dependencies = (relationships or {}).get("repo_dependencies") or {}
+    for entry in repo_dependencies.values():
+        for depends_on in (entry or {}).get("depends_on") or []:
+            if not isinstance(depends_on, dict):
+                continue
+            repo = depends_on.get("repo")
+            branch = depends_on.get("watch_branch")
+            if repo and branch:
+                yield repo, branch, depends_on.get("integration_tested_sha")
+
+
+def _watched_bases(relationships: dict) -> dict[tuple[str, str], set[str]]:
+    """Every watched (repo, branch) mapped to the union of tested_sha values
+    any dependent has recorded against it. A branch with no tested_sha yet
+    (edge never marked) still gets a snapshot entry with an empty base set,
+    so its `head` is available once the edge is first marked."""
+    grouped: dict[tuple[str, str], set[str]] = {}
+    for repo, branch, tested_sha in _edges(relationships):
+        key = (repo, branch)
+        grouped.setdefault(key, set())
+        if tested_sha:
+            grouped[key].add(tested_sha)
+    return grouped
+
+
+# --------------------------------------------------------------------------
+# git evidence
+# --------------------------------------------------------------------------
+
+def _repo_url(repo: str) -> str:
+    return f"https://github.com/{repo}.git"
+
+
+def _slug(*parts: str) -> str:
+    return re.sub(r"[^A-Za-z0-9._-]", "_", "_".join(parts))
+
+
+def _resolve_head(run: Runner, repo: str, branch: str) -> str | None:
+    result = run(["git", "ls-remote", _repo_url(repo), f"refs/heads/{branch}"], None)
+    if _failed(result):
+        return None
+    lines = _lines(result)
+    if not lines:
+        return None
+    fields = lines[0].split()
+    return fields[0] if fields else None
+
+
+def _collect_branch(run: Runner, base_dir: Path, repo: str, branch: str,
+                     tested_shas: set[str], known_head: str | None) -> dict:
+    url = _repo_url(repo)
+    repo_dir = base_dir / _slug(repo, branch)
+
+    init = run(["git", "init", "--bare", "-q", str(repo_dir)], None)
+    if _failed(init):
+        return {"head": None, "changed_files_by_base": {},
+                 "base_missing": sorted(tested_shas)}
+
+    head = known_head if known_head is not None else _resolve_head(run, repo, branch)
+    if head is None:
+        return {"head": None, "changed_files_by_base": {},
+                 "base_missing": sorted(tested_shas)}
+
+    fetch_head = run(["git", "fetch", "--filter=blob:none", "-q", url, branch], repo_dir)
+    if _failed(fetch_head):
+        return {"head": head, "changed_files_by_base": {},
+                 "base_missing": sorted(tested_shas)}
+
+    changed_files_by_base: dict[str, list[str]] = {}
+    base_missing: list[str] = []
+
+    for tested_sha in sorted(tested_shas):
+        fetch_base = run(["git", "fetch", "--filter=blob:none", "-q", url, tested_sha],
+                          repo_dir)
+        if _failed(fetch_base):
+            base_missing.append(tested_sha)
+            continue
+        diff = run(["git", "diff", "--name-only", tested_sha, head], repo_dir)
+        if _failed(diff):
+            base_missing.append(tested_sha)
+            continue
+        changed_files_by_base[tested_sha] = sorted(set(_lines(diff)))
+
+    return {
+        "head": head,
+        "changed_files_by_base": changed_files_by_base,
+        "base_missing": sorted(base_missing),
+    }
+
+
+@contextlib.contextmanager
+def _workdir_ctx(workdir: str | Path | None):
+    if workdir is not None:
+        path = Path(workdir)
+        path.mkdir(parents=True, exist_ok=True)
+        yield path
+    else:
+        with tempfile.TemporaryDirectory(prefix="pulse-impact-") as tmp:
+            yield Path(tmp)
+
+
+# --------------------------------------------------------------------------
+# collect()
+# --------------------------------------------------------------------------
+
+def collect(relationships: dict, workdir: str | Path | None = None,
+            runner: Runner | None = None,
+            known_heads: dict[str, dict[str, str]] | None = None) -> dict:
+    """Collect the audit snapshot for every watched object depends_on edge
+    in `relationships`. Shape matches `impact.py`'s module docstring
+    exactly: `{repo: {branch: {head, changed_files_by_base, base_missing}}}`.
+
+    `workdir` — directory for the temporary bare clones; a fresh temp dir
+    is created and cleaned up when omitted.
+
+    `runner` — injectable `runner(argv, cwd) -> CompletedProcess-like` git
+    seam; defaults to `default_runner` (real git). Tests always inject a
+    fake.
+
+    `known_heads` — optional pre-resolved `{repo: {branch: head_sha}}`
+    evidence (e.g. poll.py's `branch_heads` trigger state, or a cached F0
+    evidence layer). When a (repo, branch) pair is present here, its head
+    is used directly instead of running `git ls-remote` — this saves a
+    round trip only. The changed-path diff is always computed by this
+    module via git; `known_heads` never supplies path evidence.
+    """
+    run = runner or default_runner
+    known_heads = known_heads or {}
+    watched = _watched_bases(relationships)
+    if not watched:
+        return {}
+
+    snapshot: dict = {}
+    with _workdir_ctx(workdir) as base_dir:
+        for repo, branch in sorted(watched):
+            tested_shas = watched[(repo, branch)]
+            known_head = (known_heads.get(repo) or {}).get(branch)
+            branch_snap = _collect_branch(run, base_dir, repo, branch, tested_shas,
+                                          known_head)
+            snapshot.setdefault(repo, {})[branch] = branch_snap
+    return snapshot
+
+
+# --------------------------------------------------------------------------
+# CLI (thin — orchestration lives in the calling skill/script)
+# --------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--relationships", required=True, type=Path)
+    parser.add_argument("--workdir", type=Path, default=None)
+    parser.add_argument("--known-heads", type=Path, default=None,
+                        help="Optional JSON {repo: {branch: head_sha}} evidence file")
+    args = parser.parse_args()
+
+    relationships = yaml.safe_load(args.relationships.read_text()) or {}
+    known_heads = None
+    if args.known_heads is not None:
+        known_heads = json.loads(args.known_heads.read_text())
+
+    snapshot = collect(relationships, workdir=args.workdir, known_heads=known_heads)
+    print(json.dumps(snapshot, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/pulse/scripts/impact_snapshot.py
+++ b/lib/pulse/scripts/impact_snapshot.py
@@ -24,6 +24,10 @@ Binding rules (mirrors the F5 phase doc; see impact.py for the audit side):
     may short-circuit the `git ls-remote` head-resolution round trip, but
     never substitutes for the git diff itself — changed-path evidence is
     always computed by this module, never trusted from an external source.
+    Likewise the diff endpoint itself is never taken from `known_heads`
+    directly: after fetching the branch, this module resolves the actual
+    fetched tip (`git rev-parse FETCH_HEAD`) and diffs against *that* — a
+    stale cached head must never under-report staleness.
   - A tested SHA that cannot be fetched/resolved on the remote is recorded
     in `base_missing` for that repo/branch, never guessed or omitted
     silently.
@@ -120,8 +124,28 @@ def _slug(*parts: str) -> str:
     return re.sub(r"[^A-Za-z0-9._-]", "_", "_".join(parts))
 
 
+# Config-sourced values (`watch_branch`, `integration_tested_sha`) are never
+# trusted as git argv positionals as-is — a value starting with `-` could be
+# parsed as an option by `git ls-remote`/`git fetch`/`git diff`. Strict regex
+# validation is the primary guard (see module docstring); `git diff` in
+# particular takes two bare revision positionals with no clean place for a
+# `--` separator, so regex validation is its *only* guard. Values that fail
+# validation are never passed to git — they're recorded as missing/failed
+# the same way an unresolvable remote ref would be.
+_SHA_RE = re.compile(r"^[0-9a-fA-F]{7,40}$")
+_BRANCH_RE = re.compile(r"^[^\s-][^\s]*$")
+
+
+def _valid_sha(value: str | None) -> bool:
+    return bool(value) and bool(_SHA_RE.match(value))
+
+
+def _valid_branch(value: str | None) -> bool:
+    return bool(value) and bool(_BRANCH_RE.match(value))
+
+
 def _resolve_head(run: Runner, repo: str, branch: str) -> str | None:
-    result = run(["git", "ls-remote", _repo_url(repo), f"refs/heads/{branch}"], None)
+    result = run(["git", "ls-remote", "--", _repo_url(repo), f"refs/heads/{branch}"], None)
     if _failed(result):
         return None
     lines = _lines(result)
@@ -129,6 +153,19 @@ def _resolve_head(run: Runner, repo: str, branch: str) -> str | None:
         return None
     fields = lines[0].split()
     return fields[0] if fields else None
+
+
+def _resolve_fetched_head(run: Runner, repo_dir: Path) -> str | None:
+    """Resolve the actual tip just fetched into `repo_dir`. This — never a
+    caller-supplied `known_head` — is the diff endpoint and the reported
+    `head`: `known_heads` may only skip the `git ls-remote` round trip, it
+    never substitutes for the true current remote head, which can have
+    moved since the caller's cache was populated."""
+    result = run(["git", "rev-parse", "FETCH_HEAD"], repo_dir)
+    if _failed(result):
+        return None
+    lines = _lines(result)
+    return lines[0].strip() if lines else None
 
 
 def _collect_branch(run: Runner, base_dir: Path, repo: str, branch: str,
@@ -141,21 +178,39 @@ def _collect_branch(run: Runner, base_dir: Path, repo: str, branch: str,
         return {"head": None, "changed_files_by_base": {},
                  "base_missing": sorted(tested_shas)}
 
-    head = known_head if known_head is not None else _resolve_head(run, repo, branch)
-    if head is None:
+    if not _valid_branch(branch):
         return {"head": None, "changed_files_by_base": {},
                  "base_missing": sorted(tested_shas)}
 
-    fetch_head = run(["git", "fetch", "--filter=blob:none", "-q", url, branch], repo_dir)
+    if known_head is not None:
+        head_hint = known_head
+    else:
+        head_hint = _resolve_head(run, repo, branch)
+        if head_hint is None:
+            return {"head": None, "changed_files_by_base": {},
+                     "base_missing": sorted(tested_shas)}
+
+    fetch_head = run(["git", "fetch", "--filter=blob:none", "-q", "--", url, branch], repo_dir)
     if _failed(fetch_head):
-        return {"head": head, "changed_files_by_base": {},
+        return {"head": head_hint, "changed_files_by_base": {},
+                 "base_missing": sorted(tested_shas)}
+
+    # The real diff endpoint: resolved fresh from the fetch just performed,
+    # never trusted from `known_head`/`ls-remote` alone — those may be stale
+    # relative to the tip this fetch actually retrieved.
+    head = _resolve_fetched_head(run, repo_dir)
+    if head is None:
+        return {"head": head_hint, "changed_files_by_base": {},
                  "base_missing": sorted(tested_shas)}
 
     changed_files_by_base: dict[str, list[str]] = {}
     base_missing: list[str] = []
 
     for tested_sha in sorted(tested_shas):
-        fetch_base = run(["git", "fetch", "--filter=blob:none", "-q", url, tested_sha],
+        if not _valid_sha(tested_sha):
+            base_missing.append(tested_sha)
+            continue
+        fetch_base = run(["git", "fetch", "--filter=blob:none", "-q", "--", url, tested_sha],
                           repo_dir)
         if _failed(fetch_base):
             base_missing.append(tested_sha)
@@ -204,10 +259,13 @@ def collect(relationships: dict, workdir: str | Path | None = None,
 
     `known_heads` — optional pre-resolved `{repo: {branch: head_sha}}`
     evidence (e.g. poll.py's `branch_heads` trigger state, or a cached F0
-    evidence layer). When a (repo, branch) pair is present here, its head
-    is used directly instead of running `git ls-remote` — this saves a
-    round trip only. The changed-path diff is always computed by this
-    module via git; `known_heads` never supplies path evidence.
+    evidence layer). When a (repo, branch) pair is present here, `git
+    ls-remote` is skipped — this saves a round trip only. The actual diff
+    endpoint and reported `head` are always resolved fresh from the branch
+    fetch this module performs (`git rev-parse FETCH_HEAD`), never taken
+    from `known_heads` directly: a cached head can be stale relative to the
+    remote's true current tip, and diffing against a stale head would
+    under-report staleness. `known_heads` never supplies path evidence.
     """
     run = runner or default_runner
     known_heads = known_heads or {}
@@ -230,18 +288,28 @@ def collect(relationships: dict, workdir: str | Path | None = None,
 # CLI (thin — orchestration lives in the calling skill/script)
 # --------------------------------------------------------------------------
 
+def _load_known_heads(path: Path) -> dict:
+    """Load a `--known-heads` evidence file. Accepts either YAML or JSON —
+    `yaml.safe_load` parses both (JSON is a YAML subset) — so a caller can
+    hand this a YAML section extracted from poll-state.yaml (e.g.
+    `.state.branch_heads`) or a hand-authored JSON file without caring which
+    serialization it used."""
+    return yaml.safe_load(path.read_text()) or {}
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--relationships", required=True, type=Path)
     parser.add_argument("--workdir", type=Path, default=None)
     parser.add_argument("--known-heads", type=Path, default=None,
-                        help="Optional JSON {repo: {branch: head_sha}} evidence file")
+                        help="Optional YAML or JSON {repo: {branch: head_sha}} evidence "
+                             "file (e.g. poll-state.yaml's .state.branch_heads section)")
     args = parser.parse_args()
 
     relationships = yaml.safe_load(args.relationships.read_text()) or {}
     known_heads = None
     if args.known_heads is not None:
-        known_heads = json.loads(args.known_heads.read_text())
+        known_heads = _load_known_heads(args.known_heads)
 
     snapshot = collect(relationships, workdir=args.workdir, known_heads=known_heads)
     print(json.dumps(snapshot, indent=2, sort_keys=True))

--- a/lib/pulse/scripts/poll.py
+++ b/lib/pulse/scripts/poll.py
@@ -198,6 +198,51 @@ def check_org_repos(config: dict, state: dict) -> bool:
     return isinstance(previous, str) and previous != signature
 
 
+def _branch_head_watches(relationships: dict) -> list[tuple[str, str]]:
+    """Unique (upstream repo, watch_branch) pairs from configured object
+    depends_on edges (F5 Task 1 shape). Legacy string edges carry no watch
+    metadata and are skipped here (they never resolve to a currency verdict,
+    see impact.py)."""
+    pairs: set[tuple[str, str]] = set()
+    repo_dependencies = (relationships or {}).get("repo_dependencies") or {}
+    for entry in repo_dependencies.values():
+        for depends_on in (entry or {}).get("depends_on") or []:
+            if not isinstance(depends_on, dict):
+                continue
+            repo = depends_on.get("repo")
+            branch = depends_on.get("watch_branch")
+            if repo and branch:
+                pairs.add((repo, branch))
+    return sorted(pairs)
+
+
+def check_branch_heads(config_dir: Path, state: dict) -> bool:
+    """Trigger-only branch-head watch for configured impact-audit edges
+    (F5 Task 3). Fetches each watched (repo, branch) head via the gh_api
+    seam and stores it as trigger state `{repo: {branch: head_sha}}` —
+    nothing else. First observation of a (repo, branch) pair baselines
+    without triggering; a later change of a previously-seen head triggers.
+    The actual diff evidence used by the impact audit is collected
+    separately by impact_snapshot.py."""
+    relationships = load_yaml(config_dir / "relationships.yaml")
+    watches = _branch_head_watches(relationships)
+    if not watches:
+        return False
+    slot = state.setdefault("branch_heads", {})
+    changed = False
+    for repo, branch in watches:
+        resp = gh_api(f"/repos/{repo}/git/ref/heads/{branch}") or {}
+        sha = ((resp.get("object") or {}).get("sha"))
+        if not sha:
+            continue
+        repo_slot = slot.setdefault(repo, {})
+        previous = repo_slot.get(branch)
+        repo_slot[branch] = sha
+        if previous is not None and previous != sha:
+            changed = True
+    return changed
+
+
 REPO_CHECKS = {
     "pull_requests": check_pull_requests,
     "issues": check_issues,
@@ -223,6 +268,8 @@ def evaluate_source(source: str, repo: str, config: dict, config_dir: Path,
         changed = check_projects(config, config_dir, state, gold)
     elif source == "org_repos":
         changed = check_org_repos(config, state)
+    elif source == "branch_heads":
+        changed = check_branch_heads(config_dir, state)
     cache[source] = changed
     return changed
 

--- a/lib/pulse/scripts/resolve_run.py
+++ b/lib/pulse/scripts/resolve_run.py
@@ -17,6 +17,10 @@ from pathlib import Path
 
 import yaml
 
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+from lib.pulse.scripts import validate_result as _validate_result  # noqa: E402
+
 LEDGER_VERSION = 1
 STEP_STATUSES = {"pending", "running", "blocked-on-gate", "done", "failed", "skipped"}
 TERMINAL = {"done", "failed", "skipped"}
@@ -195,16 +199,15 @@ def cmd_update(args):
     save(args.file, doc)
 
 
-def cmd_gate_result(args):
-    doc = load(args.file)
-    step = find_step(doc, args.step)
-    if not step.get("gate"):
-        die(f"step {args.step} has no gate")
-    satisfied = args.satisfied == "true"
+def _apply_gate_result(step, satisfied, note=""):
+    """Shared gate-clearing logic for both the externally-adjudicated
+    `gate-result` command (a human/LLM evaluates prose and reports a
+    boolean) and `check-gate` (a registered evaluator computes the boolean
+    deterministically from a result file). Mutates `step` in place."""
     step["gate_satisfied"] = satisfied
     step["gate_checked_at"] = now_iso()
-    if args.note:
-        step["notes"].append(f"{now_iso()} gate: {args.note}")
+    if note:
+        step["notes"].append(f"{now_iso()} gate: {note}")
     if satisfied:
         # A gate-only step (pure checkpoint) completes when its gate clears.
         # A gate+workflow step must still run its workflow block: only clear the
@@ -218,8 +221,96 @@ def cmd_gate_result(args):
             step["finished_at"] = now_iso()
     else:
         step["status"] = "blocked-on-gate"
+
+
+def cmd_gate_result(args):
+    doc = load(args.file)
+    step = find_step(doc, args.step)
+    if not step.get("gate"):
+        die(f"step {args.step} has no gate")
+    satisfied = args.satisfied == "true"
+    _apply_gate_result(step, satisfied, args.note)
     recompute_status(doc)
     save(args.file, doc)
+
+
+# --------------------------------------------------------------------------
+# check-gate: deterministic gate evaluators over headless result files
+# --------------------------------------------------------------------------
+#
+# `gate-result` records an externally-adjudicated verdict (a human or LLM
+# evaluates the step's natural-language `gate` condition and reports true/
+# false). `check-gate` is the deterministic counterpart: a registered
+# evaluator computes the verdict itself from a validated headless result
+# file (see lib/patterns/headless-contract.md), fails closed on any
+# missing/malformed/non-conforming evidence, and records it the same way.
+# New evaluators register in GATE_EVALUATORS by name — this is the generic
+# extension point for future result-driven gates, not a one-off.
+
+def _load_result_kind(path, kind):
+    """Load and schema-validate a headless result file. Never raises —
+    missing files, unparseable YAML, non-mapping documents, and schema
+    violations are all reported as errors so gates built on this helper
+    fail closed on bad evidence instead of crashing the ledger operation.
+    Returns (data, errors); data is None whenever errors is non-empty."""
+    p = Path(path)
+    if not p.exists():
+        return None, [f"result file not found: {p}"]
+    try:
+        raw = yaml.safe_load(p.read_text())
+    except yaml.YAMLError as e:
+        return None, [f"unparseable YAML: {e}"]
+    if not isinstance(raw, dict):
+        return None, ["result is not a mapping"]
+    errors = _validate_result.validate(raw, kind)
+    if errors:
+        return None, errors
+    return raw, []
+
+
+def evaluate_binding_edges_gate(result_path):
+    """`binding_edges_current` — fail-closed release gate over an
+    impact-result.yaml (F5). Satisfied only when the result file is
+    present, validates cleanly as kind `impact`, and every audited edge is
+    current: `edges_stale == 0` and no edge in state `unknown`. A missing
+    file, unparseable/malformed YAML, a schema-invalid result, any stale
+    edge, or any unknown-state edge all fail closed (satisfied=False) —
+    an unauditable or incomplete result is never treated as passing."""
+    data, errors = _load_result_kind(result_path, "impact")
+    if data is None:
+        return False, "; ".join(errors) or "invalid impact result"
+    edges = data.get("edges") or []
+    stale = [e for e in edges if isinstance(e, dict) and e.get("state") == "stale"]
+    unknown = [e for e in edges if isinstance(e, dict) and e.get("state") == "unknown"]
+    if stale or unknown:
+        parts = []
+        if stale:
+            parts.append(f"{len(stale)} stale edge(s)")
+        if unknown:
+            parts.append(f"{len(unknown)} unknown-state edge(s)")
+        return False, "; ".join(parts)
+    return True, f"{len(edges)} edge(s) current"
+
+
+GATE_EVALUATORS = {
+    "binding_edges_current": evaluate_binding_edges_gate,
+}
+
+
+def cmd_check_gate(args):
+    doc = load(args.file)
+    step = find_step(doc, args.step)
+    if not step.get("gate"):
+        die(f"step {args.step} has no gate")
+    evaluator = GATE_EVALUATORS.get(args.gate_type)
+    if evaluator is None:
+        die(f"unknown gate type: {args.gate_type} "
+            f"(known: {', '.join(sorted(GATE_EVALUATORS))})")
+    satisfied, detail = evaluator(args.result)
+    _apply_gate_result(step, satisfied, detail)
+    recompute_status(doc)
+    save(args.file, doc)
+    print(json.dumps({"satisfied": satisfied, "detail": detail}))
 
 
 def cmd_lease(args):
@@ -275,6 +366,14 @@ def main():
     g.add_argument("--satisfied", required=True, choices=["true", "false"])
     g.add_argument("--note", default="")
     g.set_defaults(fn=cmd_gate_result)
+
+    cg = sub.add_parser("check-gate")
+    cg.add_argument("--file", required=True)
+    cg.add_argument("--step", required=True)
+    cg.add_argument("--result", required=True,
+                    help="path to the headless result file the evaluator reads")
+    cg.add_argument("--gate-type", required=True)
+    cg.set_defaults(fn=cmd_check_gate)
 
     l = sub.add_parser("lease")
     l.add_argument("--file", required=True)

--- a/lib/pulse/scripts/tests/fixtures/impact-invalid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/impact-invalid.yaml
@@ -1,0 +1,25 @@
+contract_version: 1
+kind: impact
+workspace: testorg
+run_at: "2026-07-10T09:15:00Z"
+actor:
+  gh_login: octocat
+  machine: mba-m4
+  mode: scheduled
+edges_checked: 5
+edges_stale: 1
+markers_updated: 0
+edges:
+  - dependent: testorg/widget
+    upstream: testorg/core
+    watch_branch: main
+    state: broken
+    tested_sha: abc123
+    remote_head: def456
+    changed_paths: [lib/api.py]
+findings:
+  - kind: integration-drift
+    repo: testorg/widget
+proposed_actions: "not-a-list"
+asks_recorded: []
+errors: []

--- a/lib/pulse/scripts/tests/fixtures/impact-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/impact-valid.yaml
@@ -1,0 +1,35 @@
+contract_version: 1
+kind: impact
+workspace: testorg
+run_at: "2026-07-10T09:15:00Z"
+actor:
+  gh_login: octocat
+  machine: mba-m4
+  mode: scheduled
+edges_checked: 2
+edges_stale: 1
+markers_updated: 0
+edges:
+  - dependent: testorg/widget
+    upstream: testorg/core
+    watch_branch: main
+    state: stale
+    tested_sha: abc123
+    remote_head: def456
+    changed_paths: [lib/api.py]
+  - dependent: testorg/widget
+    upstream: testorg/other
+    watch_branch: develop
+    state: current
+    tested_sha: aaa111
+    remote_head: aaa111
+    changed_paths: []
+findings:
+  - kind: integration-drift
+    repo: testorg/widget
+    severity: medium
+    detail: "core changed lib/api.py since abc123"
+    inferred: false
+proposed_actions: ["open tracking issue testorg/widget#42"]
+asks_recorded: []
+errors: []

--- a/lib/pulse/scripts/tests/test_impact.py
+++ b/lib/pulse/scripts/tests/test_impact.py
@@ -1,0 +1,346 @@
+"""Tests for impact.py — pure path-scoped integration-currency audit."""
+from __future__ import annotations
+
+import yaml
+
+from lib.pulse.scripts.impact import audit, mark
+
+
+def relationships(depends_on):
+    return {
+        "repo_dependencies": {
+            "dependent-repo": {
+                "depends_on": depends_on,
+                "depended_by": [],
+                "relationship_type": "test",
+            }
+        }
+    }
+
+
+def edge(**overrides):
+    e = {
+        "repo": "upstream-repo",
+        "watch_paths": ["lib/foo.py"],
+        "watch_branch": "develop",
+        "integration_tested_sha": "base111",
+        "tested_at": "2026-07-01T10:00:00Z",
+    }
+    e.update(overrides)
+    return e
+
+
+def snapshot_for(head="head999", changed_files_by_base=None, base_missing=None,
+                  repo="upstream-repo", branch="develop"):
+    return {
+        repo: {
+            branch: {
+                "head": head,
+                "changed_files_by_base": changed_files_by_base or {},
+                "base_missing": base_missing or [],
+            }
+        }
+    }
+
+
+# --- audit(): watched vs unwatched changes ---
+
+def test_watched_path_change_marks_edge_stale():
+    rel = relationships([edge(watch_paths=["lib/foo.py"])])
+    snap = snapshot_for(changed_files_by_base={"base111": ["lib/foo.py"]})
+
+    report = audit(rel, snap)
+
+    assert len(report.edges) == 1
+    result = report.edges[0]
+    assert result.dependent == "dependent-repo"
+    assert result.upstream == "upstream-repo"
+    assert result.state == "stale"
+    assert result.changed_paths == ["lib/foo.py"]
+    assert result.tested_sha == "base111"
+    assert result.remote_head == "head999"
+
+
+def test_unwatched_path_change_leaves_edge_current():
+    rel = relationships([edge(watch_paths=["lib/foo.py"])])
+    snap = snapshot_for(changed_files_by_base={"base111": ["docs/readme.md"]})
+
+    report = audit(rel, snap)
+
+    result = report.edges[0]
+    assert result.state == "current"
+    assert result.changed_paths == []
+
+
+def test_no_changes_leaves_edge_current():
+    rel = relationships([edge(watch_paths=["lib/foo.py"])])
+    snap = snapshot_for(changed_files_by_base={"base111": []})
+
+    report = audit(rel, snap)
+
+    assert report.edges[0].state == "current"
+    assert report.edges_stale == 0
+
+
+# --- audit(): ** glob semantics ---
+
+def test_double_star_watches_entire_tree():
+    rel = relationships([edge(watch_paths=["**"])])
+    snap = snapshot_for(changed_files_by_base={"base111": ["any/deeply/nested/file.txt"]})
+
+    report = audit(rel, snap)
+
+    assert report.edges[0].state == "stale"
+    assert report.edges[0].changed_paths == ["any/deeply/nested/file.txt"]
+
+
+def test_nested_double_star_glob_matches_across_directories():
+    rel = relationships([edge(watch_paths=["lib/**/*.py"])])
+    snap = snapshot_for(changed_files_by_base={
+        "base111": ["lib/a/b/c.py", "lib/top.py", "other/x.py"],
+    })
+
+    report = audit(rel, snap)
+
+    assert report.edges[0].state == "stale"
+    # lib/top.py: ** matches zero segments too, so it also hits.
+    assert report.edges[0].changed_paths == ["lib/a/b/c.py", "lib/top.py"]
+
+
+def test_single_star_does_not_cross_directory_boundary():
+    rel = relationships([edge(watch_paths=["lib/*.py"])])
+    snap = snapshot_for(changed_files_by_base={
+        "base111": ["lib/a/nested.py", "lib/top.py"],
+    })
+
+    report = audit(rel, snap)
+
+    assert report.edges[0].state == "stale"
+    assert report.edges[0].changed_paths == ["lib/top.py"]
+
+
+# --- audit(): missing / unreachable baseline blocks closed ---
+
+def test_missing_integration_tested_sha_is_unknown():
+    rel = relationships([edge(integration_tested_sha=None)])
+    snap = snapshot_for(changed_files_by_base={})
+
+    report = audit(rel, snap)
+
+    result = report.edges[0]
+    assert result.state == "unknown"
+    assert result.tested_sha is None
+    assert result.changed_paths == []
+
+
+def test_unreachable_base_sha_is_unknown():
+    rel = relationships([edge(integration_tested_sha="gone123")])
+    snap = snapshot_for(base_missing=["gone123"])
+
+    report = audit(rel, snap)
+
+    result = report.edges[0]
+    assert result.state == "unknown"
+    assert result.tested_sha == "gone123"
+    assert result.remote_head == "head999"
+
+
+def test_base_absent_entirely_from_snapshot_is_unknown():
+    rel = relationships([edge(integration_tested_sha="untouched999")])
+    snap = snapshot_for(changed_files_by_base={"other_base": ["lib/foo.py"]})
+
+    report = audit(rel, snap)
+
+    assert report.edges[0].state == "unknown"
+
+
+def test_repo_absent_from_snapshot_is_unknown():
+    rel = relationships([edge()])
+    snap = {}
+
+    report = audit(rel, snap)
+
+    result = report.edges[0]
+    assert result.state == "unknown"
+    assert result.remote_head is None
+    assert result.tested_sha == "base111"
+
+
+def test_branch_absent_from_snapshot_is_unknown():
+    rel = relationships([edge(watch_branch="develop")])
+    snap = {"upstream-repo": {"main": {"head": "x", "changed_files_by_base": {}, "base_missing": []}}}
+
+    report = audit(rel, snap)
+
+    assert report.edges[0].state == "unknown"
+
+
+def test_unknown_never_reported_as_current_even_with_no_watch_hits():
+    # Regression guard: missing baseline must not silently pass as current
+    # just because there's no path evidence to point to.
+    rel = relationships([edge(integration_tested_sha=None, watch_paths=["**"])])
+    snap = snapshot_for(changed_files_by_base={})
+
+    report = audit(rel, snap)
+
+    assert report.edges[0].state != "current"
+    assert report.edges[0].state == "unknown"
+
+
+# --- audit(): deterministic file evidence ---
+
+def test_changed_paths_are_sorted_and_deduplicated():
+    rel = relationships([edge(watch_paths=["lib/**", "lib/foo.py"])])
+    snap = snapshot_for(changed_files_by_base={
+        "base111": ["lib/foo.py", "lib/zzz.py", "lib/foo.py", "lib/aaa.py"],
+    })
+
+    report = audit(rel, snap)
+
+    assert report.edges[0].changed_paths == ["lib/aaa.py", "lib/foo.py", "lib/zzz.py"]
+
+
+# --- audit(): legacy string edges ---
+
+def test_legacy_string_edge_produces_unconfigured_edge_finding():
+    rel = relationships(["upstream-repo"])
+    snap = snapshot_for()
+
+    report = audit(rel, snap)
+
+    assert report.edges == []
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.kind == "unconfigured_edge"
+    assert finding.repo == "dependent-repo"
+    assert finding.severity == "low"
+    assert finding.inferred is False
+
+
+def test_mixed_legacy_and_object_edges():
+    rel = relationships(["legacy-upstream", edge()])
+    snap = snapshot_for(changed_files_by_base={"base111": ["lib/foo.py"]})
+
+    report = audit(rel, snap)
+
+    assert len(report.edges) == 1
+    assert len(report.findings) == 1
+    assert report.findings[0].kind == "unconfigured_edge"
+
+
+# --- ImpactReport aggregate counters ---
+
+def test_report_counts_reconcile_with_edges():
+    rel = relationships([
+        edge(repo="upstream-a", watch_branch="develop",
+             integration_tested_sha="base111"),
+    ])
+    snap = snapshot_for(repo="upstream-a", changed_files_by_base={"base111": ["lib/foo.py"]})
+
+    report = audit(rel, snap)
+
+    assert report.edges_checked == len(report.edges) == 1
+    assert report.edges_stale == 1
+
+
+def test_empty_relationships_produce_empty_report():
+    report = audit({"repo_dependencies": {}}, {})
+
+    assert report.edges == []
+    assert report.findings == []
+    assert report.edges_checked == 0
+    assert report.edges_stale == 0
+
+
+# --- mark(): expected-base guarded, idempotent, atomic marker patch ---
+
+def make_relationships_file(tmp_path, depends_on):
+    path = tmp_path / "relationships.yaml"
+    path.write_text(yaml.safe_dump(relationships(depends_on), sort_keys=False))
+    return path
+
+
+def test_mark_updates_when_current_matches_expected(tmp_path):
+    path = make_relationships_file(tmp_path, [edge(integration_tested_sha="base111")])
+
+    result = mark(path, "dependent-repo", "upstream-repo",
+                   expected_sha="base111", new_sha="base222",
+                   tested_at="2026-07-19T00:00:00Z")
+
+    assert result.status == "updated"
+    assert result.previous_sha == "base111"
+    assert result.new_sha == "base222"
+
+    on_disk = yaml.safe_load(path.read_text())
+    written_edge = on_disk["repo_dependencies"]["dependent-repo"]["depends_on"][0]
+    assert written_edge["integration_tested_sha"] == "base222"
+    assert written_edge["tested_at"] == "2026-07-19T00:00:00Z"
+
+
+def test_mark_repeat_call_is_idempotent_after_update(tmp_path):
+    path = make_relationships_file(tmp_path, [edge(integration_tested_sha="base111")])
+    args = dict(dependent="dependent-repo", upstream="upstream-repo",
+                expected_sha="base111", new_sha="base222",
+                tested_at="2026-07-19T00:00:00Z")
+
+    first = mark(path, **args)
+    second = mark(path, **args)
+
+    assert first.status == "updated"
+    assert second.status == "noop"
+
+    on_disk = yaml.safe_load(path.read_text())
+    written_edge = on_disk["repo_dependencies"]["dependent-repo"]["depends_on"][0]
+    assert written_edge["integration_tested_sha"] == "base222"
+
+
+def test_mark_conflict_on_mismatched_expected_base_does_not_write(tmp_path):
+    path = make_relationships_file(tmp_path, [edge(integration_tested_sha="base111")])
+    before = path.read_text()
+
+    result = mark(path, "dependent-repo", "upstream-repo",
+                   expected_sha="wrong-base", new_sha="base222",
+                   tested_at="2026-07-19T00:00:00Z")
+
+    assert result.status == "conflict"
+    assert result.previous_sha == "base111"
+    assert path.read_text() == before
+
+
+def test_mark_not_found_for_unknown_edge(tmp_path):
+    path = make_relationships_file(tmp_path, [edge(repo="some-other-upstream")])
+    before = path.read_text()
+
+    result = mark(path, "dependent-repo", "upstream-repo",
+                   expected_sha="base111", new_sha="base222",
+                   tested_at="2026-07-19T00:00:00Z")
+
+    assert result.status == "not_found"
+    assert path.read_text() == before
+
+
+def test_mark_not_found_for_legacy_string_edge(tmp_path):
+    path = make_relationships_file(tmp_path, ["upstream-repo"])
+    before = path.read_text()
+
+    result = mark(path, "dependent-repo", "upstream-repo",
+                   expected_sha="base111", new_sha="base222",
+                   tested_at="2026-07-19T00:00:00Z")
+
+    assert result.status == "not_found"
+    assert path.read_text() == before
+
+
+def test_mark_preserves_other_edges_and_sections(tmp_path):
+    other_edge = edge(repo="other-upstream", integration_tested_sha="untouched")
+    path = make_relationships_file(
+        tmp_path, [edge(integration_tested_sha="base111"), other_edge])
+
+    mark(path, "dependent-repo", "upstream-repo",
+         expected_sha="base111", new_sha="base222",
+         tested_at="2026-07-19T00:00:00Z")
+
+    on_disk = yaml.safe_load(path.read_text())
+    edges = on_disk["repo_dependencies"]["dependent-repo"]["depends_on"]
+    other = next(e for e in edges if e["repo"] == "other-upstream")
+    assert other["integration_tested_sha"] == "untouched"

--- a/lib/pulse/scripts/tests/test_impact.py
+++ b/lib/pulse/scripts/tests/test_impact.py
@@ -200,6 +200,55 @@ def test_changed_paths_are_sorted_and_deduplicated():
     assert report.edges[0].changed_paths == ["lib/aaa.py", "lib/foo.py", "lib/zzz.py"]
 
 
+# --- audit(): empty/missing watch_paths fails closed ---
+
+def test_empty_watch_paths_list_is_unknown_with_finding():
+    rel = relationships([edge(watch_paths=[])])
+    snap = snapshot_for(changed_files_by_base={"base111": ["lib/foo.py"]})
+
+    report = audit(rel, snap)
+
+    assert len(report.edges) == 1
+    result = report.edges[0]
+    assert result.state == "unknown"
+    assert result.changed_paths == []
+
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.kind == "empty_watch_paths"
+    assert finding.repo == "dependent-repo"
+    assert finding.severity == "low"
+    assert finding.inferred is False
+
+
+def test_missing_watch_paths_key_is_unknown_with_finding():
+    edge_config = edge()
+    del edge_config["watch_paths"]
+    rel = relationships([edge_config])
+    snap = snapshot_for(changed_files_by_base={"base111": ["lib/foo.py"]})
+
+    report = audit(rel, snap)
+
+    result = report.edges[0]
+    assert result.state == "unknown"
+    assert result.changed_paths == []
+    assert len(report.findings) == 1
+    assert report.findings[0].kind == "empty_watch_paths"
+
+
+def test_empty_watch_paths_never_reported_as_current_even_with_no_changes():
+    # Regression guard mirroring the missing-baseline case: an edge that can
+    # never be marked stale (no watch_paths to hit) must not default to
+    # current just because there's nothing to point to.
+    rel = relationships([edge(watch_paths=[])])
+    snap = snapshot_for(changed_files_by_base={})
+
+    report = audit(rel, snap)
+
+    assert report.edges[0].state != "current"
+    assert report.edges[0].state == "unknown"
+
+
 # --- audit(): legacy string edges ---
 
 def test_legacy_string_edge_produces_unconfigured_edge_finding():

--- a/lib/pulse/scripts/tests/test_impact.py
+++ b/lib/pulse/scripts/tests/test_impact.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import yaml
 
-from lib.pulse.scripts.impact import audit, mark
+from lib.pulse.scripts.impact import audit, apply_proposals, mark, propose_marks
 
 
 def relationships(depends_on):
@@ -329,6 +329,155 @@ def test_mark_not_found_for_legacy_string_edge(tmp_path):
 
     assert result.status == "not_found"
     assert path.read_text() == before
+
+
+# --- propose_marks(): workflow-run evidence -> exact mark proposal ---
+
+def run_evidence(**overrides):
+    e = {
+        "workflow": "ci.yml",
+        "repo": "upstream-repo",
+        "outcome": "success",
+        "head_sha": "head999",
+        "tested_at": "2026-07-19T00:00:00Z",
+    }
+    e.update(overrides)
+    return e
+
+
+def test_propose_marks_only_configured_successful_workflow_proposes():
+    rel = relationships([edge(integration_workflow="ci.yml",
+                               integration_tested_sha="base111")])
+
+    proposals = propose_marks(rel, [run_evidence()])
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.dependent == "dependent-repo"
+    assert proposal.upstream == "upstream-repo"
+    assert proposal.expected_sha == "base111"
+    assert proposal.new_sha == "head999"
+    assert proposal.tested_at == "2026-07-19T00:00:00Z"
+
+
+def test_propose_marks_failed_run_produces_nothing():
+    rel = relationships([edge(integration_workflow="ci.yml",
+                               integration_tested_sha="base111")])
+
+    proposals = propose_marks(rel, [run_evidence(outcome="failure")])
+
+    assert proposals == []
+
+
+def test_propose_marks_in_progress_run_produces_nothing():
+    rel = relationships([edge(integration_workflow="ci.yml",
+                               integration_tested_sha="base111")])
+
+    proposals = propose_marks(rel, [run_evidence(outcome="aborted")])
+
+    assert proposals == []
+
+
+def test_propose_marks_unrelated_workflow_produces_nothing():
+    rel = relationships([edge(integration_workflow="ci.yml",
+                               integration_tested_sha="base111")])
+
+    proposals = propose_marks(rel, [run_evidence(workflow="other-workflow.yml")])
+
+    assert proposals == []
+
+
+def test_propose_marks_unrelated_repo_produces_nothing():
+    rel = relationships([edge(integration_workflow="ci.yml",
+                               integration_tested_sha="base111")])
+
+    proposals = propose_marks(rel, [run_evidence(repo="some-other-repo")])
+
+    assert proposals == []
+
+
+def test_propose_marks_edge_without_configured_workflow_produces_nothing():
+    rel = relationships([edge(integration_tested_sha="base111")])  # no integration_workflow
+
+    proposals = propose_marks(rel, [run_evidence()])
+
+    assert proposals == []
+
+
+def test_propose_marks_legacy_string_edge_produces_nothing():
+    rel = relationships(["upstream-repo"])
+
+    proposals = propose_marks(rel, [run_evidence()])
+
+    assert proposals == []
+
+
+def test_propose_marks_dispatch_alone_never_advances_markers():
+    # skipped-cooldown means the workflow never actually ran this pass —
+    # dispatch/skip is not evidence of validation.
+    rel = relationships([edge(integration_workflow="ci.yml",
+                               integration_tested_sha="base111")])
+
+    proposals = propose_marks(rel, [run_evidence(outcome="skipped-cooldown")])
+
+    assert proposals == []
+
+
+def test_apply_proposals_writes_marks(tmp_path):
+    path = make_relationships_file(
+        tmp_path, [edge(integration_workflow="ci.yml", integration_tested_sha="base111")])
+    rel = yaml.safe_load(path.read_text())
+
+    proposals = propose_marks(rel, [run_evidence()])
+    results = apply_proposals(path, proposals)
+
+    assert len(results) == 1
+    assert results[0].status == "updated"
+    assert results[0].new_sha == "head999"
+
+    on_disk = yaml.safe_load(path.read_text())
+    written_edge = on_disk["repo_dependencies"]["dependent-repo"]["depends_on"][0]
+    assert written_edge["integration_tested_sha"] == "head999"
+
+
+def test_apply_proposals_idempotent_on_repeat_application(tmp_path):
+    path = make_relationships_file(
+        tmp_path, [edge(integration_workflow="ci.yml", integration_tested_sha="base111")])
+    rel = yaml.safe_load(path.read_text())
+    proposals = propose_marks(rel, [run_evidence()])
+
+    first = apply_proposals(path, proposals)
+    second = apply_proposals(path, proposals)
+
+    assert first[0].status == "updated"
+    assert second[0].status == "noop"
+
+    on_disk = yaml.safe_load(path.read_text())
+    written_edge = on_disk["repo_dependencies"]["dependent-repo"]["depends_on"][0]
+    assert written_edge["integration_tested_sha"] == "head999"
+
+
+def test_apply_proposals_expected_base_conflict_passes_through(tmp_path):
+    path = make_relationships_file(
+        tmp_path, [edge(integration_workflow="ci.yml", integration_tested_sha="base111")])
+    rel = yaml.safe_load(path.read_text())
+    # Build the proposal from a stale in-memory view (expected_sha base111),
+    # then have the on-disk marker move to something else before applying —
+    # the expected-base guard must surface a conflict, not silently overwrite.
+    proposals = propose_marks(rel, [run_evidence()])
+
+    mark(path, "dependent-repo", "upstream-repo",
+         expected_sha="base111", new_sha="unexpected-sha",
+         tested_at="2026-07-18T00:00:00Z")
+
+    results = apply_proposals(path, proposals)
+
+    assert results[0].status == "conflict"
+    assert results[0].previous_sha == "unexpected-sha"
+
+    on_disk = yaml.safe_load(path.read_text())
+    written_edge = on_disk["repo_dependencies"]["dependent-repo"]["depends_on"][0]
+    assert written_edge["integration_tested_sha"] == "unexpected-sha"
 
 
 def test_mark_preserves_other_edges_and_sections(tmp_path):

--- a/lib/pulse/scripts/tests/test_impact_audit_skill.py
+++ b/lib/pulse/scripts/tests/test_impact_audit_skill.py
@@ -1,0 +1,58 @@
+"""Contract checks for the headless impact-audit orchestration skill."""
+
+from pathlib import Path
+
+
+SKILL = Path("skills/gh-impact-audit-headless/SKILL.md")
+
+
+def read_skill() -> str:
+    return SKILL.read_text()
+
+
+def test_phases_are_present_in_order():
+    skill = read_skill()
+    for phase in ("Phase 1: VALIDATE", "Phase 2: SNAPSHOT", "Phase 3: AUDIT",
+                  "Phase 4: PROPOSE ISSUE/DISPATCH", "Phase 5: RECORD"):
+        assert phase in skill
+    normalized = " ".join(skill.split())
+    order = [
+        normalized.index("Phase 1: VALIDATE"),
+        normalized.index("Phase 2: SNAPSHOT"),
+        normalized.index("Phase 3: AUDIT"),
+        normalized.index("Phase 4: PROPOSE ISSUE/DISPATCH"),
+        normalized.index("Phase 5: RECORD"),
+    ]
+    assert order == sorted(order)
+
+
+def test_dispatch_never_advances_markers():
+    skill = read_skill()
+    normalized = " ".join(skill.split())
+
+    assert "markers_updated: 0" in normalized
+    assert (
+        "successful integration-workflow dispatch proposal, even if a human or "
+        "automation later runs it, does not by itself advance any marker"
+    ) in normalized
+    assert (
+        "this skill never writes `integration_tested_sha` markers "
+        "(`impact.py::mark`) and never opens issues or dispatches workflows"
+    ) in normalized
+    assert "never calls `gh` and never invokes `impact.py mark`" in normalized
+
+
+def test_result_kind_is_impact_and_validated():
+    skill = read_skill()
+    assert "kind: impact" in skill
+    assert "validate_result.py" in skill
+    assert '--kind impact' in skill
+
+
+def test_missing_baseline_blocks_closed_language():
+    skill = read_skill()
+    normalized = " ".join(skill.split())
+    assert (
+        "an edge whose `integration_tested_sha` cannot be resolved on the remote "
+        "is `state: unknown`, never `current`"
+    ) in normalized

--- a/lib/pulse/scripts/tests/test_impact_snapshot.py
+++ b/lib/pulse/scripts/tests/test_impact_snapshot.py
@@ -1,0 +1,309 @@
+"""Tests for impact_snapshot.py — remote evidence collector for the F5
+impact audit. Every git invocation goes through a fake runner; no real git
+process, no network (see nave_adapter's RecordingRunner idiom in
+test_nave_adapter.py)."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from lib.pulse.scripts import impact_snapshot as snap
+
+
+@dataclass
+class Completed:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+class RecordingRunner:
+    """Fake `runner(argv, cwd) -> Completed` seam. Responses keyed by exact
+    argv tuple; unmatched calls fail loudly so tests catch drift."""
+
+    def __init__(self, responses: dict[tuple, Completed] | None = None):
+        self.responses = responses or {}
+        self.calls: list[tuple[tuple, str | None]] = []
+
+    def __call__(self, argv, cwd=None):
+        key = tuple(argv)
+        self.calls.append((key, str(cwd) if cwd is not None else None))
+        return self.responses.get(key, Completed(1, "", f"no fixture for {argv}"))
+
+
+def relationships(depends_on, dependent="dependent-repo"):
+    return {
+        "repo_dependencies": {
+            dependent: {
+                "depends_on": depends_on,
+                "depended_by": [],
+                "relationship_type": "test",
+            }
+        }
+    }
+
+
+def edge(**overrides):
+    e = {
+        "repo": "upstream-repo",
+        "watch_paths": ["lib/foo.py"],
+        "watch_branch": "develop",
+        "integration_tested_sha": "base111",
+        "tested_at": "2026-07-01T10:00:00Z",
+    }
+    e.update(overrides)
+    return e
+
+
+def ls_remote_ok(sha="head999"):
+    return Completed(0, f"{sha}\trefs/heads/develop\n", "")
+
+
+def init_ok():
+    return Completed(0, "", "")
+
+
+def fetch_ok():
+    return Completed(0, "", "")
+
+
+def diff_ok(paths):
+    return Completed(0, "\n".join(paths) + ("\n" if paths else ""), "")
+
+
+# --- no watched edges ---
+
+def test_no_object_edges_returns_empty_snapshot():
+    rel = relationships([])
+    runner = RecordingRunner()
+
+    result = snap.collect(rel, runner=runner)
+
+    assert result == {}
+    assert runner.calls == []
+
+
+def test_legacy_string_edges_are_skipped():
+    rel = relationships(["upstream-repo"])
+    runner = RecordingRunner()
+
+    result = snap.collect(rel, runner=runner)
+
+    assert result == {}
+    assert runner.calls == []
+
+
+# --- happy path ---
+
+def test_happy_path_produces_exact_snapshot_shape(tmp_path):
+    rel = relationships([edge()])
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "base111"): fetch_ok(),
+        ("git", "diff", "--name-only", "base111", "head999"): diff_ok(
+            ["lib/foo.py", "lib/bar.py"]
+        ),
+    })
+
+    result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
+
+    assert result == {
+        "upstream-repo": {
+            "develop": {
+                "head": "head999",
+                "changed_files_by_base": {
+                    "base111": ["lib/bar.py", "lib/foo.py"],  # sorted
+                },
+                "base_missing": [],
+            }
+        }
+    }
+
+
+def test_diff_command_runs_in_the_bare_repo_dir(tmp_path):
+    rel = relationships([edge()])
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "base111"): fetch_ok(),
+        ("git", "diff", "--name-only", "base111", "head999"): diff_ok(["lib/foo.py"]),
+    })
+
+    snap.collect(rel, workdir=tmp_path / "work", runner=runner)
+
+    diff_call = [c for c in runner.calls
+                if c[0] == ("git", "diff", "--name-only", "base111", "head999")][0]
+    assert diff_call[1] == str(repo_dir)
+
+
+# --- base_missing ---
+
+def test_unresolvable_tested_sha_is_recorded_in_base_missing(tmp_path):
+    rel = relationships([edge(integration_tested_sha="ghost-sha")])
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "ghost-sha"):
+            Completed(128, "", "fatal: could not find remote ref ghost-sha"),
+    })
+
+    result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
+
+    branch_snap = result["upstream-repo"]["develop"]
+    assert branch_snap["head"] == "head999"
+    assert branch_snap["changed_files_by_base"] == {}
+    assert branch_snap["base_missing"] == ["ghost-sha"]
+
+
+def test_unresolvable_head_marks_all_tested_shas_missing_and_head_none(tmp_path):
+    rel = relationships([edge(integration_tested_sha="base111")])
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "ls-remote", url, "refs/heads/develop"):
+            Completed(128, "", "fatal: repository not found"),
+    })
+
+    result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
+
+    branch_snap = result["upstream-repo"]["develop"]
+    assert branch_snap["head"] is None
+    assert branch_snap["changed_files_by_base"] == {}
+    assert branch_snap["base_missing"] == ["base111"]
+    # never fetched branch tip or a base once head resolution failed
+    fetch_calls = [c for c in runner.calls if c[0][1] == "fetch"]
+    assert fetch_calls == []
+
+
+def test_branch_fetch_failure_marks_tested_shas_missing_but_keeps_head(tmp_path):
+    rel = relationships([edge(integration_tested_sha="base111")])
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"):
+            Completed(128, "", "fatal: could not fetch branch"),
+    })
+
+    result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
+
+    branch_snap = result["upstream-repo"]["develop"]
+    assert branch_snap["head"] == "head999"
+    assert branch_snap["changed_files_by_base"] == {}
+    assert branch_snap["base_missing"] == ["base111"]
+
+
+# --- multiple tested_shas on the same edge ---
+
+def test_multiple_dependents_watching_same_branch_union_their_tested_shas(tmp_path):
+    rel = {
+        "repo_dependencies": {
+            "dependent-a": {
+                "depends_on": [edge(integration_tested_sha="base111")],
+                "depended_by": [], "relationship_type": "test",
+            },
+            "dependent-b": {
+                "depends_on": [edge(integration_tested_sha="base222")],
+                "depended_by": [], "relationship_type": "test",
+            },
+        }
+    }
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "base111"): fetch_ok(),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "base222"): fetch_ok(),
+        ("git", "diff", "--name-only", "base111", "head999"): diff_ok(["a.py"]),
+        ("git", "diff", "--name-only", "base222", "head999"): diff_ok(["b.py"]),
+    })
+
+    result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
+
+    branch_snap = result["upstream-repo"]["develop"]
+    assert branch_snap["changed_files_by_base"] == {
+        "base111": ["a.py"],
+        "base222": ["b.py"],
+    }
+    assert branch_snap["base_missing"] == []
+
+
+def test_edge_without_tested_sha_still_resolves_head_with_no_bases(tmp_path):
+    rel = relationships([edge(integration_tested_sha=None)])
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
+    })
+
+    result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
+
+    branch_snap = result["upstream-repo"]["develop"]
+    assert branch_snap == {"head": "head999", "changed_files_by_base": {},
+                           "base_missing": []}
+
+
+# --- known_heads short-circuit ---
+
+def test_known_heads_skips_ls_remote_but_diff_is_still_computed_by_git(tmp_path):
+    rel = relationships([edge()])
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
+        ("git", "fetch", "--filter=blob:none", "-q", url, "base111"): fetch_ok(),
+        ("git", "diff", "--name-only", "base111", "head999"): diff_ok(["lib/foo.py"]),
+    })
+
+    result = snap.collect(
+        rel, workdir=tmp_path / "work", runner=runner,
+        known_heads={"upstream-repo": {"develop": "head999"}},
+    )
+
+    assert result["upstream-repo"]["develop"]["head"] == "head999"
+    assert result["upstream-repo"]["develop"]["changed_files_by_base"] == {
+        "base111": ["lib/foo.py"],
+    }
+    ls_remote_calls = [c for c in runner.calls if c[0][1] == "ls-remote"]
+    assert ls_remote_calls == []
+    # the diff still runs through git — known_heads never supplies path evidence
+    diff_calls = [c for c in runner.calls if c[0][1] == "diff"]
+    assert len(diff_calls) == 1
+
+
+# --- workdir cleanup default ---
+
+def test_default_workdir_is_a_cleaned_up_temp_dir():
+    rel = relationships([edge()])
+    captured = {}
+
+    def runner(argv, cwd=None):
+        if "init" in argv:
+            captured["init_target"] = argv[-1]
+        if "ls-remote" in argv:
+            return Completed(0, "head999\trefs/heads/develop\n", "")
+        return Completed(0, "", "")
+
+    result = snap.collect(rel, runner=runner)
+
+    assert result["upstream-repo"]["develop"]["head"] == "head999"
+    # temp dir used for git init must not survive the call
+    from pathlib import Path
+    assert "init_target" in captured
+    assert not Path(captured["init_target"]).exists()

--- a/lib/pulse/scripts/tests/test_impact_snapshot.py
+++ b/lib/pulse/scripts/tests/test_impact_snapshot.py
@@ -47,7 +47,7 @@ def edge(**overrides):
         "repo": "upstream-repo",
         "watch_paths": ["lib/foo.py"],
         "watch_branch": "develop",
-        "integration_tested_sha": "base111",
+        "integration_tested_sha": "abc1234",
         "tested_at": "2026-07-01T10:00:00Z",
     }
     e.update(overrides)
@@ -64,6 +64,10 @@ def init_ok():
 
 def fetch_ok():
     return Completed(0, "", "")
+
+
+def rev_parse_ok(sha="head999"):
+    return Completed(0, f"{sha}\n", "")
 
 
 def diff_ok(paths):
@@ -100,10 +104,11 @@ def test_happy_path_produces_exact_snapshot_shape(tmp_path):
     url = "https://github.com/upstream-repo.git"
     runner = RecordingRunner({
         ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
-        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "base111"): fetch_ok(),
-        ("git", "diff", "--name-only", "base111", "head999"): diff_ok(
+        ("git", "ls-remote", "--", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "develop"): fetch_ok(),
+        ("git", "rev-parse", "FETCH_HEAD"): rev_parse_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "abc1234"): fetch_ok(),
+        ("git", "diff", "--name-only", "abc1234", "head999"): diff_ok(
             ["lib/foo.py", "lib/bar.py"]
         ),
     })
@@ -115,7 +120,7 @@ def test_happy_path_produces_exact_snapshot_shape(tmp_path):
             "develop": {
                 "head": "head999",
                 "changed_files_by_base": {
-                    "base111": ["lib/bar.py", "lib/foo.py"],  # sorted
+                    "abc1234": ["lib/bar.py", "lib/foo.py"],  # sorted
                 },
                 "base_missing": [],
             }
@@ -129,31 +134,55 @@ def test_diff_command_runs_in_the_bare_repo_dir(tmp_path):
     url = "https://github.com/upstream-repo.git"
     runner = RecordingRunner({
         ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
-        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "base111"): fetch_ok(),
-        ("git", "diff", "--name-only", "base111", "head999"): diff_ok(["lib/foo.py"]),
+        ("git", "ls-remote", "--", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "develop"): fetch_ok(),
+        ("git", "rev-parse", "FETCH_HEAD"): rev_parse_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "abc1234"): fetch_ok(),
+        ("git", "diff", "--name-only", "abc1234", "head999"): diff_ok(["lib/foo.py"]),
     })
 
     snap.collect(rel, workdir=tmp_path / "work", runner=runner)
 
     diff_call = [c for c in runner.calls
-                if c[0] == ("git", "diff", "--name-only", "base111", "head999")][0]
+                if c[0] == ("git", "diff", "--name-only", "abc1234", "head999")][0]
     assert diff_call[1] == str(repo_dir)
 
 
 # --- base_missing ---
 
 def test_unresolvable_tested_sha_is_recorded_in_base_missing(tmp_path):
+    rel = relationships([edge(integration_tested_sha="deadbee1")])
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "ls-remote", "--", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "develop"): fetch_ok(),
+        ("git", "rev-parse", "FETCH_HEAD"): rev_parse_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "deadbee1"):
+            Completed(128, "", "fatal: could not find remote ref deadbee1"),
+    })
+
+    result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
+
+    branch_snap = result["upstream-repo"]["develop"]
+    assert branch_snap["head"] == "head999"
+    assert branch_snap["changed_files_by_base"] == {}
+    assert branch_snap["base_missing"] == ["deadbee1"]
+
+
+def test_malformed_tested_sha_never_invokes_git(tmp_path):
+    """A tested_sha that doesn't look like a git SHA (hex, 7-40 chars) is
+    never passed to git — it's recorded as missing without a fetch/diff
+    round trip, per the hardened argv-validation rule."""
     rel = relationships([edge(integration_tested_sha="ghost-sha")])
     repo_dir = tmp_path / "work" / "upstream-repo_develop"
     url = "https://github.com/upstream-repo.git"
     runner = RecordingRunner({
         ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
-        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "ghost-sha"):
-            Completed(128, "", "fatal: could not find remote ref ghost-sha"),
+        ("git", "ls-remote", "--", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "develop"): fetch_ok(),
+        ("git", "rev-parse", "FETCH_HEAD"): rev_parse_ok("head999"),
     })
 
     result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
@@ -162,15 +191,40 @@ def test_unresolvable_tested_sha_is_recorded_in_base_missing(tmp_path):
     assert branch_snap["head"] == "head999"
     assert branch_snap["changed_files_by_base"] == {}
     assert branch_snap["base_missing"] == ["ghost-sha"]
+    base_fetch_calls = [c for c in runner.calls if c[0][1] == "fetch" and "ghost-sha" in c[0]]
+    assert base_fetch_calls == []
+    diff_calls = [c for c in runner.calls if c[0][1] == "diff"]
+    assert diff_calls == []
+
+
+def test_invalid_branch_name_is_never_passed_to_git(tmp_path):
+    """A watch_branch starting with '-' could be parsed as a git option if
+    passed as a bare positional; it must never reach ls-remote/fetch."""
+    rel = relationships([edge(watch_branch="-evil-branch")])
+    repo_dir = tmp_path / "work" / "upstream-repo_-evil-branch"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+    })
+
+    result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
+
+    branch_snap = result["upstream-repo"]["-evil-branch"]
+    assert branch_snap["head"] is None
+    assert branch_snap["changed_files_by_base"] == {}
+    assert branch_snap["base_missing"] == ["abc1234"]
+    ls_remote_calls = [c for c in runner.calls if c[0][1] == "ls-remote"]
+    fetch_calls = [c for c in runner.calls if c[0][1] == "fetch"]
+    assert ls_remote_calls == []
+    assert fetch_calls == []
 
 
 def test_unresolvable_head_marks_all_tested_shas_missing_and_head_none(tmp_path):
-    rel = relationships([edge(integration_tested_sha="base111")])
+    rel = relationships([edge(integration_tested_sha="abc1234")])
     repo_dir = tmp_path / "work" / "upstream-repo_develop"
     url = "https://github.com/upstream-repo.git"
     runner = RecordingRunner({
         ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
-        ("git", "ls-remote", url, "refs/heads/develop"):
+        ("git", "ls-remote", "--", url, "refs/heads/develop"):
             Completed(128, "", "fatal: repository not found"),
     })
 
@@ -179,20 +233,20 @@ def test_unresolvable_head_marks_all_tested_shas_missing_and_head_none(tmp_path)
     branch_snap = result["upstream-repo"]["develop"]
     assert branch_snap["head"] is None
     assert branch_snap["changed_files_by_base"] == {}
-    assert branch_snap["base_missing"] == ["base111"]
+    assert branch_snap["base_missing"] == ["abc1234"]
     # never fetched branch tip or a base once head resolution failed
     fetch_calls = [c for c in runner.calls if c[0][1] == "fetch"]
     assert fetch_calls == []
 
 
 def test_branch_fetch_failure_marks_tested_shas_missing_but_keeps_head(tmp_path):
-    rel = relationships([edge(integration_tested_sha="base111")])
+    rel = relationships([edge(integration_tested_sha="abc1234")])
     repo_dir = tmp_path / "work" / "upstream-repo_develop"
     url = "https://github.com/upstream-repo.git"
     runner = RecordingRunner({
         ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
-        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"):
+        ("git", "ls-remote", "--", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "develop"):
             Completed(128, "", "fatal: could not fetch branch"),
     })
 
@@ -201,7 +255,29 @@ def test_branch_fetch_failure_marks_tested_shas_missing_but_keeps_head(tmp_path)
     branch_snap = result["upstream-repo"]["develop"]
     assert branch_snap["head"] == "head999"
     assert branch_snap["changed_files_by_base"] == {}
-    assert branch_snap["base_missing"] == ["base111"]
+    assert branch_snap["base_missing"] == ["abc1234"]
+
+
+def test_fetch_head_resolution_failure_keeps_previous_head_hint(tmp_path):
+    """If the branch fetch succeeds but `git rev-parse FETCH_HEAD` cannot be
+    resolved, fall back to the pre-fetch head hint rather than crashing or
+    fabricating a head."""
+    rel = relationships([edge(integration_tested_sha="abc1234")])
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "ls-remote", "--", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "develop"): fetch_ok(),
+        ("git", "rev-parse", "FETCH_HEAD"): Completed(128, "", "fatal: ambiguous argument"),
+    })
+
+    result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
+
+    branch_snap = result["upstream-repo"]["develop"]
+    assert branch_snap["head"] == "head999"
+    assert branch_snap["changed_files_by_base"] == {}
+    assert branch_snap["base_missing"] == ["abc1234"]
 
 
 # --- multiple tested_shas on the same edge ---
@@ -210,11 +286,11 @@ def test_multiple_dependents_watching_same_branch_union_their_tested_shas(tmp_pa
     rel = {
         "repo_dependencies": {
             "dependent-a": {
-                "depends_on": [edge(integration_tested_sha="base111")],
+                "depends_on": [edge(integration_tested_sha="abc1234")],
                 "depended_by": [], "relationship_type": "test",
             },
             "dependent-b": {
-                "depends_on": [edge(integration_tested_sha="base222")],
+                "depends_on": [edge(integration_tested_sha="bcd2234")],
                 "depended_by": [], "relationship_type": "test",
             },
         }
@@ -223,20 +299,21 @@ def test_multiple_dependents_watching_same_branch_union_their_tested_shas(tmp_pa
     url = "https://github.com/upstream-repo.git"
     runner = RecordingRunner({
         ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
-        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "base111"): fetch_ok(),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "base222"): fetch_ok(),
-        ("git", "diff", "--name-only", "base111", "head999"): diff_ok(["a.py"]),
-        ("git", "diff", "--name-only", "base222", "head999"): diff_ok(["b.py"]),
+        ("git", "ls-remote", "--", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "develop"): fetch_ok(),
+        ("git", "rev-parse", "FETCH_HEAD"): rev_parse_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "abc1234"): fetch_ok(),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "bcd2234"): fetch_ok(),
+        ("git", "diff", "--name-only", "abc1234", "head999"): diff_ok(["a.py"]),
+        ("git", "diff", "--name-only", "bcd2234", "head999"): diff_ok(["b.py"]),
     })
 
     result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
 
     branch_snap = result["upstream-repo"]["develop"]
     assert branch_snap["changed_files_by_base"] == {
-        "base111": ["a.py"],
-        "base222": ["b.py"],
+        "abc1234": ["a.py"],
+        "bcd2234": ["b.py"],
     }
     assert branch_snap["base_missing"] == []
 
@@ -247,8 +324,9 @@ def test_edge_without_tested_sha_still_resolves_head_with_no_bases(tmp_path):
     url = "https://github.com/upstream-repo.git"
     runner = RecordingRunner({
         ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
-        ("git", "ls-remote", url, "refs/heads/develop"): ls_remote_ok("head999"),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
+        ("git", "ls-remote", "--", url, "refs/heads/develop"): ls_remote_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "develop"): fetch_ok(),
+        ("git", "rev-parse", "FETCH_HEAD"): rev_parse_ok("head999"),
     })
 
     result = snap.collect(rel, workdir=tmp_path / "work", runner=runner)
@@ -266,9 +344,10 @@ def test_known_heads_skips_ls_remote_but_diff_is_still_computed_by_git(tmp_path)
     url = "https://github.com/upstream-repo.git"
     runner = RecordingRunner({
         ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "develop"): fetch_ok(),
-        ("git", "fetch", "--filter=blob:none", "-q", url, "base111"): fetch_ok(),
-        ("git", "diff", "--name-only", "base111", "head999"): diff_ok(["lib/foo.py"]),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "develop"): fetch_ok(),
+        ("git", "rev-parse", "FETCH_HEAD"): rev_parse_ok("head999"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "abc1234"): fetch_ok(),
+        ("git", "diff", "--name-only", "abc1234", "head999"): diff_ok(["lib/foo.py"]),
     })
 
     result = snap.collect(
@@ -278,13 +357,82 @@ def test_known_heads_skips_ls_remote_but_diff_is_still_computed_by_git(tmp_path)
 
     assert result["upstream-repo"]["develop"]["head"] == "head999"
     assert result["upstream-repo"]["develop"]["changed_files_by_base"] == {
-        "base111": ["lib/foo.py"],
+        "abc1234": ["lib/foo.py"],
     }
     ls_remote_calls = [c for c in runner.calls if c[0][1] == "ls-remote"]
     assert ls_remote_calls == []
     # the diff still runs through git — known_heads never supplies path evidence
     diff_calls = [c for c in runner.calls if c[0][1] == "diff"]
     assert len(diff_calls) == 1
+
+
+def test_stale_known_head_is_not_used_as_diff_endpoint(tmp_path):
+    """A cached known_head that has fallen behind the remote's true current
+    tip must never become the diff endpoint — that would under-report
+    staleness (fail open). The collector always resolves the actual fetched
+    head via `git rev-parse FETCH_HEAD` and diffs against THAT, regardless
+    of what known_heads supplied."""
+    rel = relationships([edge()])
+    repo_dir = tmp_path / "work" / "upstream-repo_develop"
+    url = "https://github.com/upstream-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): init_ok(),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "develop"): fetch_ok(),
+        ("git", "rev-parse", "FETCH_HEAD"): rev_parse_ok("newerhead000"),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "abc1234"): fetch_ok(),
+        ("git", "diff", "--name-only", "abc1234", "newerhead000"): diff_ok(["lib/foo.py"]),
+    })
+
+    result = snap.collect(
+        rel, workdir=tmp_path / "work", runner=runner,
+        known_heads={"upstream-repo": {"develop": "stalehead999"}},
+    )
+
+    branch_snap = result["upstream-repo"]["develop"]
+    assert branch_snap["head"] == "newerhead000"
+    assert branch_snap["changed_files_by_base"] == {"abc1234": ["lib/foo.py"]}
+
+    diff_calls = [c for c in runner.calls if c[0][1] == "diff"]
+    assert diff_calls[0][0] == ("git", "diff", "--name-only", "abc1234", "newerhead000")
+    # the stale known_head must never appear as a diff endpoint
+    stale_diff_calls = [c for c in diff_calls if "stalehead999" in c[0]]
+    assert stale_diff_calls == []
+    ls_remote_calls = [c for c in runner.calls if c[0][1] == "ls-remote"]
+    assert ls_remote_calls == []
+
+
+# --- --known-heads loader: accepts YAML or JSON ---
+
+def test_load_known_heads_parses_yaml(tmp_path):
+    path = tmp_path / "known-heads.yaml"
+    path.write_text(
+        "upstream-repo:\n"
+        "  develop: head999\n"
+        "  main: head888\n"
+    )
+
+    result = snap._load_known_heads(path)
+
+    assert result == {"upstream-repo": {"develop": "head999", "main": "head888"}}
+
+
+def test_load_known_heads_parses_json(tmp_path):
+    import json as jsonlib
+    path = tmp_path / "known-heads.json"
+    path.write_text(jsonlib.dumps({"upstream-repo": {"develop": "head999"}}))
+
+    result = snap._load_known_heads(path)
+
+    assert result == {"upstream-repo": {"develop": "head999"}}
+
+
+def test_load_known_heads_empty_file_returns_empty_dict(tmp_path):
+    path = tmp_path / "known-heads.yaml"
+    path.write_text("")
+
+    result = snap._load_known_heads(path)
+
+    assert result == {}
 
 
 # --- workdir cleanup default ---
@@ -298,6 +446,8 @@ def test_default_workdir_is_a_cleaned_up_temp_dir():
             captured["init_target"] = argv[-1]
         if "ls-remote" in argv:
             return Completed(0, "head999\trefs/heads/develop\n", "")
+        if "rev-parse" in argv:
+            return Completed(0, "head999\n", "")
         return Completed(0, "", "")
 
     result = snap.collect(rel, runner=runner)

--- a/lib/pulse/scripts/tests/test_poll.py
+++ b/lib/pulse/scripts/tests/test_poll.py
@@ -162,3 +162,92 @@ def test_org_repos_unchanged_signature_does_not_trigger(tmp_path):
     unchanged = json.loads(run_poll(ws, fixtures=fixtures).stdout)
 
     assert unchanged["triggered_workflows"] == []
+
+
+def make_impact_relationships(cfg, dependent="testorg/downstream",
+                              upstream="testorg/upstream", branch="main"):
+    (cfg / "relationships.yaml").write_text(
+        "repo_dependencies:\n"
+        f"  {dependent}:\n"
+        "    depends_on:\n"
+        f"      - repo: {upstream}\n"
+        "        watch_paths:\n"
+        "          - \"**\"\n"
+        f"        watch_branch: {branch}\n"
+        "        integration_tested_sha: abc123\n"
+        "        tested_at: \"2026-07-01T10:00:00Z\"\n"
+        "    depended_by: []\n"
+        "    relationship_type: main\n"
+        f"  {upstream}:\n"
+        "    depends_on: []\n"
+        f"    depended_by:\n      - {dependent}\n"
+        "    relationship_type: main\n"
+    )
+
+
+def _ref_fixture_slug(repo, branch):
+    import re
+    path = f"/repos/{repo}/git/ref/heads/{branch}"
+    return re.sub(r"[^A-Za-z0-9._-]", "_", path)
+
+
+def test_branch_heads_first_sight_baselines_then_move_triggers(tmp_path):
+    ws, cfg = make_workspace(tmp_path, with_workflow=False)
+    (cfg / "workflows" / "impact-watch.yaml").write_text(
+        "name: impact-watch\nenabled: true\nauto: false\ncooldown_minutes: 0\n"
+        "trigger:\n  type: session_poll\n  source: branch_heads\n"
+    )
+    make_impact_relationships(cfg)
+    fixtures = tmp_path / "fixtures"
+    fixtures.mkdir()
+    (fixtures / "_rate_limit.json").write_text('{"rate":{"remaining":5000}}')
+    ref_fixture = fixtures / f"{_ref_fixture_slug('testorg/upstream', 'main')}.json"
+    ref_fixture.write_text(json.dumps({"object": {"sha": "sha-one"}}))
+
+    run_poll(ws, fixtures=fixtures)  # poll-state bootstrap
+    first_observation = json.loads(run_poll(ws, fixtures=fixtures).stdout)
+
+    assert first_observation["triggered_workflows"] == []
+    state = yaml.safe_load((cfg / "poll-state.yaml").read_text())
+    assert state["state"]["branch_heads"]["testorg/upstream"]["main"] == "sha-one"
+
+    ref_fixture.write_text(json.dumps({"object": {"sha": "sha-two"}}))
+    changed = json.loads(run_poll(ws, fixtures=fixtures).stdout)
+
+    assert changed["triggered_workflows"] == ["impact-watch"]
+    state = yaml.safe_load((cfg / "poll-state.yaml").read_text())
+    assert state["state"]["branch_heads"]["testorg/upstream"]["main"] == "sha-two"
+
+
+def test_branch_heads_unchanged_head_does_not_trigger(tmp_path):
+    ws, cfg = make_workspace(tmp_path, with_workflow=False)
+    (cfg / "workflows" / "impact-watch.yaml").write_text(
+        "name: impact-watch\nenabled: true\nauto: false\ncooldown_minutes: 0\n"
+        "trigger:\n  type: session_poll\n  source: branch_heads\n"
+    )
+    make_impact_relationships(cfg)
+    fixtures = tmp_path / "fixtures"
+    fixtures.mkdir()
+    (fixtures / "_rate_limit.json").write_text('{"rate":{"remaining":5000}}')
+    ref_fixture = fixtures / f"{_ref_fixture_slug('testorg/upstream', 'main')}.json"
+    ref_fixture.write_text(json.dumps({"object": {"sha": "sha-one"}}))
+
+    run_poll(ws, fixtures=fixtures)
+    run_poll(ws, fixtures=fixtures)
+    unchanged = json.loads(run_poll(ws, fixtures=fixtures).stdout)
+
+    assert unchanged["triggered_workflows"] == []
+
+
+def test_branch_heads_no_relationships_file_does_not_trigger_or_crash(tmp_path):
+    ws, cfg = make_workspace(tmp_path, with_workflow=False)
+    (cfg / "workflows" / "impact-watch.yaml").write_text(
+        "name: impact-watch\nenabled: true\nauto: false\ncooldown_minutes: 0\n"
+        "trigger:\n  type: session_poll\n  source: branch_heads\n"
+    )
+    # no relationships.yaml written at all
+    run_poll(ws)
+    r = run_poll(ws)
+    out = json.loads(r.stdout)
+    assert r.returncode == 0, r.stderr
+    assert out["triggered_workflows"] == []

--- a/lib/pulse/scripts/tests/test_resolve_run.py
+++ b/lib/pulse/scripts/tests/test_resolve_run.py
@@ -152,3 +152,160 @@ def test_gate_only_step_completes_on_satisfy(tmp_path):
     step = [s for s in yaml.safe_load(open(path))["steps"]
             if s["id"] == "verify-lib"][0]
     assert step["status"] == "done"
+
+
+# --------------------------------------------------------------------------
+# check-gate: binding_edges_current (F5 Task 4 release gate)
+# --------------------------------------------------------------------------
+
+GATE_STEPS = json.dumps([
+    {"id": "audit", "repo": "testorg/app"},
+    {"id": "release-gate", "repo": "testorg/app", "depends_on": ["audit"],
+     "gate": "binding edges current"},
+])
+
+
+def create_gate_run(tmp_path, run_id="2026-07-19-octocat-100000"):
+    return create(tmp_path, steps=GATE_STEPS, run_id=run_id)
+
+
+def impact_result(edges, edges_stale=None, kind="impact"):
+    stale_count = (
+        edges_stale if edges_stale is not None
+        else sum(1 for e in edges if e.get("state") == "stale")
+    )
+    return {
+        "contract_version": 1,
+        "kind": kind,
+        "workspace": "testorg",
+        "run_at": "2026-07-19T00:00:00Z",
+        "actor": {"gh_login": "octocat", "machine": "mba-m4", "mode": "scheduled"},
+        "edges_checked": len(edges),
+        "edges_stale": stale_count,
+        "markers_updated": 0,
+        "edges": edges,
+        "findings": [],
+        "proposed_actions": [],
+        "asks_recorded": [],
+        "errors": [],
+    }
+
+
+def _edge(state, dependent="testorg/app", upstream="testorg/lib"):
+    return {
+        "dependent": dependent,
+        "upstream": upstream,
+        "watch_branch": "main",
+        "state": state,
+        "tested_sha": "aaa" if state != "unknown" else None,
+        "remote_head": "bbb",
+        "changed_paths": ["lib/x.py"] if state == "stale" else [],
+    }
+
+
+def write_yaml(path, data):
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+
+
+def check_gate(path, result_path, step="release-gate", gate_type="binding_edges_current"):
+    return run("check-gate", "--file", path, "--step", step,
+               "--result", str(result_path), "--gate-type", gate_type)
+
+
+def test_check_gate_current_satisfies(tmp_path):
+    path = create_gate_run(tmp_path)
+    result_path = tmp_path / "impact-result.yaml"
+    write_yaml(result_path, impact_result([_edge("current")]))
+
+    r = check_gate(path, result_path)
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["satisfied"] is True
+
+    doc = yaml.safe_load(open(path))
+    step = [s for s in doc["steps"] if s["id"] == "release-gate"][0]
+    assert step["gate_satisfied"] is True
+    assert step["status"] == "done"
+
+
+def test_check_gate_stale_edge_blocks_closed(tmp_path):
+    path = create_gate_run(tmp_path)
+    result_path = tmp_path / "impact-result.yaml"
+    write_yaml(result_path, impact_result([_edge("current"), _edge("stale")]))
+
+    r = check_gate(path, result_path)
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["satisfied"] is False
+
+    doc = yaml.safe_load(open(path))
+    step = [s for s in doc["steps"] if s["id"] == "release-gate"][0]
+    assert step["gate_satisfied"] is False
+    assert step["status"] == "blocked-on-gate"
+
+
+def test_check_gate_unknown_edge_blocks_closed(tmp_path):
+    path = create_gate_run(tmp_path)
+    result_path = tmp_path / "impact-result.yaml"
+    write_yaml(result_path, impact_result([_edge("current"), _edge("unknown")]))
+
+    r = check_gate(path, result_path)
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["satisfied"] is False
+
+    step = [s for s in yaml.safe_load(open(path))["steps"]
+            if s["id"] == "release-gate"][0]
+    assert step["gate_satisfied"] is False
+
+
+def test_check_gate_missing_result_blocks_closed(tmp_path):
+    path = create_gate_run(tmp_path)
+    missing_path = tmp_path / "no-such-impact-result.yaml"
+
+    r = check_gate(path, missing_path)
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["satisfied"] is False
+    assert "not found" in out["detail"]
+
+    step = [s for s in yaml.safe_load(open(path))["steps"]
+            if s["id"] == "release-gate"][0]
+    assert step["gate_satisfied"] is False
+
+
+def test_check_gate_malformed_result_blocks_closed(tmp_path):
+    path = create_gate_run(tmp_path)
+    result_path = tmp_path / "impact-result.yaml"
+    result_path.write_text("not: [valid, yaml structure for this schema\n")
+
+    r = check_gate(path, result_path)
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["satisfied"] is False
+
+    step = [s for s in yaml.safe_load(open(path))["steps"]
+            if s["id"] == "release-gate"][0]
+    assert step["gate_satisfied"] is False
+
+
+def test_check_gate_schema_invalid_result_blocks_closed(tmp_path):
+    # Valid YAML, but fails impact schema validation (wrong kind).
+    path = create_gate_run(tmp_path)
+    result_path = tmp_path / "impact-result.yaml"
+    write_yaml(result_path, impact_result([_edge("current")], kind="healthcheck"))
+
+    r = check_gate(path, result_path)
+    assert r.returncode == 0, r.stderr
+    out = json.loads(r.stdout)
+    assert out["satisfied"] is False
+
+
+def test_check_gate_unknown_gate_type_errors(tmp_path):
+    path = create_gate_run(tmp_path)
+    result_path = tmp_path / "impact-result.yaml"
+    write_yaml(result_path, impact_result([_edge("current")]))
+
+    r = check_gate(path, result_path, gate_type="nonsense_gate")
+    assert r.returncode == 1
+    assert "unknown gate type" in r.stderr.lower()

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -15,7 +15,7 @@ from lib.pulse.scripts.evaluate_checks import (
 
 SCRIPT = "lib/pulse/scripts/validate_result.py"
 FIXTURES = Path("lib/pulse/scripts/tests/fixtures")
-KINDS = ["status", "healthcheck", "refresh", "workflow-run", "fleet-membership"]
+KINDS = ["status", "healthcheck", "refresh", "workflow-run", "fleet-membership", "impact"]
 
 
 def run_validator(path, kind):
@@ -517,3 +517,130 @@ def test_membership_explanation_requires_inferred_marker(tmp_path):
 
     assert result.returncode == 1
     assert "inferred: true" in result.stderr
+
+
+def test_impact_rejects_invalid_edge_state(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "impact-valid.yaml").read_text())
+    doc["edges"][0]["state"] = "broken"
+    path = tmp_path / "impact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "impact")
+
+    assert result.returncode == 1
+    assert "state invalid: broken" in result.stderr
+
+
+@pytest.mark.parametrize("state", ["current", "stale", "unknown"])
+def test_impact_accepts_exact_edge_states(tmp_path, state):
+    doc = yaml.safe_load((FIXTURES / "impact-valid.yaml").read_text())
+    doc["edges"][0]["state"] = state
+    doc["edges_stale"] = sum(1 for e in doc["edges"] if e["state"] == "stale")
+    path = tmp_path / "impact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "impact")
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_impact_rejects_edges_checked_not_derived_from_edges(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "impact-valid.yaml").read_text())
+    doc["edges_checked"] = 5
+    path = tmp_path / "impact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "impact")
+
+    assert result.returncode == 1
+    assert "edges_checked does not match edges" in result.stderr
+
+
+def test_impact_rejects_edges_stale_not_derived_from_edges(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "impact-valid.yaml").read_text())
+    doc["edges_stale"] = 0
+    path = tmp_path / "impact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "impact")
+
+    assert result.returncode == 1
+    assert "edges_stale does not match edges" in result.stderr
+
+
+def test_impact_rejects_negative_markers_updated(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "impact-valid.yaml").read_text())
+    doc["markers_updated"] = -1
+    path = tmp_path / "impact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "impact")
+
+    assert result.returncode == 1
+    assert "markers_updated must be a non-negative integer" in result.stderr
+
+
+def test_impact_rejects_duplicate_edge_identity(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "impact-valid.yaml").read_text())
+    dup = copy.deepcopy(doc["edges"][0])
+    doc["edges"].append(dup)
+    doc["edges_checked"] = len(doc["edges"])
+    doc["edges_stale"] = sum(1 for e in doc["edges"] if e["state"] == "stale")
+    path = tmp_path / "impact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "impact")
+
+    assert result.returncode == 1
+    assert "duplicate edge identity" in result.stderr
+
+
+def test_impact_requires_edge_fields(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "impact-valid.yaml").read_text())
+    edge = doc["edges"][0]
+    edge.pop("dependent")
+    edge.pop("upstream")
+    edge.pop("watch_branch")
+    edge.pop("changed_paths")
+    path = tmp_path / "impact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "impact")
+
+    assert result.returncode == 1
+    assert "edges[0].dependent" in result.stderr
+    assert "edges[0].upstream" in result.stderr
+    assert "edges[0].watch_branch" in result.stderr
+    assert "edges[0].changed_paths" in result.stderr
+
+
+def test_impact_edge_tested_sha_and_remote_head_are_nullable(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "impact-valid.yaml").read_text())
+    doc["edges"][0]["state"] = "unknown"
+    doc["edges"][0]["tested_sha"] = None
+    doc["edges"][0]["remote_head"] = None
+    doc["edges_stale"] = sum(1 for e in doc["edges"] if e["state"] == "stale")
+    path = tmp_path / "impact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "impact")
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_impact_legacy_string_edge_surfaces_as_unconfigured_finding(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "impact-valid.yaml").read_text())
+    doc["findings"].append(
+        {
+            "kind": "unconfigured_edge",
+            "repo": "testorg/widget",
+            "severity": "low",
+            "detail": "legacy string dependency carries no watch metadata",
+        }
+    )
+    path = tmp_path / "impact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "impact")
+
+    assert result.returncode == 0, result.stderr

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -5,7 +5,7 @@
 # ///
 """Validate a headless result file against the pulse result contract.
 
-Usage: validate_result.py <result.yaml> --kind status|healthcheck|refresh|workflow-run|fleet-membership
+Usage: validate_result.py <result.yaml> --kind status|healthcheck|refresh|workflow-run|fleet-membership|impact
 
 See lib/patterns/headless-contract.md for the schemas.
 
@@ -37,6 +37,7 @@ GRADES = {"A", "B", "C", "D", "F"}
 REFRESH_SECTION_STATUSES = {"refreshed", "skipped", "failed"}
 OUTCOMES = {"success", "failure", "skipped-cooldown", "aborted"}
 SEVERITIES = {"low", "medium", "high"}
+EDGE_STATES = {"current", "stale", "unknown"}
 
 
 def _err(errors, msg):
@@ -474,6 +475,45 @@ def validate(data, kind: str) -> list[str]:
         _require(data, "proposed_actions", list, errors)
         _require(data, "asks_recorded", list, errors)
 
+    elif kind == "impact":
+        edges = _require(data, "edges", list, errors)
+        seen_edges: set[tuple] = set()
+        stale_count = 0
+        for i, e in enumerate(edges or []):
+            if not isinstance(e, dict):
+                _err(errors, f"edges[{i}] is not a mapping")
+                continue
+            ctx = f"edges[{i}]."
+            dependent = _require(e, "dependent", str, errors, ctx=ctx)
+            upstream = _require(e, "upstream", str, errors, ctx=ctx)
+            watch_branch = _require(e, "watch_branch", str, errors, ctx=ctx)
+            state = _require_enum(e, "state", EDGE_STATES, errors, ctx=ctx)
+            _require_nullable(e, "tested_sha", str, errors, ctx=ctx)
+            _require_nullable(e, "remote_head", str, errors, ctx=ctx)
+            _validate_string_list(e, "changed_paths", errors, ctx=ctx)
+            if state == "stale":
+                stale_count += 1
+            if None not in (dependent, upstream, watch_branch):
+                identity = (dependent, upstream, watch_branch)
+                if identity in seen_edges:
+                    _err(
+                        errors,
+                        f"duplicate edge identity: {dependent} <- {upstream} "
+                        f"({watch_branch})",
+                    )
+                else:
+                    seen_edges.add(identity)
+        edges_checked = _require_nonnegative_integer(data, "edges_checked", errors)
+        if edges_checked is not None and edges_checked != len(edges or []):
+            _err(errors, "edges_checked does not match edges")
+        edges_stale = _require_nonnegative_integer(data, "edges_stale", errors)
+        if edges_stale is not None and edges_stale != stale_count:
+            _err(errors, "edges_stale does not match edges")
+        _require_nonnegative_integer(data, "markers_updated", errors)
+        _validate_findings(data, errors)
+        _require(data, "proposed_actions", list, errors)
+        _require(data, "asks_recorded", list, errors)
+
     return errors
 
 
@@ -482,7 +522,7 @@ def main():
     parser.add_argument("file", help="Path to result YAML file")
     parser.add_argument("--kind", required=True,
                         choices=["status", "healthcheck", "refresh", "workflow-run",
-                                 "fleet-membership"])
+                                 "fleet-membership", "impact"])
     args = parser.parse_args()
 
     path = Path(args.file)

--- a/lib/references/config-schema.md
+++ b/lib/references/config-schema.md
@@ -675,6 +675,13 @@ any hit marks the edge `stale`. A missing or unreachable
 passes as current. Local working-tree content is never a binding side —
 only the committed marker and the upstream remote head participate.
 
+An empty or missing `watch_paths[]` is a misconfiguration, not "watch
+nothing": no path evidence can ever mark such an edge `stale`, so the audit
+classifies it `state: unknown` (with an `empty_watch_paths` finding,
+`severity: low`) rather than letting it default to `current`. To
+intentionally watch the whole upstream tree, set `watch_paths: ["**"]`
+explicitly.
+
 **Legacy string edges.** A `depends_on[]` entry may also be a bare repository
 name (string), matching the pre-F5 shape. These remain accepted for backward
 compatibility but carry no watch metadata, so the impact audit cannot

--- a/lib/references/config-schema.md
+++ b/lib/references/config-schema.md
@@ -650,9 +650,37 @@ Documents repository dependency relationships (manually maintained).
 | Path | Type | Description |
 |------|------|-------------|
 | `.repo_dependencies.{repo}` | object | Dependencies for a repository |
-| `.repo_dependencies.{repo}.depends_on[]` | array | Repositories this repo depends on |
+| `.repo_dependencies.{repo}.depends_on[]` | array | Repositories this repo depends on — object edges (see below), or legacy strings |
 | `.repo_dependencies.{repo}.depended_by[]` | array | Repositories that depend on this repo |
 | `.repo_dependencies.{repo}.relationship_type` | string | `main`, `plugin`, `test`, `documentation` |
+
+#### depends_on edges (object shape, F5 impact audit)
+
+Each `depends_on[]` entry is normally an object edge carrying the state the
+impact audit (`impact.py`) needs to compute path-scoped integration
+currency:
+
+| Path | Type | Description |
+|------|------|-------------|
+| `.depends_on[].repo` | string | Upstream repository name |
+| `.depends_on[].watch_paths[]` | array of string | Glob paths in the upstream repo whose changes matter to this dependent; `"**"` watches the whole tree |
+| `.depends_on[].watch_branch` | string | Upstream branch to diff against (`main`, `develop`, ...) |
+| `.depends_on[].integration_tested_sha` | string | Last upstream SHA this dependent validated against — committed shared state |
+| `.depends_on[].tested_at` | string | ISO 8601 timestamp of that validation |
+| `.depends_on[].integration_workflow` | string | Optional — workflow whose success advances `integration_tested_sha` |
+
+Currency is `git diff integration_tested_sha..<watch_branch head> -- watch_paths`;
+any hit marks the edge `stale`. A missing or unreachable
+`integration_tested_sha` blocks closed (`state: unknown`), never silently
+passes as current. Local working-tree content is never a binding side —
+only the committed marker and the upstream remote head participate.
+
+**Legacy string edges.** A `depends_on[]` entry may also be a bare repository
+name (string), matching the pre-F5 shape. These remain accepted for backward
+compatibility but carry no watch metadata, so the impact audit cannot
+determine their currency; it surfaces them as `unconfigured_edge` findings
+(see `lib/patterns/headless-contract.md` § impact-result.yaml) instead of a
+current/stale verdict.
 
 ### cross_project_coordination
 
@@ -700,7 +728,14 @@ repo_dependencies:
 
   hiivmind-pulse-gh-tests:
     depends_on:
-      - hiivmind-pulse-gh
+      - repo: hiivmind-pulse-gh
+        watch_paths:
+          - "lib/patterns/headless-contract.md"
+          - "lib/pulse/scripts/validate_result.py"
+        watch_branch: develop
+        integration_tested_sha: abc1234
+        tested_at: "2026-07-01T10:00:00Z"
+        integration_workflow: ci.yml
     depended_by: []
     relationship_type: test
 
@@ -713,6 +748,8 @@ repo_dependencies:
 
   hiivmind-corpus-data:
     depends_on:
+      # Legacy string edge: accepted, but carries no watch metadata and is
+      # surfaced as an unconfigured_edge finding by the impact audit.
       - hiivmind-corpus
     depended_by: []
     relationship_type: plugin
@@ -735,7 +772,8 @@ cache:
 |------|------------|
 | Get repos for project | `yq '.project_repo_links[2].linked_repos[].name' relationships.yaml` |
 | Find projects for repo | `yq '.project_repo_links \| to_entries \| .[] \| select(.value.linked_repos[].name == "repo-name") \| .key' relationships.yaml` |
-| Get repo dependencies | `yq '.repo_dependencies["repo-name"].depends_on[]' relationships.yaml` |
+| Get repo dependencies (raw edges) | `yq '.repo_dependencies["repo-name"].depends_on[]' relationships.yaml` |
+| Get upstream repo names (object or legacy string edges) | `yq '.repo_dependencies["repo-name"].depends_on[] \| (.repo // .)' relationships.yaml` |
 | Get repo dependents | `yq '.repo_dependencies["repo-name"].depended_by[]' relationships.yaml` |
 | Get repo type | `yq '.repo_dependencies["repo-name"].relationship_type' relationships.yaml` |
 | Find coordinated projects | `yq '.cross_project_coordination[] \| select(.source_project == 2 or .target_project == 2)' relationships.yaml` |

--- a/skills/gh-impact-audit-headless/SKILL.md
+++ b/skills/gh-impact-audit-headless/SKILL.md
@@ -92,10 +92,16 @@ Collect remote branch-head and changed-path evidence for every watched object
 metadata and contribute no snapshot entries — they surface later as
 `unconfigured_edge` findings, not audit failures.
 
-When `CONFIG_DIR/poll-state.yaml` exists and has a `branch_heads` section
-(`lib/pulse/scripts/poll.py`'s `branch_heads` trigger — `{repo: {branch: head_sha}}`),
-pass it as `--known-heads` to save a redundant `git ls-remote` round trip. This never
-substitutes for the diff evidence itself, which the collector always computes fresh.
+When `CONFIG_DIR/poll-state.yaml` exists and its `.state.branch_heads` section is
+non-empty (`lib/pulse/scripts/poll.py`'s `branch_heads` trigger — `{repo: {branch:
+head_sha}}`), extract just that section — not the whole poll-state file — write it to
+`$KNOWN_HEADS_PATH`, and pass it as `--known-heads` to save a redundant `git ls-remote`
+round trip. `impact_snapshot.py --known-heads` parses YAML or JSON (`yaml.safe_load`
+accepts both), so `.state.branch_heads` can be extracted and written as either — no
+reserialization required. Skipping `ls-remote` never substitutes for the diff evidence
+itself or for the diff endpoint: the collector always fetches the branch fresh and
+resolves the actual current head from that fetch, so a stale `branch_heads` entry
+cannot under-report staleness — it only saves the redundant head-resolution round trip.
 
 ```bash
 uv run "${PLUGIN_ROOT}/lib/pulse/scripts/impact_snapshot.py" \

--- a/skills/gh-impact-audit-headless/SKILL.md
+++ b/skills/gh-impact-audit-headless/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: gh-impact-audit-headless
+description: >
+  Headless path-scoped integration-currency audit over repo_dependencies object edges
+  (F5). Collects remote branch-head and diff evidence, classifies every configured
+  edge as current/stale/unknown, and records tracking-issue and integration-workflow
+  dispatch proposals for stale bindings. Writes a validated impact-result.yaml. Zero
+  prompts; explicit inputs only. Never advances integration_tested_sha markers itself
+  — that only happens from confirmed workflow-run evidence (F5 follow-on). Use when a
+  scheduler audits binding currency, or a release gate needs binding_edges_current
+  evidence.
+---
+
+# Headless Impact Audit
+
+Audit whether each dependent repository's pinned `integration_tested_sha` is still
+current against its upstream's watched branch and paths. Currency is computed purely
+from remote evidence — never from local working-tree content — and severity beyond the
+deterministic current/stale/unknown verdict is out of scope: this skill records facts
+and proposals, it never mutates `relationships.yaml` or GitHub.
+
+`{PLUGIN_ROOT}` is the directory containing `plugin.json`.
+
+## Inputs and outputs
+
+- `workspace_path` (required): absolute workspace root containing `.hiivmind/github/`.
+- `repo` (optional): a dependent repo's full or short name; narrows the audit to that
+  repo's `repo_dependencies` entry. Defaults to every configured dependent.
+- `result_path` (optional): workspace default when usable, otherwise
+  `./impact-result.yaml`.
+- `mode` (optional): `interactive` or `scheduled`; defaults to `scheduled`.
+- Result: validated `impact-result.yaml` with kind `impact`
+  (`lib/patterns/headless-contract.md` § impact-result.yaml).
+
+## Contract
+
+- Zero prompts. Explicit inputs only. Every exit writes a result file.
+- Read-only against GitHub and against `relationships.yaml`: this skill never writes
+  `integration_tested_sha` markers (`impact.py::mark`) and never opens issues or
+  dispatches workflows. Stale bindings become `proposed_actions` entries — typed
+  strings an orchestrator or human reviews before acting.
+- **A successful integration-workflow dispatch proposal, even if a human or automation
+  later runs it, does not by itself advance any marker.** Markers only ever move from
+  confirmed workflow-run evidence consumed by a later run (F5 follow-on work) — this
+  skill's dispatch proposal is a suggestion, not evidence of a passing run.
+- Missing or unreachable baselines block closed: an edge whose `integration_tested_sha`
+  cannot be resolved on the remote is `state: unknown`, never `current`. This mirrors
+  `impact.py`'s own binding rule; the skill performs no arithmetic of its own here — it
+  copies the audit engine's verdict into the result unchanged.
+- Severity on any finding this skill adds is deterministic, `inferred: false`. No LLM
+  judgment pass runs here.
+
+## State
+
+Determine `RESULT_PATH` before validating the workspace: explicit `result_path`;
+otherwise the workspace default when `workspace_path` is non-empty and usable;
+otherwise `./impact-result.yaml` in the current directory. This fallback must be
+available for every early ABORT to write and validate its result.
+
+```text
+CONFIG_DIR      = {workspace_path}/.hiivmind/github
+RELATIONSHIPS   = CONFIG_DIR/relationships.yaml
+RESULT_PATH     = {explicit result_path, workspace default, or current-directory fallback}
+LOGIN           = unknown
+RUN_AT          = current UTC timestamp
+MODE            = {mode, default scheduled}
+ERRORS          = []
+PROPOSED_ACTIONS = []
+```
+
+## Phase 1: VALIDATE
+
+1. Missing `workspace_path` → ABORT `"missing required input: workspace_path"`.
+2. Missing `CONFIG_DIR/config.yaml` or its top-level `workspace` → ABORT
+   `"not a workspace root: {workspace_path}"`.
+3. After config validation succeeds, replace `LOGIN` with the authoritative
+   `.workspace.login` value from `CONFIG_DIR/config.yaml`.
+4. Ensure `*-result.yaml` is present in `CONFIG_DIR/.gitignore`.
+5. Missing `RELATIONSHIPS` → ABORT `"relationships.yaml not found: {RELATIONSHIPS}"`
+   (an impact audit with no dependency config has nothing to audit; this is a workspace
+   setup gap, not a valid empty run).
+6. Load `RELATIONSHIPS`. When `repo` is given, resolve it against
+   `repo_dependencies` full/short names and build `PREPARED_RELATIONSHIPS`, a temporary
+   copy whose `repo_dependencies` contains exactly that one entry. An unresolvable
+   `repo` → ABORT `"unknown repo: {repo}"`. Otherwise `PREPARED_RELATIONSHIPS` is
+   `RELATIONSHIPS` unchanged.
+
+## Phase 2: SNAPSHOT
+
+Collect remote branch-head and changed-path evidence for every watched object
+`depends_on` edge in `PREPARED_RELATIONSHIPS`. Legacy string edges carry no watch
+metadata and contribute no snapshot entries — they surface later as
+`unconfigured_edge` findings, not audit failures.
+
+When `CONFIG_DIR/poll-state.yaml` exists and has a `branch_heads` section
+(`lib/pulse/scripts/poll.py`'s `branch_heads` trigger — `{repo: {branch: head_sha}}`),
+pass it as `--known-heads` to save a redundant `git ls-remote` round trip. This never
+substitutes for the diff evidence itself, which the collector always computes fresh.
+
+```bash
+uv run "${PLUGIN_ROOT}/lib/pulse/scripts/impact_snapshot.py" \
+  --relationships "$PREPARED_RELATIONSHIPS_PATH" \
+  [--known-heads "$KNOWN_HEADS_PATH"] > "$SNAPSHOT_JSON"
+```
+
+A collector failure (non-zero exit, e.g. no network) → append its stderr to `ERRORS`
+and continue to Phase 3 with whatever partial snapshot it produced (or `{}` if it
+produced none) — a collection gap on one edge still lets the audit engine mark that
+edge `unknown` per its own fail-closed rule, rather than aborting the whole run.
+
+## Phase 3: AUDIT
+
+Classify every configured edge from the collected snapshot. This is the pure engine —
+no network, no git commands, no arithmetic in this skill:
+
+```bash
+uv run "${PLUGIN_ROOT}/lib/pulse/scripts/impact.py" audit \
+  --relationships "$PREPARED_RELATIONSHIPS_PATH" \
+  --snapshot "$SNAPSHOT_JSON" > "$AUDIT_JSON"
+```
+
+`$AUDIT_JSON` carries `edges_checked`, `edges_stale`, `edges[]`, and `findings[]`
+verbatim into the result — copy, do not recompute.
+
+## Phase 4: PROPOSE ISSUE/DISPATCH
+
+For every edge in `$AUDIT_JSON.edges` with `state: stale`:
+
+1. Append a tracking-issue proposal to `PROPOSED_ACTIONS`:
+   `"open tracking issue on {dependent}: {upstream}@{watch_branch} changed "
+   "{changed_paths} since {tested_sha} (binding stale)"`.
+2. Look up that edge's `depends_on[]` entry in `PREPARED_RELATIONSHIPS`
+   (`repo_dependencies.{dependent}.depends_on[]` matching `repo: {upstream}`). If it
+   carries `integration_workflow`, append a second proposal:
+   `"dispatch {integration_workflow} on {dependent} to re-verify against "
+   "{upstream}@{remote_head}"`. No `integration_workflow` configured → no dispatch
+   proposal; the tracking issue alone stands.
+
+For every `unconfigured_edge` finding in `$AUDIT_JSON.findings`, append a migration
+proposal: `"migrate legacy depends_on edge on {repo} to the object edge shape "
+"(lib/references/config-schema.md § depends_on edges) so impact audit can track it"`.
+
+This phase never calls `gh` and never invokes `impact.py mark` — proposals are data,
+not actions. An orchestrator or human decides whether to open the issue or run the
+dispatch; running it is still not evidence of currency (see Contract).
+
+## Phase 5: RECORD
+
+Write `RESULT_PATH`:
+
+```yaml
+contract_version: 1
+kind: impact
+workspace: {LOGIN}
+run_at: "{RUN_AT}"                # quote: an unquoted ISO-8601 value parses as a YAML datetime
+actor: { gh_login: {gh api user login or unknown}, machine: {hostname}, mode: {MODE} }
+edges_checked: {AUDIT_JSON.edges_checked}
+edges_stale: {AUDIT_JSON.edges_stale}
+markers_updated: 0                # this skill never calls impact.py mark; see Contract
+edges: {AUDIT_JSON.edges}
+findings: {AUDIT_JSON.findings}
+proposed_actions: {PROPOSED_ACTIONS}
+asks_recorded: []                 # every gap this skill hits is deterministic; nothing to ask
+errors: {ERRORS}
+```
+
+Validate:
+
+```bash
+uv run "${PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py" "$RESULT_PATH" --kind impact
+```
+
+Non-zero exit is a skill bug; report validator stderr verbatim.
+
+Print a one-line log summary:
+`impact-audit: edges={edges_checked} stale={edges_stale} proposed={n}`
+
+## ABORT semantics
+
+Every ABORT above appends the reason to `ERRORS` and falls through to Phase 5 with
+`edges_checked: 0`, `edges_stale: 0`, `markers_updated: 0`, `edges: []`,
+`findings: []`, `proposed_actions: []`, `asks_recorded: []` — the result file is
+always written and validated. If `CONFIG_DIR` is unusable, write to the `result_path`
+input, else `impact-result.yaml` in the current directory, and say so.
+
+## Related
+
+- `lib/pulse/scripts/impact_snapshot.py` — remote-evidence collector (F5 Task 3)
+- `lib/pulse/scripts/impact.py` — pure audit engine + marker writer (F5 Task 1/2)
+- `lib/patterns/headless-contract.md` — the impact-result schema
+- `lib/references/config-schema.md` § depends_on edges — `repo_dependencies` shape
+- `lib/patterns/run-ledger.md` — the `binding_edges_current` release gate that consumes
+  this skill's `impact-result.yaml` via `resolve_run.py check-gate`

--- a/templates/relationships.yaml.template
+++ b/templates/relationships.yaml.template
@@ -43,9 +43,13 @@ project_repo_links:
 # depends_on entries are object edges that carry integration-currency state
 # for the impact audit (impact.py, F5):
 #   - repo: {{repo_name}}                     # Upstream repository this edge watches
-#     watch_paths: []                         # Glob paths in the upstream repo whose
-#                                              # changes matter to this dependent ("**"
-#                                              # watches the whole tree)
+#     watch_paths:                            # Glob paths in the upstream repo whose
+#       - {{glob_path}}                       # changes matter to this dependent ("**"
+#                                              # watches the whole tree). Required and
+#                                              # non-empty — an edge with no watch_paths
+#                                              # can never be marked stale, so the audit
+#                                              # treats it as unknown (misconfigured),
+#                                              # never current.
 #     watch_branch: {{branch}}                # Upstream branch to diff against (main, develop, ...)
 #     integration_tested_sha: {{sha}}         # Last upstream SHA this dependent validated against
 #     tested_at: {{timestamp}}                # ISO 8601 timestamp of that validation
@@ -58,7 +62,9 @@ project_repo_links:
 # Legacy plain-string entries (a bare repo name, no watch metadata) remain
 # accepted for backward compatibility, but the impact audit cannot determine
 # their currency — they are surfaced as `unconfigured_edge` findings instead
-# of a current/stale verdict.
+# of a current/stale verdict. An object edge with empty/missing watch_paths
+# is surfaced the same way: `state: unknown` plus an `empty_watch_paths`
+# finding, never `current`.
 repo_dependencies:
   {{repo_name}}:                     # Repository name
     depends_on: []                   # Repositories this repo depends on (object edges; see above)

--- a/templates/relationships.yaml.template
+++ b/templates/relationships.yaml.template
@@ -39,9 +39,29 @@ project_repo_links:
 # Repository Dependencies
 # Documents which repositories depend on each other
 # This is typically manually maintained based on project architecture
+#
+# depends_on entries are object edges that carry integration-currency state
+# for the impact audit (impact.py, F5):
+#   - repo: {{repo_name}}                     # Upstream repository this edge watches
+#     watch_paths: []                         # Glob paths in the upstream repo whose
+#                                              # changes matter to this dependent ("**"
+#                                              # watches the whole tree)
+#     watch_branch: {{branch}}                # Upstream branch to diff against (main, develop, ...)
+#     integration_tested_sha: {{sha}}         # Last upstream SHA this dependent validated against
+#     tested_at: {{timestamp}}                # ISO 8601 timestamp of that validation
+#     integration_workflow: {{workflow}}      # Optional: workflow whose success advances the marker
+#
+# Currency is computed as `git diff integration_tested_sha..<watch_branch head> -- watch_paths`;
+# any hit marks the edge stale. A missing or unreachable integration_tested_sha
+# blocks closed (state: unknown), never silently passes.
+#
+# Legacy plain-string entries (a bare repo name, no watch metadata) remain
+# accepted for backward compatibility, but the impact audit cannot determine
+# their currency — they are surfaced as `unconfigured_edge` findings instead
+# of a current/stale verdict.
 repo_dependencies:
   {{repo_name}}:                     # Repository name
-    depends_on: []                   # Repositories this repo depends on
+    depends_on: []                   # Repositories this repo depends on (object edges; see above)
     depended_by: []                  # Repositories that depend on this repo
     relationship_type: {{type}}      # main, plugin, test, documentation
 
@@ -54,7 +74,14 @@ repo_dependencies:
 #     relationship_type: main
 #   hiivmind-pulse-gh-tests:
 #     depends_on:
-#       - hiivmind-pulse-gh
+#       - repo: hiivmind-pulse-gh
+#         watch_paths:
+#           - "lib/patterns/headless-contract.md"
+#           - "lib/pulse/scripts/validate_result.py"
+#         watch_branch: develop
+#         integration_tested_sha: abc1234
+#         tested_at: "2026-07-01T10:00:00Z"
+#         integration_workflow: ci.yml
 #     depended_by: []
 #     relationship_type: test
 #   hiivmind-corpus:
@@ -63,6 +90,13 @@ repo_dependencies:
 #       - hiivmind-corpus-data
 #       - hiivmind-corpus-claude
 #     relationship_type: main
+#   hiivmind-corpus-data:
+#     depends_on:
+#       # Legacy string edge: accepted, but carries no watch metadata and is
+#       # surfaced as an unconfigured_edge finding by the impact audit.
+#       - hiivmind-corpus
+#     depended_by: []
+#     relationship_type: plugin
 
 # Cross-Project Coordination
 # Documents scenarios where work in one project affects another

--- a/templates/workflows/impact-audit.yaml
+++ b/templates/workflows/impact-audit.yaml
@@ -1,0 +1,39 @@
+# hiivmind-pulse-gh - Impact Audit Workflow
+# Audit path-scoped integration currency for repo_dependencies object edges (F5)
+# and record tracking-issue / integration-workflow dispatch proposals for stale
+# bindings. Never advances integration_tested_sha markers itself.
+# Copy to: .hiivmind/github/workflows/impact-audit.yaml
+
+name: "impact-audit"
+description: "Audit binding edge currency and propose tracking issues/dispatches for stale bindings"
+enabled: true
+auto: false  # Must be explicitly requested — never runs automatically
+
+# Reference headless annotation: the audit is read-only against GitHub and
+# relationships.yaml; INVOKE maps to the gh-impact-audit-headless sibling when
+# present (see workflow-execution.md).
+headless:
+  enabled: true
+  on_ask: record
+  on_mutation: propose   # tracking issues and integration dispatches are proposed, never applied unattended
+
+trigger:
+  type: on_demand
+  condition: user_requested
+
+params:
+  repo:
+    description: "Optional dependent repo (full or short name) to scope the audit to; empty audits every configured dependent"
+    type: string
+    default: ""
+
+state: {}
+
+workflow: |
+  EXECUTE:
+    INVOKE skill hiivmind-pulse-gh:gh-impact-audit-headless
+      WITH workspace_path=workspace_root,
+           repo=params.repo,
+           mode=scheduled
+
+cooldown_minutes: 1440  # 24 hours


### PR DESCRIPTION
## Summary
- Object-shaped dependency edges (`{repo, watch_paths, watch_branch, integration_tested_sha, tested_at, integration_workflow}`) in relationships config + new headless result kind `impact` (validator, headless contract, config schema docs)
- Pure audit engine `lib/pulse/scripts/impact.py`: `audit()` classifies edges current/stale/unknown from snapshot evidence; `mark()` expected-base-guarded idempotent atomic marker patch; `propose_marks()`/`apply_proposals()` close the loop from successful configured integration-workflow evidence only — dispatch alone never advances markers
- Remote evidence collection `impact_snapshot.py` (git-first via injectable runner seam; bare `--filter=blob:none` fetches; fail-closed `base_missing`) + `branch_heads` trigger-only source in `poll.py`
- Headless workflow: `skills/gh-impact-audit-headless/SKILL.md`, `templates/workflows/impact-audit.yaml`, and fail-closed `binding_edges_current` gate via a new `GATE_EVALUATORS` registry in `resolve_run.py`
- Final-review hardening: FETCH_HEAD is always the diff endpoint (stale cached heads can't fail open), empty `watch_paths` fails closed to `unknown`, `--known-heads` accepts YAML/JSON, SHA/branch regex-gated before any git argv

## Review
5 SDD tasks, each spec+quality reviewed; final whole-branch Opus review (1 Important + 3 Minor, all fixed in a5f0f8c) re-verified clean.

## Test plan
- `uv run pytest -q` → 453 passed (develop baseline 371; +82)
- `git diff --check` clean

Part of the F5–F9 fleet program stack; next phases (F6–F9) branch off this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)