### PR TITLE
F6: Nave pen mutation orchestration

### DIFF
--- a/lib/patterns/headless-contract.md
+++ b/lib/patterns/headless-contract.md
@@ -14,6 +14,7 @@ retained for human-readable logs only — orchestrators MUST read the file.
 | refresh | refresh-result.yaml | `{workspace_root}/.hiivmind/github/refresh-result.yaml` |
 | workflow-run | workflow-run-result.yaml | `{workspace_root}/.hiivmind/github/workflow-run-result.yaml` |
 | impact | impact-result.yaml | `{workspace_root}/.hiivmind/github/impact-result.yaml` |
+| repo-mutation | repo-mutation-result.yaml | `{workspace_root}/.hiivmind/github/repo-mutation-result.yaml` |
 
 Result files are per-machine transient run artifacts (never authority — see
 `workspace-detection.md` § Multi-machine topology). The workspace repo's
@@ -33,7 +34,7 @@ not kinds they were not asked to validate.
 
 ```yaml
 contract_version: 1                   # int, required
-kind: status | healthcheck | fleet-membership | refresh | workflow-run | impact
+kind: status | healthcheck | fleet-membership | refresh | workflow-run | impact | repo-mutation
 workspace: <login>                    # str, required — org/user login
 run_at: <ISO 8601 timestamp>          # str, required
 actor:                                # required on ALL kinds (I4)
@@ -55,6 +56,7 @@ profiles, and machines: identity-sensitive logic resolves against the
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py refresh-result.yaml --kind refresh
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py workflow-run-result.yaml --kind workflow-run
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py impact-result.yaml --kind impact
+    uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py repo-mutation-result.yaml --kind repo-mutation
 
 Orchestrators validate before consuming and treat exit 1/2 as a failed run
 (report, do not commit). Exit codes: 0 valid, 1 invalid (errors on stderr),
@@ -309,6 +311,38 @@ unauditable-by-construction edge: no path evidence can ever mark it stale,
 so it blocks closed too — `state: unknown` plus an `empty_watch_paths`
 finding (`severity: low`) — rather than defaulting to `current` for lack of
 any hits to report.
+
+### repo-mutation-result.yaml (written by the pen orchestrator, F6)
+
+Carries the `PenRunResult` attribution record (`lib/pulse/scripts/pen_orchestrator.py`)
+for one repository-file mutation run driven through a Nave pen. See
+`lib/patterns/repository-mutations.md` for the mutation-policy vocabulary and
+the pen state machine this result is the terminal record of.
+
+```yaml
+contract_version: 1
+kind: repo-mutation
+workspace: <login>
+run_at: <ISO 8601>
+actor: { gh_login: <str>, machine: <str>, mode: <enum> }
+state: proposed | blocked | failed  # required enum — the run's terminal state
+proposal_id: <str>                  # required — the mutation_plan.Proposal id
+transformation: <str>               # required — registered transformation id
+pen_name: <str>                     # required — the Nave pen this run used
+selection: [<owner/name>, ...]      # list of str, required — repos targeted
+nave_version: <str or null>         # required key, nullable — probed `nave --version`
+repo_outcomes:                      # dict, required: owner/name -> outcome
+  <owner/name>: ok | failed | blocked
+reason: <str or null>               # required key, nullable — non-null when state
+                                     #   is blocked or failed
+errors: []
+```
+
+This orchestrator is propose-only: `state: proposed` is its only terminal
+success, meaning a commit/push/PR action is proposed for something else to
+apply later, never performed by the run itself. `reason` is required
+(non-null) whenever `state` is `blocked` or `failed`, and optional (may be
+null) when `state` is `proposed`.
 
 ## Related patterns
 

--- a/lib/patterns/repository-mutations.md
+++ b/lib/patterns/repository-mutations.md
@@ -58,6 +58,12 @@ mutations are not a separate policy dialect from GitHub-object mutations:
   other gate below (still requires a registered transformation; still
   blocks on a stale/dirty pen or a validation failure).
 
+> **Current implementation status:** the F6 orchestrator
+> (`pen_orchestrator.execute`) is propose-only — it blocks any policy other
+> than `propose` before making a single Nave call. `allow-listed` and
+> `allow` describe the semantics reserved for a later apply step; until that
+> lands, setting either yields a `blocked` result, never a push.
+
 ## The transformation registry
 
 `mutation_plan.load_registry(path_or_dict)` loads and cross-validates

--- a/lib/patterns/repository-mutations.md
+++ b/lib/patterns/repository-mutations.md
@@ -1,0 +1,141 @@
+# Repository-file mutations via Nave pens
+
+Repository-file writes never happen through raw shell commands or a
+second checkout mechanism — they route through a Nave pen
+(`lib/pulse/scripts/nave_adapter.py`, F6 Task 1), driven by a typed
+mutation proposal validated against a strict, committed transformation
+registry (`lib/pulse/scripts/mutation_plan.py`, F6 Task 2). Task 3's pen
+orchestrator (`pen_orchestrator.py`) consumes a validated `Proposal`, walks
+it through `planned -> created -> executed -> validated -> proposed |
+blocked | failed`, and is the only caller that actually drives
+`nave_adapter.pen_create` / `pen_exec`. This document is the normative
+contract those two modules implement; both modules are pure — no
+subprocess calls, no filesystem writes, no Nave interaction.
+
+## Global constraints (repeated from the F6 plan)
+
+- `nave pen exec` arbitrary commands are user-gated unless mapped to a
+  registered transformation.
+- Automatic/scheduled mode permits only registered transformation IDs with
+  `allow_scheduled: true`.
+- Default mutation policy is propose-only: create/run locally, no push.
+- Stale or dirty pens block application.
+- Pulse records actor, machine, Nave version, pen name, selection, command
+  ID, and per-repo outcome.
+
+## The proposal
+
+`mutation_plan.build_proposal(...)` constructs and validates a `Proposal`:
+
+```text
+{id, selection, transformation, expected_shas, mutation_policy, actor}
+```
+
+| Field | Shape | Meaning |
+|---|---|---|
+| `id` | non-empty string | Caller-assigned identifier for this proposal/run. |
+| `selection` | list of `owner/name` strings, non-empty, no duplicates | The repositories this proposal targets. Resolving a fleet query (Nave `search`/`match` terms) into this concrete repo list is the caller's job — `mutation_plan` never talks to Nave. |
+| `transformation` | string | A registered transformation ID (`TransformationRegistry` key). |
+| `expected_shas` | dict `owner/name -> sha` | The expected-base guard: keys must be **exactly** `selection`, no more, no fewer. The orchestrator (Task 3) compares this against each repo's current SHA before executing and blocks on any mismatch — a stale base is never silently mutated. |
+| `mutation_policy` | one of `propose`, `allow-listed`, `allow` | See below. Default: `propose`. |
+| `actor` | `{gh_login, machine, mode}` | Same shape as the headless result contract's `actor:` block (`lib/patterns/headless-contract.md`); `mode` is `interactive` or `scheduled`. |
+
+### `mutation_policy` values
+
+Reused verbatim from the `on_mutation` headless-workflow vocabulary
+(`lib/patterns/workflow-execution.md` § Headless Execution) — repository
+mutations are not a separate policy dialect from GitHub-object mutations:
+
+- **`propose`** (default) — create the pen, run the transformation locally,
+  report the resulting diff/status as a proposed action. Never commits or
+  pushes. This is what "default mutation policy is propose-only" means in
+  pen terms: `pen_exec` is called with `commit=False, push_changes=False`.
+- **`allow-listed`** — commit/push only when the proposal's transformation
+  is itself the allow-listed capability (registry membership + a scheduled
+  run's `allow_scheduled: true` gate stand in for the workflow-level
+  `mutation_allowlist`); otherwise behaves like `propose`.
+- **`allow`** — commit and push are permitted outright, subject to every
+  other gate below (still requires a registered transformation; still
+  blocks on a stale/dirty pen or a validation failure).
+
+## The transformation registry
+
+`mutation_plan.load_registry(path_or_dict)` loads and cross-validates
+`templates/transformations.yaml.template`-shaped content into a
+`TransformationRegistry`. Each entry:
+
+```text
+{id, command_argv, applies_to, validation, allow_scheduled}
+```
+
+| Field | Shape | Meaning |
+|---|---|---|
+| `id` | string, must match its registry key | The transformation ID proposals reference. |
+| `command_argv` | non-empty list of plain strings | The **exact** argv passed to `nave_adapter.pen_exec` after `--`. No nested structures (lists/dicts as elements are rejected), no booleans. |
+| `applies_to` | non-empty list of predicates | OR-matched repository eligibility, in the same grammar `profile_dispatch.py` uses for scorecard-check applicability: `always`, `profile:<id>`, `capability:<id>`, `evidence_path:<glob>`. `mutation_plan.transformation_applies(entry, profiles, capabilities, evidence_paths)` evaluates it. |
+| `validation` | `{kind: none \| json_schema, ...}` | Post-execution check the orchestrator runs after `pen_exec` succeeds. `kind: none` takes no extra fields. `kind: json_schema` requires `path` (repo-relative file the transformation is expected to produce/modify) and `schema` (inline JSON Schema mapping the file's parsed content must satisfy). A validation failure is a `blocked`/`failed` outcome, never a silent pass. |
+| `allow_scheduled` | boolean | Whether this transformation may run under `actor.mode: scheduled`. Interactive-only transformations (destructive, judgment-requiring, or simply not yet trusted unattended) set this `false`. |
+
+### No shell strings, ever
+
+`command_argv` is a strict argv array. There is no template/command
+substitution of any kind — `mutation_plan.resolve_argv(entry)` returns
+`entry.command_argv` byte-identical to what was committed, and no proposal
+field (repo name, SHA, actor, …) is ever interpolated into it. An argv
+element containing shell metacharacters (`` `$(rm -rf /)` ``, `` ; rm -rf / ``,
+`` | cat ``, backticks) is passed through as **literal data** to
+`subprocess.run(..., shell=False)` (`nave_adapter.NaveRunner.run`) — it is
+never parsed or expanded by a shell, because no shell is ever invoked. This
+is the same guarantee `nave_adapter.pen_exec`'s docstring makes for its
+`command` parameter; the registry is simply the only place argv is allowed
+to originate from for anything other than an explicitly user-approved
+one-off `pen exec`.
+
+## Gating rules
+
+1. **Unknown transformation ID is a hard error.** `registry.get(id)` /
+   `validate_proposal` raise `MutationPlanError` — there is no fallback to
+   raw argv.
+2. **Scheduled mode requires `allow_scheduled: true`.** A proposal whose
+   `actor.mode == "scheduled"` referencing a transformation with
+   `allow_scheduled: false` fails validation before anything runs. This is
+   the mechanical enforcement of "automatic/scheduled mode permits only
+   registered transformation IDs with `allow_scheduled: true`" — unregistered
+   or interactive-only commands can never reach an unattended run.
+3. **Arbitrary `pen exec` stays user-gated.** `mutation_plan` has no code
+   path that turns free-form text into argv; only a registry entry's fixed
+   `command_argv` is ever executed by the orchestrator. A human running
+   `nave pen exec` directly, outside Pulse, is unaffected — that gate is a
+   property of *this* module's proposal path, not of Nave itself.
+4. **`expected_shas` must cover the selection exactly.** Every selected
+   repo needs a guard SHA; no guard SHA may reference a repo outside the
+   selection (that would silently widen the blast radius of a "matched"
+   proposal).
+5. **Propose-only is the default.** Omitting `mutation_policy` yields
+   `propose`; nothing commits or pushes without an explicit, validated
+   opt-in.
+
+## Attribution
+
+Every proposal carries the `actor` block Pulse needs to record who/what ran
+a mutation: `gh_login`, `machine`, and `mode`. Task 3's orchestrator
+combines this with the pen name, the probed Nave version
+(`nave_adapter.probe`), the resolved `selection`, the `transformation` ID,
+and each repo's exec outcome (from `pen_status --json`) into the
+`repo-mutation` result kind (F6 Task 4, `lib/patterns/headless-contract.md`).
+Nothing in that attribution record is inferred or reconstructed after the
+fact — it is built from the same `Proposal` that gated execution.
+
+## Validation
+
+```text
+uv run pytest lib/pulse/scripts/tests/test_mutation_plan.py -q
+```
+
+## Related patterns
+
+- `lib/patterns/nave-evidence-contract.md` — read-side Nave fleet evidence.
+- `lib/patterns/headless-contract.md` — actor block, mutation-policy
+  vocabulary (`on_mutation`), and the `repo-mutation` result kind (F6 Task 4).
+- `lib/pulse/scripts/profile_dispatch.py` — the applicability predicate
+  grammar `applies_to` reuses.

--- a/lib/patterns/repository-mutations.md
+++ b/lib/patterns/repository-mutations.md
@@ -36,7 +36,7 @@ subprocess calls, no filesystem writes, no Nave interaction.
 | `id` | non-empty string | Caller-assigned identifier for this proposal/run. |
 | `selection` | list of `owner/name` strings, non-empty, no duplicates | The repositories this proposal targets. Resolving a fleet query (Nave `search`/`match` terms) into this concrete repo list is the caller's job — `mutation_plan` never talks to Nave. |
 | `transformation` | string | A registered transformation ID (`TransformationRegistry` key). |
-| `expected_shas` | dict `owner/name -> sha` | The expected-base guard: keys must be **exactly** `selection`, no more, no fewer. The orchestrator (Task 3) compares this against each repo's current SHA before executing and blocks on any mismatch — a stale base is never silently mutated. |
+| `expected_shas` | dict `owner/name -> sha` | The expected-base guard: keys must be **exactly** `selection`, no more, no fewer. The orchestrator (Task 3) compares this against each repo's current SHA before executing and blocks on any mismatch — a stale base is never silently mutated. Since no Nave surface exposes a per-repo SHA, this comparison runs through an injectable `read_repo_head` reader `execute` accepts (same seam pattern as `read_repo_file`); with `expected_shas` non-empty and no reader supplied, verification fails closed. |
 | `mutation_policy` | one of `propose`, `allow-listed`, `allow` | See below. Default: `propose`. |
 | `actor` | `{gh_login, machine, mode}` | Same shape as the headless result contract's `actor:` block (`lib/patterns/headless-contract.md`); `mode` is `interactive` or `scheduled`. |
 

--- a/lib/pulse/scripts/mutation_plan.py
+++ b/lib/pulse/scripts/mutation_plan.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Typed repository-mutation proposals and the transformation registry.
+
+Pure module: no subprocess calls, no filesystem writes, no Nave interaction.
+`lib/pulse/scripts/pen_orchestrator.py` (F6 Task 3) resolves a validated
+`Proposal`'s `transformation` into exact argv via `resolve_argv` and drives
+`nave_adapter.pen_exec` with it. See `lib/patterns/repository-mutations.md`
+for the normative contract this module implements.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from fnmatch import fnmatchcase
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ACTOR_MODES = {"interactive", "scheduled"}
+MUTATION_POLICIES = {"propose", "allow-listed", "allow"}
+VALIDATION_KINDS = {"none", "json_schema"}
+
+
+class MutationPlanError(ValueError):
+    """Raised when registry metadata or a mutation proposal violates its contract."""
+
+
+# --- registry -----------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ValidationSpec:
+    """Post-execution validation a transformation's result must satisfy."""
+
+    kind: str
+    path: str | None = None
+    schema: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class TransformationEntry:
+    """One registered, strict-argv repository transformation."""
+
+    id: str
+    command_argv: tuple[str, ...]
+    applies_to: tuple[str, ...]
+    validation: ValidationSpec
+    allow_scheduled: bool
+
+
+@dataclass(frozen=True)
+class TransformationRegistry:
+    """Loaded, cross-validated `transformations.yaml` content."""
+
+    transformations: dict[str, TransformationEntry]
+
+    def get(self, transformation_id: str) -> TransformationEntry:
+        entry = self.transformations.get(transformation_id)
+        if entry is None:
+            raise MutationPlanError(f"unknown transformation: {transformation_id}")
+        return entry
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MutationPlanError(f"{label} must be a mapping")
+    if not all(isinstance(key, str) for key in value):
+        raise MutationPlanError(f"{label} keys must be strings")
+    return value
+
+
+def _list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise MutationPlanError(f"{label} must be a list")
+    return value
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise MutationPlanError(f"{label} must be a non-empty string")
+    return value
+
+
+def _only_keys(data: dict[str, Any], allowed: set[str], label: str) -> None:
+    unknown = set(data) - allowed
+    if unknown:
+        raise MutationPlanError(f"unknown {label} key: {sorted(unknown)[0]}")
+
+
+def _argv(value: Any, label: str) -> tuple[str, ...]:
+    """Strict argv: a non-empty list of plain strings, no nested structures.
+
+    Shell metacharacters inside an element (e.g. `$(rm -rf /)`, `; rm -rf /`,
+    `| cat`) are never interpreted — they are opaque literal bytes handed to
+    `subprocess.run(..., shell=False)` (see `nave_adapter.NaveRunner.run`).
+    There is no templating or command substitution of any kind: an argv
+    element is exactly the string committed in the registry, always.
+    """
+    items = _list(value, label)
+    if not items:
+        raise MutationPlanError(f"{label} must be a non-empty list")
+    for index, item in enumerate(items):
+        if isinstance(item, bool) or not isinstance(item, str):
+            raise MutationPlanError(f"{label}[{index}] must be a string")
+    return tuple(items)
+
+
+def _load_validation(raw: Any, entry_id: str) -> ValidationSpec:
+    item = _mapping(raw, f"transformation {entry_id}.validation")
+    _only_keys(item, {"kind", "path", "schema"}, f"transformation {entry_id}.validation")
+    kind = _string(item.get("kind"), f"transformation {entry_id}.validation.kind")
+    if kind not in VALIDATION_KINDS:
+        raise MutationPlanError(
+            f"transformation {entry_id}.validation.kind invalid: {kind}"
+        )
+    if kind == "none":
+        if "path" in item or "schema" in item:
+            raise MutationPlanError(
+                f"transformation {entry_id}.validation: kind 'none' takes no path/schema"
+            )
+        return ValidationSpec(kind="none")
+    # kind == "json_schema"
+    path = _string(item.get("path"), f"transformation {entry_id}.validation.path")
+    schema = _mapping(item.get("schema"), f"transformation {entry_id}.validation.schema")
+    return ValidationSpec(kind="json_schema", path=path, schema=schema)
+
+
+def _applicability_predicate(predicate: str, entry_id: str) -> str:
+    """Validate one `applies_to` predicate against the profile-dispatch grammar.
+
+    Reuses `lib/pulse/scripts/profile_dispatch.py`'s applicability vocabulary
+    verbatim (`always`, `profile:<id>`, `capability:<id>`,
+    `evidence_path:<glob>`) so a transformation's repository eligibility is
+    expressed the same way a scorecard check's applicability is.
+    """
+    predicate = _string(predicate, f"transformation {entry_id}.applies_to entry")
+    if predicate == "always":
+        return predicate
+    if ":" not in predicate:
+        raise MutationPlanError(
+            f"transformation {entry_id}.applies_to invalid predicate: {predicate}"
+        )
+    kind, value = predicate.split(":", 1)
+    if kind not in {"profile", "capability", "evidence_path"} or not value:
+        raise MutationPlanError(
+            f"transformation {entry_id}.applies_to invalid predicate: {predicate}"
+        )
+    return predicate
+
+
+def _load_transformation(raw: Any, entry_id: str) -> TransformationEntry:
+    item = _mapping(raw, f"transformation {entry_id}")
+    _only_keys(
+        item,
+        {"id", "command_argv", "applies_to", "validation", "allow_scheduled"},
+        f"transformation {entry_id}",
+    )
+    declared_id = _string(item.get("id"), f"transformation {entry_id}.id")
+    if declared_id != entry_id:
+        raise MutationPlanError(
+            f"transformation {entry_id}.id must match its registry key: {declared_id}"
+        )
+    command_argv = _argv(item.get("command_argv"), f"transformation {entry_id}.command_argv")
+    applies_to_raw = _list(item.get("applies_to"), f"transformation {entry_id}.applies_to")
+    if not applies_to_raw:
+        raise MutationPlanError(f"transformation {entry_id}.applies_to must be non-empty")
+    applies_to = tuple(
+        _applicability_predicate(predicate, entry_id) for predicate in applies_to_raw
+    )
+    validation = _load_validation(item.get("validation"), entry_id)
+    allow_scheduled = item.get("allow_scheduled")
+    if not isinstance(allow_scheduled, bool):
+        raise MutationPlanError(
+            f"transformation {entry_id}.allow_scheduled must be a boolean"
+        )
+    return TransformationEntry(
+        id=entry_id,
+        command_argv=command_argv,
+        applies_to=applies_to,
+        validation=validation,
+        allow_scheduled=allow_scheduled,
+    )
+
+
+def load_registry(source: str | Path | dict[str, Any]) -> TransformationRegistry:
+    """Load and cross-validate `transformations.yaml` content.
+
+    `source` is either a path to a YAML file or an already-parsed mapping
+    (tests and in-process callers may pass a dict directly).
+    """
+    if isinstance(source, dict):
+        data = source
+    elif isinstance(source, (str, Path)):
+        path = Path(source)
+        try:
+            data = yaml.safe_load(path.read_text())
+        except FileNotFoundError as exc:
+            raise MutationPlanError(f"registry not found: {path}") from exc
+        except (OSError, UnicodeError, yaml.YAMLError) as exc:
+            raise MutationPlanError(f"could not load registry: {exc}") from exc
+    else:
+        raise MutationPlanError("registry source must be a path or a mapping")
+
+    root = _mapping(data, "registry")
+    _only_keys(root, {"transformations"}, "registry")
+    if "transformations" not in root:
+        raise MutationPlanError("missing required key: transformations")
+    raw_transformations = _mapping(root["transformations"], "registry.transformations")
+
+    transformations = {
+        transformation_id: _load_transformation(value, transformation_id)
+        for transformation_id, value in raw_transformations.items()
+    }
+    return TransformationRegistry(transformations)
+
+
+def resolve_argv(entry: TransformationEntry) -> tuple[str, ...]:
+    """Return a registered transformation's exact argv, verbatim.
+
+    No templating, no interpolation of proposal fields, no shell
+    interpretation of any element — the returned tuple is byte-identical to
+    `entry.command_argv`.
+    """
+    return entry.command_argv
+
+
+def transformation_applies(
+    entry: TransformationEntry,
+    profiles: tuple[str, ...] = (),
+    capabilities: tuple[str, ...] = (),
+    evidence_paths: tuple[str, ...] = (),
+) -> bool:
+    """Evaluate `applies_to` (OR semantics) against one repository's evidence.
+
+    Mirrors `profile_dispatch._is_applicable`'s predicate grammar so a
+    transformation's eligibility reads the same way a scorecard check's
+    applicability does.
+    """
+    for predicate in entry.applies_to:
+        if predicate == "always":
+            return True
+        kind, value = predicate.split(":", 1)
+        if kind == "profile" and value in profiles:
+            return True
+        if kind == "capability" and value in capabilities:
+            return True
+        if kind == "evidence_path" and any(
+            fnmatchcase(path, value) for path in evidence_paths
+        ):
+            return True
+    return False
+
+
+# --- proposal -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Actor:
+    """Attribution block — identical shape to the headless result contract's
+    `actor:` (see `lib/patterns/headless-contract.md`)."""
+
+    gh_login: str
+    machine: str
+    mode: str
+
+
+@dataclass(frozen=True)
+class Proposal:
+    """A validated repository-mutation proposal.
+
+    `selection` is the list of `owner/name` repositories this proposal
+    targets. `expected_shas` is the expected-base guard: the SHA each
+    selected repo must currently be at before the orchestrator (F6 Task 3)
+    proceeds — a mismatch means the remote moved since the proposal was
+    built and the run must block rather than mutate a stale base.
+    """
+
+    id: str
+    selection: tuple[str, ...]
+    transformation: str
+    expected_shas: dict[str, str]
+    mutation_policy: str
+    actor: Actor
+
+
+def _repo_name(value: Any, label: str) -> str:
+    name = _string(value, label)
+    parts = name.split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise MutationPlanError(f"{label} must be owner/name: {name}")
+    return name
+
+
+def _load_actor(raw: Any) -> Actor:
+    item = _mapping(raw, "proposal.actor")
+    _only_keys(item, {"gh_login", "machine", "mode"}, "proposal.actor")
+    gh_login = _string(item.get("gh_login"), "proposal.actor.gh_login")
+    machine = _string(item.get("machine"), "proposal.actor.machine")
+    mode = _string(item.get("mode"), "proposal.actor.mode")
+    if mode not in ACTOR_MODES:
+        raise MutationPlanError(f"proposal.actor.mode invalid: {mode}")
+    return Actor(gh_login=gh_login, machine=machine, mode=mode)
+
+
+def build_proposal(
+    id: str,
+    selection: list[str] | tuple[str, ...],
+    transformation: str,
+    expected_shas: dict[str, str],
+    actor: dict[str, Any] | Actor,
+    mutation_policy: str = "propose",
+    registry: TransformationRegistry | None = None,
+) -> Proposal:
+    """Construct and validate a `Proposal`.
+
+    Raises `MutationPlanError` for any contract violation — see
+    `lib/patterns/repository-mutations.md` § Gating rules. When `registry`
+    is supplied, the proposal is also checked against it (unknown
+    transformation id, scheduled/`allow_scheduled` gating); omit it only for
+    shape-only construction in tests that check registry gating separately.
+    """
+    proposal_id = _string(id, "proposal.id")
+    selection_list = _list(list(selection), "proposal.selection")
+    if not selection_list:
+        raise MutationPlanError("proposal.selection must be non-empty")
+    repos = tuple(_repo_name(repo, "proposal.selection entry") for repo in selection_list)
+    if len(set(repos)) != len(repos):
+        raise MutationPlanError("proposal.selection must not contain duplicate repos")
+
+    transformation_id = _string(transformation, "proposal.transformation")
+
+    shas = _mapping(expected_shas, "proposal.expected_shas")
+    missing = set(repos) - set(shas)
+    if missing:
+        raise MutationPlanError(
+            f"proposal.expected_shas missing entry for: {sorted(missing)[0]}"
+        )
+    extra = set(shas) - set(repos)
+    if extra:
+        raise MutationPlanError(
+            f"proposal.expected_shas has entry outside selection: {sorted(extra)[0]}"
+        )
+    normalized_shas = {
+        repo: _string(shas[repo], f"proposal.expected_shas[{repo}]") for repo in repos
+    }
+
+    policy = _string(mutation_policy, "proposal.mutation_policy")
+    if policy not in MUTATION_POLICIES:
+        raise MutationPlanError(f"proposal.mutation_policy invalid: {policy}")
+
+    actor_block = actor if isinstance(actor, Actor) else _load_actor(actor)
+
+    proposal = Proposal(
+        id=proposal_id,
+        selection=repos,
+        transformation=transformation_id,
+        expected_shas=normalized_shas,
+        mutation_policy=policy,
+        actor=actor_block,
+    )
+
+    if registry is not None:
+        validate_proposal(proposal, registry)
+    return proposal
+
+
+def validate_proposal(proposal: Proposal, registry: TransformationRegistry) -> None:
+    """Validate a `Proposal` against a loaded registry.
+
+    Raises `MutationPlanError` when the transformation is unknown, or when
+    the proposal's actor runs in `scheduled` mode against a transformation
+    that does not set `allow_scheduled: true` (see the F6 global constraint:
+    "automatic mode permits only registered transformation IDs").
+    """
+    entry = registry.get(proposal.transformation)
+    if proposal.actor.mode == "scheduled" and not entry.allow_scheduled:
+        raise MutationPlanError(
+            f"transformation not allowed in scheduled mode: {proposal.transformation}"
+        )

--- a/lib/pulse/scripts/nave_adapter.py
+++ b/lib/pulse/scripts/nave_adapter.py
@@ -49,6 +49,37 @@ class LifecycleResult:
     stderr: str
 
 
+@dataclass(frozen=True)
+class PenQuery:
+    """Fleet-filter query used to seed `nave pen create`.
+
+    Mirrors `nave_pen::CreateOptions` (minus `name`, which is a required,
+    separately-controlled argument on `pen_create` — see the F6 design
+    decision to never let Nave derive a pen name we'd have to parse back out
+    of opaque human text).
+    """
+
+    terms: Sequence[str] = ()
+    match_preds: Sequence[str] = ()
+    ignore_case: bool = False
+
+
+@dataclass(frozen=True)
+class PenHandle:
+    """Normalized result of `pen_create`: exit status plus a resolved pen.
+
+    `pen` is the normalized `pen show --json` payload (or the typed adapter
+    error from that call) — never a parse of create's human-readable stdout.
+    """
+
+    name: str
+    state: str
+    returncode: int
+    stdout: str
+    stderr: str
+    pen: dict | None
+
+
 def _fixture_output_path(root: Path, args: Sequence[str]) -> Path:
     if list(args) == ["--version"]:
         return root / "probe" / "version.txt"
@@ -57,6 +88,14 @@ def _fixture_output_path(root: Path, args: Sequence[str]) -> Path:
     if args and args[-1] == "--help":
         command = "-".join(args[:-1])
         return root / "probe" / f"{command}-help.txt"
+    if len(args) >= 2 and args[0] == "pen":
+        # Every `pen` subcommand shares args[0]; disambiguate by action
+        # (args[1]) into its own directory instead of colliding on
+        # `pen.json`/`pen.txt`.
+        action = args[1]
+        if "--json" in args:
+            return root / "pen" / f"{action}.json"
+        return root / "pen" / f"{action}.txt"
     if args and "--json" in args:
         return root / f"{args[0]}.json"
     if args:
@@ -325,6 +364,139 @@ def materialize(runner: NaveRunner, request: str) -> dict:
     return _decode_json("materialize", runner.run(args))
 
 
+def _decode_json_list(command: str, completed: Completed) -> dict:
+    """Decode a JSON-array-rooted command, normalized into `{"repos": [...]}`.
+
+    `pen status --json` serializes `Vec<RepoState>` — an array root, unlike
+    every other adapter command's object root — so it needs its own decoder
+    rather than reusing `_decode_json`.
+    """
+    try:
+        parsed = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        return {
+            "adapter_state": "error",
+            "command": command,
+            "returncode": completed.returncode,
+            "error": f"invalid JSON from nave {command}: {exc.msg}",
+            "stderr": completed.stderr,
+        }
+    if not isinstance(parsed, list):
+        return {
+            "adapter_state": "error",
+            "command": command,
+            "returncode": completed.returncode,
+            "error": f"invalid JSON from nave {command}: root is not an array",
+            "stderr": completed.stderr,
+        }
+    return {"repos": parsed}
+
+
+def pen_show(
+    runner: NaveRunner,
+    name: str = "",
+    filter_regex: str | None = None,
+) -> dict:
+    """Show a pen's normalized definition (`nave_pen::Pen` serialization)."""
+    args = ["pen", "show"]
+    if name:
+        args.append(name)
+    if filter_regex is not None:
+        args.extend(["--filter", filter_regex])
+    args.append("--json")
+    return _decode_json("pen show", runner.run(args))
+
+
+def pen_status(runner: NaveRunner, name: str) -> dict:
+    """Per-repo pen state (`Vec<nave_pen::RepoState>`), normalized to a dict."""
+    args = ["pen", "status", name, "--json"]
+    return _decode_json_list("pen status", runner.run(args))
+
+
+def pen_create(runner: NaveRunner, query: PenQuery, name: str) -> PenHandle:
+    """Create a pen, then resolve it via `pen show --json`.
+
+    `pen create` has no `--json` flag; its stdout is opaque text and is
+    NEVER parsed for data — only its exit code is used. The caller must
+    supply `name` explicitly (rather than letting Nave derive one from the
+    first term) precisely so this function never needs to scrape a name back
+    out of that opaque text to find the pen to show.
+    """
+    args = ["pen", "create", "--name", name]
+    if query.ignore_case:
+        args.append("--ignore-case")
+    for predicate in query.match_preds:
+        args.extend(["--match", predicate])
+    args.extend(query.terms)
+
+    create_result = runner.run(args)
+    if create_result.returncode != 0:
+        return PenHandle(
+            name=name,
+            state="error",
+            returncode=create_result.returncode,
+            stdout=create_result.stdout,
+            stderr=create_result.stderr,
+            pen=None,
+        )
+
+    show_result = pen_show(runner, name=name)
+    state = "error" if show_result.get("adapter_state") == "error" else "ok"
+    return PenHandle(
+        name=name,
+        state=state,
+        returncode=create_result.returncode,
+        stdout=create_result.stdout,
+        stderr=create_result.stderr,
+        pen=show_result,
+    )
+
+
+def pen_exec(
+    runner: NaveRunner,
+    name: str,
+    command: Sequence[str],
+    only: str | None = None,
+    commit: bool = False,
+    push_changes: bool = False,
+    message: str | None = None,
+) -> dict:
+    """Run a command in each pen repo, then verify via `pen status --json`.
+
+    `pen exec` has no `--json` flag; its stdout/stderr are opaque and are
+    recorded as-is for the caller's report, never parsed. `--push-changes`
+    (which implies `--commit` on the real CLI) and `--commit` are NEVER
+    emitted unless the caller explicitly requests them — this keeps the
+    default mutation policy propose-only (create/run locally, no push).
+    `command` is passed as an argv list after `--`, never a shell string.
+    """
+    if not command:
+        raise ValueError("pen_exec requires a non-empty command argv")
+
+    args = ["pen", "exec", name]
+    if only is not None:
+        args.extend(["--only", only])
+    if push_changes:
+        args.append("--push-changes")
+    elif commit:
+        args.append("--commit")
+    if message is not None:
+        args.extend(["-m", message])
+    args.append("--")
+    args.extend(command)
+
+    exec_result = runner.run(args)
+    status = pen_status(runner, name)
+    return {
+        "adapter_state": "ok" if exec_result.returncode == 0 else "error",
+        "command": "pen exec",
+        "returncode": exec_result.returncode,
+        "stdout": exec_result.stdout,
+        "stderr": exec_result.stderr,
+        "status": status,
+    }
+
+
 def _materialize_summary(report: dict) -> dict:
     """Build a content-free per-repo, per-state artifact summary.
 
@@ -386,6 +558,27 @@ def main(argv: list[str] | None = None) -> int:
     materialize_parser = subparsers.add_parser("materialize")
     add_runner_options(materialize_parser)
     materialize_parser.add_argument("--request", required=True)
+    pen_show_parser = subparsers.add_parser("pen-show")
+    add_runner_options(pen_show_parser)
+    pen_show_parser.add_argument("--name", default="")
+    pen_show_parser.add_argument("--filter")
+    pen_status_parser = subparsers.add_parser("pen-status")
+    add_runner_options(pen_status_parser)
+    pen_status_parser.add_argument("--name", required=True)
+    pen_create_parser = subparsers.add_parser("pen-create")
+    add_runner_options(pen_create_parser)
+    pen_create_parser.add_argument("--name", required=True)
+    pen_create_parser.add_argument("--ignore-case", action="store_true")
+    pen_create_parser.add_argument("--match", dest="matches", action="append", default=[])
+    pen_create_parser.add_argument("--term", action="append", default=[])
+    pen_exec_parser = subparsers.add_parser("pen-exec")
+    add_runner_options(pen_exec_parser)
+    pen_exec_parser.add_argument("--name", required=True)
+    pen_exec_parser.add_argument("--only")
+    pen_exec_parser.add_argument("--commit", action="store_true")
+    pen_exec_parser.add_argument("--push-changes", action="store_true")
+    pen_exec_parser.add_argument("--message", "-m")
+    pen_exec_parser.add_argument("cmd", nargs=argparse.REMAINDER)
     args = parser.parse_args(argv)
 
     runner = _runner_from_args(args)
@@ -427,6 +620,37 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         print(json.dumps(_materialize_summary(result), indent=2, sort_keys=True))
         return 0
+    if args.command == "pen-show":
+        result = pen_show(runner, name=args.name, filter_regex=args.filter)
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1 if result.get("adapter_state") == "error" else 0
+    if args.command == "pen-status":
+        result = pen_status(runner, args.name)
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1 if result.get("adapter_state") == "error" else 0
+    if args.command == "pen-create":
+        query = PenQuery(
+            terms=args.term, match_preds=args.matches, ignore_case=args.ignore_case
+        )
+        handle = pen_create(runner, query, args.name)
+        print(json.dumps(asdict(handle), indent=2, sort_keys=True))
+        return 1 if handle.state == "error" else 0
+    if args.command == "pen-exec":
+        cmd = args.cmd[1:] if args.cmd[:1] == ["--"] else args.cmd
+        if not cmd:
+            print("pen-exec requires a command after --", file=sys.stderr)
+            return 2
+        result = pen_exec(
+            runner,
+            args.name,
+            cmd,
+            only=args.only,
+            commit=args.commit,
+            push_changes=args.push_changes,
+            message=args.message,
+        )
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1 if result.get("adapter_state") == "error" else 0
     return 2
 
 

--- a/lib/pulse/scripts/pen_orchestrator.py
+++ b/lib/pulse/scripts/pen_orchestrator.py
@@ -48,6 +48,26 @@ pen layout itself. With no reader supplied, `json_schema` validation
 still fails closed (see `_validate` below) with a message explaining
 *why* — the capability gap is real, but no longer unconditional.
 
+## expected-SHA guard: injectable head reader
+
+`Proposal.expected_shas` (`mutation_plan.py`) is the expected-base guard:
+each selected repo's SHA at proposal-build time, which `execute` must
+verify still matches before mutating anything (a stale base is never
+silently mutated — see `lib/patterns/repository-mutations.md`). No Nave
+CLI surface exposes a per-repo SHA either: `pen show`/`pen status`
+(verified against `crates/nave_pen/src/state.rs` fixtures) carry
+`working_tree`/`freshness`/`divergence`, never a hex SHA. So, exactly like
+`read_repo_file` above, `execute` accepts a second injectable seam:
+`read_repo_head: Callable[[str], str] | None` (repo `owner/name` -> current
+HEAD SHA as hex, raising `FileNotFoundError`/`KeyError` when the repo is
+unknown to the caller). A caller with direct filesystem/git access to the
+pen's clones (or a future Nave surface that exposes this) wires a reader
+in. With `expected_shas` non-empty and no reader supplied, verification
+fails closed — blocked, not skipped — with a message naming the gap. This
+check runs after pen creation and the freshness/cleanliness preflight
+(a pen must exist, and have a resolvable HEAD, before it can be checked)
+and strictly before `pen exec`.
+
 ## NEEDS_CONTEXT: per-repo command-failure attribution
 
 `nave_pen::ops::exec_pen` (verified against
@@ -268,6 +288,7 @@ def execute(
     nave_adapter_runner,
     *,
     read_repo_file: Callable[[str, str], bytes] | None = None,
+    read_repo_head: Callable[[str], str] | None = None,
 ) -> PenRunResult:
     """Drive `plan` through the pen state machine using `nave_adapter_runner`.
 
@@ -278,8 +299,13 @@ def execute(
 
     `read_repo_file`, if supplied, is called as `read_repo_file(repo,
     relative_path) -> bytes` (raising `FileNotFoundError` when the path is
-    absent) to satisfy `kind: json_schema` validation entries. It is the
-    only filesystem seam this module accepts — see the module docstring.
+    absent) to satisfy `kind: json_schema` validation entries.
+
+    `read_repo_head`, if supplied, is called as `read_repo_head(repo) ->
+    str` (raising `FileNotFoundError` or `KeyError` when `repo` is unknown)
+    to satisfy `proposal.expected_shas` verification — see the module
+    docstring's "expected-SHA guard" section. These two callables are the
+    only filesystem seams this module accepts.
     """
     proposal = plan.proposal
     entry = plan.entry
@@ -317,14 +343,6 @@ def execute(
         )
 
     pen_payload = handle.pen or {}
-    if pen_payload.get("adapter_state") == "error":
-        return _result(
-            plan,
-            "failed",
-            version,
-            {repo: "failed" for repo in selection},
-            f"pen show after create failed: {pen_payload.get('error')}",
-        )
     pen_repos = {
         f"{repo.get('owner')}/{repo.get('name')}" for repo in pen_payload.get("repos", [])
     }
@@ -373,6 +391,53 @@ def execute(
             {repo: "blocked" for repo in selection},
             "; ".join(reasons),
         )
+
+    # --- created -> executed: expected-SHA guard (stale-base block) ------
+    # See module docstring "expected-SHA guard" section: Nave exposes no
+    # per-repo SHA on its own, so verification requires an injected reader.
+    # Runs after the pen exists and preflight passed, strictly before exec.
+    expected_shas = proposal.expected_shas
+    if expected_shas:
+        if read_repo_head is None:
+            return _result(
+                plan,
+                "blocked",
+                version,
+                {repo: "blocked" for repo in selection},
+                "proposal.expected_shas is non-empty but no read_repo_head "
+                "callable was provided to execute(); expected-SHA "
+                "verification requires reading each repo's current HEAD, "
+                "and Nave's pen show/status JSON exposes no per-repo SHA "
+                "to compare against",
+            )
+        sha_outcomes: dict[str, str] = {}
+        sha_reasons: list[str] = []
+        for repo in selection:
+            expected = expected_shas.get(repo)
+            if expected is None:
+                sha_outcomes[repo] = "ok"
+                continue
+            try:
+                actual = read_repo_head(repo)
+            except (FileNotFoundError, KeyError) as exc:
+                sha_outcomes[repo] = "blocked"
+                sha_reasons.append(f"{repo}: could not read current HEAD: {exc}")
+                continue
+            if actual.strip().lower() != expected.strip().lower():
+                sha_outcomes[repo] = "blocked"
+                sha_reasons.append(
+                    f"{repo}: expected SHA {expected!r} but current HEAD is {actual!r}"
+                )
+            else:
+                sha_outcomes[repo] = "ok"
+        if sha_reasons:
+            return _result(
+                plan,
+                "blocked",
+                version,
+                sha_outcomes,
+                "; ".join(sha_reasons),
+            )
 
     # --- executed -----------------------------------------------------------
     argv = resolve_argv(entry)

--- a/lib/pulse/scripts/pen_orchestrator.py
+++ b/lib/pulse/scripts/pen_orchestrator.py
@@ -28,20 +28,25 @@ before any Nave call. See `lib/patterns/repository-mutations.md` for the
 full mutation-policy vocabulary; Task 4 (F6 plan) is where a policy other
 than `propose` gets to actually authorize a later apply step.
 
-## NEEDS_CONTEXT: `validation.kind == "json_schema"` cannot be checked
+## `validation.kind == "json_schema"`: injectable file reader
 
-`mutation_plan.ValidationSpec` declares a `json_schema` kind that is
-supposed to validate a repo-relative output file's parsed content against
-an inline JSON Schema. No Nave CLI surface exposes that content:
-`pen show`/`pen status` (`nave_pen::storage::Pen` / `state::RepoState`)
-carry no local clone path, and `pen exec`'s stdout/stderr are opaque by
+`mutation_plan.ValidationSpec` declares a `json_schema` kind that
+validates a repo-relative output file's parsed content against an inline
+JSON Schema. No Nave CLI surface exposes that content directly: `pen
+show`/`pen status` (`nave_pen::storage::Pen` / `state::RepoState`) carry
+no local clone path, and `pen exec`'s stdout/stderr are opaque by
 contract (Task 1: "never parsed as data"). `nave materialize` fetches
 committed content from the GitHub API, not a pen's local uncommitted
-working tree, so it cannot stand in either. Every transformation entry
-whose `validation.kind == "json_schema"` therefore fails closed today —
-see `_validate` below — until a future Nave/adapter capability exposes
-pen repo file content (e.g. a `pen cat`/`--json` command). This is a real
-capability gap, not a design choice this module can route around.
+working tree, so it cannot stand in either. `pen_orchestrator` therefore
+never reads a pen's working tree itself — instead `execute` accepts an
+injectable `read_repo_file: Callable[[str, str], bytes] | None` seam
+(repo `owner/name` + relative path -> bytes, raising `FileNotFoundError`
+when absent). A caller that knows its pen root (e.g. a future `pen
+cat`/`--json` adapter, or a caller with direct filesystem access to the
+pen's clones) wires a reader in; Pulse never hardcodes Nave's internal
+pen layout itself. With no reader supplied, `json_schema` validation
+still fails closed (see `_validate` below) with a message explaining
+*why* — the capability gap is real, but no longer unconditional.
 
 ## NEEDS_CONTEXT: per-repo command-failure attribution
 
@@ -60,7 +65,9 @@ false per-repo split by guessing from opaque text.
 
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
+from typing import Any, Callable
 
 from lib.pulse.scripts import nave_adapter
 from lib.pulse.scripts.mutation_plan import (
@@ -165,29 +172,114 @@ def _is_stale(state: dict) -> bool:
     return state.get("freshness") == "stale" or state.get("divergence") in _STALE_DIVERGENCE
 
 
-def _validate(spec: ValidationSpec) -> str | None:
-    """Run the post-exec check `spec` declares; return an error string or
-    `None` on success. See the module-level NEEDS_CONTEXT note: `none` is
-    the only kind currently checkable — `json_schema` fails closed."""
+_SCHEMA_TYPE_CHECKS: dict[str, Callable[[Any], bool]] = {
+    "object": lambda v: isinstance(v, dict),
+    "array": lambda v: isinstance(v, list),
+    "string": lambda v: isinstance(v, str),
+    "number": lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+    "integer": lambda v: isinstance(v, int) and not isinstance(v, bool),
+    "boolean": lambda v: isinstance(v, bool),
+    "null": lambda v: v is None,
+}
+
+
+def _schema_errors(value: Any, schema: dict[str, Any], path: str = "$") -> list[str]:
+    """Minimal, pure structural check against a JSON Schema subset: `type`
+    (object/array/string/number/integer/boolean/null), `required` (list of
+    keys on objects), `properties` (recursive). No external `jsonschema`
+    dependency — any schema keyword outside this subset is simply ignored."""
+    errors: list[str] = []
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        checker = _SCHEMA_TYPE_CHECKS.get(expected_type)
+        if checker is None or not checker(value):
+            errors.append(f"{path}: expected type {expected_type!r}, got {type(value).__name__}")
+            return errors
+    required = schema.get("required")
+    if required:
+        if not isinstance(value, dict):
+            errors.append(f"{path}: 'required' check needs an object, got {type(value).__name__}")
+        else:
+            errors.extend(
+                f"{path}: missing required property {key!r}"
+                for key in required
+                if key not in value
+            )
+    properties = schema.get("properties")
+    if properties and isinstance(value, dict):
+        for key, subschema in properties.items():
+            if key in value:
+                errors.extend(_schema_errors(value[key], subschema, f"{path}.{key}"))
+    return errors
+
+
+def _validate_repo_output(spec: ValidationSpec, read_repo_file, repo: str) -> str | None:
+    """Read and schema-check `spec.path` for one `repo` via the injected
+    `read_repo_file` seam; return an error string or `None` on success."""
+    try:
+        raw = read_repo_file(repo, spec.path)
+    except FileNotFoundError as exc:
+        return f"{repo}: validation file {spec.path!r} not found: {exc}"
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        return f"{repo}: validation file {spec.path!r} is not valid JSON: {exc}"
+    errors = _schema_errors(data, spec.schema or {})
+    if errors:
+        return f"{repo}: schema validation failed for {spec.path!r}: {'; '.join(errors)}"
+    return None
+
+
+def _validate(
+    spec: ValidationSpec, read_repo_file, selection: tuple[str, ...]
+) -> tuple[dict[str, str], str] | None:
+    """Run the post-exec check `spec` declares across `selection`; return
+    `None` on success, or `(repo_outcomes, reason)` on failure. `kind ==
+    "none"` always passes. `kind == "json_schema"` with no `read_repo_file`
+    fails closed uniformly (see module docstring); with a reader, each repo
+    is checked independently so failure is attributed per repo."""
     if spec.kind == "none":
         return None
-    return (
-        f"validation kind 'json_schema' (path={spec.path!r}) cannot be "
-        "checked: no Nave adapter capability exposes a pen repo's local "
-        "file content (pen show/status carry no clone path, pen exec "
-        "stdout/stderr are opaque by contract, and `materialize` fetches "
-        "committed GitHub content, not a pen's local working tree) — see "
-        "the NEEDS_CONTEXT note in pen_orchestrator.py / task-3-report.md"
-    )
+    if read_repo_file is None:
+        reason = (
+            f"validation kind 'json_schema' (path={spec.path!r}) requires a "
+            "read_repo_file callable to read the pen's local output file "
+            "content — none was provided to execute(); pen show/status "
+            "carry no clone path, pen exec stdout/stderr are opaque by "
+            "contract, and `materialize` fetches committed GitHub content, "
+            "not a pen's local working tree, so pen_orchestrator cannot "
+            "read repo files on its own"
+        )
+        return ({repo: "failed" for repo in selection}, reason)
+    errors = {
+        repo: error
+        for repo in selection
+        if (error := _validate_repo_output(spec, read_repo_file, repo)) is not None
+    }
+    if not errors:
+        return None
+    repo_outcomes = {repo: ("failed" if repo in errors else "ok") for repo in selection}
+    reason = "; ".join(errors[repo] for repo in selection if repo in errors)
+    return (repo_outcomes, reason)
 
 
-def execute(plan: PenPlan, nave_adapter_runner) -> PenRunResult:
+def execute(
+    plan: PenPlan,
+    nave_adapter_runner,
+    *,
+    read_repo_file: Callable[[str, str], bytes] | None = None,
+) -> PenRunResult:
     """Drive `plan` through the pen state machine using `nave_adapter_runner`.
 
     `nave_adapter_runner` is the injectable runner (`NaveRunner` /
     `RecordingRunner` / `QueuedRunner` / `NaveRunner(fixtures=...)`) passed
     to the statically-imported `nave_adapter` module's functions — this
     function never imports or calls `subprocess` itself.
+
+    `read_repo_file`, if supplied, is called as `read_repo_file(repo,
+    relative_path) -> bytes` (raising `FileNotFoundError` when the path is
+    absent) to satisfy `kind: json_schema` validation entries. It is the
+    only filesystem seam this module accepts — see the module docstring.
     """
     proposal = plan.proposal
     entry = plan.entry
@@ -305,15 +397,10 @@ def execute(plan: PenPlan, nave_adapter_runner) -> PenRunResult:
         )
 
     # --- validated -----------------------------------------------------------
-    validation_error = _validate(entry.validation)
-    if validation_error is not None:
-        return _result(
-            plan,
-            "failed",
-            version,
-            {repo: "failed" for repo in selection},
-            validation_error,
-        )
+    validation_failure = _validate(entry.validation, read_repo_file, selection)
+    if validation_failure is not None:
+        repo_outcomes, reason = validation_failure
+        return _result(plan, "failed", version, repo_outcomes, reason)
 
     # --- proposed: terminal success, propose-only, never pushed -------------
     return _result(

--- a/lib/pulse/scripts/pen_orchestrator.py
+++ b/lib/pulse/scripts/pen_orchestrator.py
@@ -106,13 +106,6 @@ class PenOrchestratorError(ValueError):
     `PenRunResult`, never raised."""
 
 
-# Any divergence other than "up-to-date" means the pen's local branch has
-# moved relative to its remote counterpart in some way the orchestrator
-# did not itself cause yet (it hasn't run anything at this point) — treat
-# all of them as staleness pre-flight, fail closed.
-_STALE_DIVERGENCE = {"ahead", "behind", "diverged", "unknown"}
-
-
 @dataclass(frozen=True)
 class PenPlan:
     """Everything `execute` needs to drive one pen run.
@@ -186,10 +179,6 @@ def _result(plan: PenPlan, state: str, version: str | None, repo_outcomes: dict[
         repo_outcomes=repo_outcomes,
         reason=reason,
     )
-
-
-def _is_stale(state: dict) -> bool:
-    return state.get("freshness") == "stale" or state.get("divergence") in _STALE_DIVERGENCE
 
 
 _SCHEMA_TYPE_CHECKS: dict[str, Callable[[Any], bool]] = {
@@ -374,9 +363,17 @@ def execute(
         state = preflight_by_repo.get(repo)
         if state is None:
             reasons.append(f"{repo}: missing from pen status")
-        elif state.get("working_tree") == "dirty":
-            reasons.append(f"{repo}: dirty working tree before run")
-        elif _is_stale(state):
+        elif state.get("working_tree") != "clean":
+            # Fail closed on partial/malformed status entries too: anything
+            # other than an explicit "clean" blocks, not just "dirty".
+            reasons.append(
+                f"{repo}: working tree not clean before run "
+                f"(working_tree={state.get('working_tree')!r})"
+            )
+        # Freshness must be explicitly "fresh" and divergence explicitly
+        # "up-to-date"; any other value — including a missing field on a
+        # partial status entry — is staleness, fail closed.
+        elif state.get("freshness") != "fresh" or state.get("divergence") != "up-to-date":
             reasons.append(
                 f"{repo}: stale pen (freshness={state.get('freshness')}, "
                 f"divergence={state.get('divergence')})"
@@ -396,16 +393,21 @@ def execute(
     # See module docstring "expected-SHA guard" section: Nave exposes no
     # per-repo SHA on its own, so verification requires an injected reader.
     # Runs after the pen exists and preflight passed, strictly before exec.
+    # Fail closed on coverage, not just mismatch: `execute` cannot assume the
+    # Proposal came through build_proposal, so a selected repo missing from
+    # expected_shas (or an entirely empty dict) blocks rather than skipping
+    # the guard — an unguarded repo is exactly the stale-base mutation this
+    # gate exists to prevent.
     expected_shas = proposal.expected_shas
-    if expected_shas:
+    if selection:
         if read_repo_head is None:
             return _result(
                 plan,
                 "blocked",
                 version,
                 {repo: "blocked" for repo in selection},
-                "proposal.expected_shas is non-empty but no read_repo_head "
-                "callable was provided to execute(); expected-SHA "
+                "no read_repo_head callable was provided to execute(); "
+                "expected-SHA "
                 "verification requires reading each repo's current HEAD, "
                 "and Nave's pen show/status JSON exposes no per-repo SHA "
                 "to compare against",
@@ -415,7 +417,11 @@ def execute(
         for repo in selection:
             expected = expected_shas.get(repo)
             if expected is None:
-                sha_outcomes[repo] = "ok"
+                sha_outcomes[repo] = "blocked"
+                sha_reasons.append(
+                    f"{repo}: selected but has no expected_shas entry; "
+                    "an unguarded repo cannot be mutated"
+                )
                 continue
             try:
                 actual = read_repo_head(repo)

--- a/lib/pulse/scripts/pen_orchestrator.py
+++ b/lib/pulse/scripts/pen_orchestrator.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Drive a validated mutation `Proposal` through a Nave pen, safely.
+
+The state machine: `planned -> created -> executed -> validated ->
+proposed | blocked | failed` (F6 plan, verbatim). This module is pure
+w.r.t. subprocess — every Nave interaction is a call into
+`lib.pulse.scripts.nave_adapter`'s `pen_create`/`pen_status`/`pen_exec`/
+`probe` functions, using the injectable `runner` `execute()` receives as
+its second argument. This is the same `runner` idiom `nave_adapter.py`
+and `test_nave_adapter.py` already establish (`NaveRunner`,
+`RecordingRunner`, `QueuedRunner`) — tests never touch a real `nave`
+binary or the network; `execute`'s second parameter is that runner
+(named `nave_adapter` in the interface per the F6 plan, since together
+with the statically-imported `nave_adapter` module it forms "the Nave
+adapter").
+
+This orchestrator is **propose-only, unconditionally**: it never emits
+`--commit`/`--push-changes` to `pen exec` regardless of a proposal's
+`mutation_policy`. Its terminal success state is always `proposed` — a
+commit/push/PR action for something else to apply later, never performed
+here. A proposal whose `mutation_policy` is not `propose`, or a `PenPlan`
+that explicitly requests a push, is a **forbidden push** and blocks
+before any Nave call. See `lib/patterns/repository-mutations.md` for the
+full mutation-policy vocabulary; Task 4 (F6 plan) is where a policy other
+than `propose` gets to actually authorize a later apply step.
+
+## NEEDS_CONTEXT: `validation.kind == "json_schema"` cannot be checked
+
+`mutation_plan.ValidationSpec` declares a `json_schema` kind that is
+supposed to validate a repo-relative output file's parsed content against
+an inline JSON Schema. No Nave CLI surface exposes that content:
+`pen show`/`pen status` (`nave_pen::storage::Pen` / `state::RepoState`)
+carry no local clone path, and `pen exec`'s stdout/stderr are opaque by
+contract (Task 1: "never parsed as data"). `nave materialize` fetches
+committed content from the GitHub API, not a pen's local uncommitted
+working tree, so it cannot stand in either. Every transformation entry
+whose `validation.kind == "json_schema"` therefore fails closed today —
+see `_validate` below — until a future Nave/adapter capability exposes
+pen repo file content (e.g. a `pen cat`/`--json` command). This is a real
+capability gap, not a design choice this module can route around.
+
+## NEEDS_CONTEXT: per-repo command-failure attribution
+
+`nave_pen::ops::exec_pen` (verified against
+`crates/nave_pen/src/ops.rs`) iterates a pen's repos and `bail!`s
+immediately at the **first** repo whose command exits non-zero — it never
+attempts the remaining repos, and its only externally visible signal is
+one aggregate process exit code. There is no structured per-repo
+success/failure record, and `pen_exec`'s stdout/stderr must never be
+parsed for data (Task 1 contract) — so the exact failing repo cannot be
+identified from the adapter surface without violating that contract. On
+an exec failure this module therefore marks **every** selected repo's
+outcome `"failed"` and fails the whole run, rather than fabricating a
+false per-repo split by guessing from opaque text.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lib.pulse.scripts import nave_adapter
+from lib.pulse.scripts.mutation_plan import (
+    Actor,
+    Proposal,
+    TransformationEntry,
+    ValidationSpec,
+    resolve_argv,
+)
+
+
+class PenOrchestratorError(ValueError):
+    """Raised for a structurally invalid `PenPlan` — a caller/programmer
+    bug (e.g. a mismatched resolved transformation), never a runtime
+    gating outcome. Runtime gating outcomes are always reported via a
+    `PenRunResult`, never raised."""
+
+
+# Any divergence other than "up-to-date" means the pen's local branch has
+# moved relative to its remote counterpart in some way the orchestrator
+# did not itself cause yet (it hasn't run anything at this point) — treat
+# all of them as staleness pre-flight, fail closed.
+_STALE_DIVERGENCE = {"ahead", "behind", "diverged", "unknown"}
+
+
+@dataclass(frozen=True)
+class PenPlan:
+    """Everything `execute` needs to drive one pen run.
+
+    Bundles the validated `Proposal` (`mutation_plan.py`) with its
+    already-resolved `TransformationEntry` — registry loading and lookup
+    are the caller's job; `execute` never loads a registry itself, it
+    only requires `entry.id == proposal.transformation` (checked, raises
+    `PenOrchestratorError` otherwise). `pen_name`/`query` are the pen
+    provisioning details only the orchestrator needs: the pen to
+    create and the `PenQuery` used to seed it. `request_push` records an
+    explicit caller ask to commit/push; since this orchestrator's
+    terminal success state is always `proposed` (propose-only, never
+    pushes — see module docstring), `request_push=True` is always a
+    forbidden-push attempt and blocks before any Nave call.
+    """
+
+    proposal: Proposal
+    entry: TransformationEntry
+    pen_name: str
+    query: nave_adapter.PenQuery
+    request_push: bool = False
+
+
+@dataclass(frozen=True)
+class PenRunResult:
+    """Terminal record of one orchestrator run — the attribution record.
+
+    Carries actor, machine (inside `actor`), probed Nave version, pen
+    name, selection, transformation (command) ID, and per-repo outcome —
+    the F6 attribution requirement, built entirely from the `Proposal`
+    that gated execution plus what the adapter actually observed; nothing
+    here is inferred or reconstructed after the fact.
+
+    `repo_outcomes` maps each selected `owner/name` to
+    `"ok" | "failed" | "blocked"`. `reason` is set whenever `state` is
+    `"blocked"` or `"failed"`.
+    """
+
+    state: str
+    proposal_id: str
+    transformation: str
+    pen_name: str
+    selection: tuple[str, ...]
+    actor: Actor
+    nave_version: str | None
+    repo_outcomes: dict[str, str]
+    reason: str | None = None
+
+
+def _probe_version(runner) -> str | None:
+    try:
+        result = nave_adapter.probe(runner)
+    except Exception:
+        return None
+    if not isinstance(result, dict):
+        return None
+    version = result.get("version")
+    return version if isinstance(version, str) else None
+
+
+def _result(plan: PenPlan, state: str, version: str | None, repo_outcomes: dict[str, str], reason: str | None) -> PenRunResult:
+    return PenRunResult(
+        state=state,
+        proposal_id=plan.proposal.id,
+        transformation=plan.proposal.transformation,
+        pen_name=plan.pen_name,
+        selection=plan.proposal.selection,
+        actor=plan.proposal.actor,
+        nave_version=version,
+        repo_outcomes=repo_outcomes,
+        reason=reason,
+    )
+
+
+def _is_stale(state: dict) -> bool:
+    return state.get("freshness") == "stale" or state.get("divergence") in _STALE_DIVERGENCE
+
+
+def _validate(spec: ValidationSpec) -> str | None:
+    """Run the post-exec check `spec` declares; return an error string or
+    `None` on success. See the module-level NEEDS_CONTEXT note: `none` is
+    the only kind currently checkable — `json_schema` fails closed."""
+    if spec.kind == "none":
+        return None
+    return (
+        f"validation kind 'json_schema' (path={spec.path!r}) cannot be "
+        "checked: no Nave adapter capability exposes a pen repo's local "
+        "file content (pen show/status carry no clone path, pen exec "
+        "stdout/stderr are opaque by contract, and `materialize` fetches "
+        "committed GitHub content, not a pen's local working tree) — see "
+        "the NEEDS_CONTEXT note in pen_orchestrator.py / task-3-report.md"
+    )
+
+
+def execute(plan: PenPlan, nave_adapter_runner) -> PenRunResult:
+    """Drive `plan` through the pen state machine using `nave_adapter_runner`.
+
+    `nave_adapter_runner` is the injectable runner (`NaveRunner` /
+    `RecordingRunner` / `QueuedRunner` / `NaveRunner(fixtures=...)`) passed
+    to the statically-imported `nave_adapter` module's functions — this
+    function never imports or calls `subprocess` itself.
+    """
+    proposal = plan.proposal
+    entry = plan.entry
+    if entry.id != proposal.transformation:
+        raise PenOrchestratorError(
+            f"plan.entry.id ({entry.id!r}) does not match "
+            f"plan.proposal.transformation ({proposal.transformation!r})"
+        )
+
+    runner = nave_adapter_runner
+    version = _probe_version(runner)
+    selection = proposal.selection
+
+    # --- forbidden push: checked before any Nave call --------------------
+    if plan.request_push or proposal.mutation_policy != "propose":
+        return _result(
+            plan,
+            "blocked",
+            version,
+            {repo: "blocked" for repo in selection},
+            "push forbidden: pen_orchestrator is propose-only and never "
+            f"commits or pushes; got mutation_policy={proposal.mutation_policy!r} "
+            f"request_push={plan.request_push!r}",
+        )
+
+    # --- planned -> created ------------------------------------------------
+    handle = nave_adapter.pen_create(runner, plan.query, plan.pen_name)
+    if handle.state != "ok":
+        return _result(
+            plan,
+            "failed",
+            version,
+            {repo: "failed" for repo in selection},
+            f"pen create failed: {(handle.stderr or handle.stdout).strip()}",
+        )
+
+    pen_payload = handle.pen or {}
+    if pen_payload.get("adapter_state") == "error":
+        return _result(
+            plan,
+            "failed",
+            version,
+            {repo: "failed" for repo in selection},
+            f"pen show after create failed: {pen_payload.get('error')}",
+        )
+    pen_repos = {
+        f"{repo.get('owner')}/{repo.get('name')}" for repo in pen_payload.get("repos", [])
+    }
+    if pen_repos != set(selection):
+        return _result(
+            plan,
+            "blocked",
+            version,
+            {repo: "blocked" for repo in selection},
+            f"pen {plan.pen_name!r} repos {sorted(pen_repos)} do not match "
+            f"proposal selection {sorted(selection)}",
+        )
+
+    # --- created -> executed: preflight (stale/dirty block BEFORE run) ---
+    preflight = nave_adapter.pen_status(runner, plan.pen_name)
+    if preflight.get("adapter_state") == "error":
+        return _result(
+            plan,
+            "failed",
+            version,
+            {repo: "failed" for repo in selection},
+            f"pen status failed: {preflight.get('error')}",
+        )
+    preflight_by_repo = {
+        f"{r.get('owner')}/{r.get('repo')}": r for r in preflight.get("repos", [])
+    }
+    reasons: list[str] = []
+    for repo in selection:
+        state = preflight_by_repo.get(repo)
+        if state is None:
+            reasons.append(f"{repo}: missing from pen status")
+        elif state.get("working_tree") == "dirty":
+            reasons.append(f"{repo}: dirty working tree before run")
+        elif _is_stale(state):
+            reasons.append(
+                f"{repo}: stale pen (freshness={state.get('freshness')}, "
+                f"divergence={state.get('divergence')})"
+            )
+    if reasons:
+        # Fail closed: a stale or dirty repo blocks the *whole* run, never
+        # just itself — nothing gets executed anywhere.
+        return _result(
+            plan,
+            "blocked",
+            version,
+            {repo: "blocked" for repo in selection},
+            "; ".join(reasons),
+        )
+
+    # --- executed -----------------------------------------------------------
+    argv = resolve_argv(entry)
+    exec_result = nave_adapter.pen_exec(
+        runner,
+        plan.pen_name,
+        list(argv),
+        only=None,
+        commit=False,
+        push_changes=False,
+        message=None,
+    )
+    if exec_result.get("adapter_state") == "error":
+        # See module NEEDS_CONTEXT note: no per-repo attribution is
+        # possible, so the whole run fails and every repo is "failed".
+        return _result(
+            plan,
+            "failed",
+            version,
+            {repo: "failed" for repo in selection},
+            f"pen exec failed: {(exec_result.get('stderr') or '').strip() or 'nonzero exit'}",
+        )
+
+    # --- validated -----------------------------------------------------------
+    validation_error = _validate(entry.validation)
+    if validation_error is not None:
+        return _result(
+            plan,
+            "failed",
+            version,
+            {repo: "failed" for repo in selection},
+            validation_error,
+        )
+
+    # --- proposed: terminal success, propose-only, never pushed -------------
+    return _result(
+        plan,
+        "proposed",
+        version,
+        {repo: "ok" for repo in selection},
+        None,
+    )

--- a/lib/pulse/scripts/tests/fixtures/nave/pen/create.txt
+++ b/lib/pulse/scripts/tests/fixtures/nave/pen/create.txt
@@ -1,0 +1,3 @@
+nave/api-audit
+  acme/api
+  acme/web

--- a/lib/pulse/scripts/tests/fixtures/nave/pen/exec.txt
+++ b/lib/pulse/scripts/tests/fixtures/nave/pen/exec.txt
@@ -1,0 +1,2 @@
+running `make fmt` in acme/api
+running `make fmt` in acme/web

--- a/lib/pulse/scripts/tests/fixtures/nave/pen/show.json
+++ b/lib/pulse/scripts/tests/fixtures/nave/pen/show.json
@@ -1,0 +1,27 @@
+{
+  "name": "nave/api-audit",
+  "created_at": "2026-07-15T10:00:00Z",
+  "branch": "nave/api-audit",
+  "filter": {
+    "terms": [
+      "workflow:pytest"
+    ]
+  },
+  "repos": [
+    {
+      "owner": "acme",
+      "name": "api",
+      "default_branch": "main",
+      "clone_url": "git@github.com:acme/api.git",
+      "synced_at": "2026-07-15T10:00:00Z"
+    },
+    {
+      "owner": "acme",
+      "name": "web",
+      "default_branch": "main",
+      "clone_url": "git@github.com:acme/web.git",
+      "synced_at": "2026-07-15T10:00:00Z"
+    }
+  ],
+  "ops": []
+}

--- a/lib/pulse/scripts/tests/fixtures/nave/pen/status.json
+++ b/lib/pulse/scripts/tests/fixtures/nave/pen/status.json
@@ -1,0 +1,22 @@
+[
+  {
+    "owner": "acme",
+    "repo": "api",
+    "working_tree": "dirty",
+    "freshness": "fresh",
+    "run_state": "run-local",
+    "divergence": "up-to-date",
+    "ahead": 0,
+    "behind": 0
+  },
+  {
+    "owner": "acme",
+    "repo": "web",
+    "working_tree": "clean",
+    "freshness": "stale",
+    "run_state": "not-run",
+    "divergence": "behind",
+    "ahead": 0,
+    "behind": 2
+  }
+]

--- a/lib/pulse/scripts/tests/fixtures/repo-mutation-invalid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/repo-mutation-invalid.yaml
@@ -1,0 +1,14 @@
+contract_version: 1
+kind: repo-mutation
+workspace: testorg
+run_at: "2026-07-10T09:15:00Z"
+state: blocked
+transformation: bump-lockfile
+pen_name: pen-bump-lockfile-2026-07-10
+selection: [testorg/widget, testorg/core]
+nave_version: "0.9.2"
+repo_outcomes:
+  testorg/widget: blocked
+  testorg/core: exploded
+reason: null
+errors: []

--- a/lib/pulse/scripts/tests/fixtures/repo-mutation-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/repo-mutation-valid.yaml
@@ -1,0 +1,19 @@
+contract_version: 1
+kind: repo-mutation
+workspace: testorg
+run_at: "2026-07-10T09:15:00Z"
+actor:
+  gh_login: octocat
+  machine: mba-m4
+  mode: scheduled
+state: proposed
+proposal_id: bump-lockfile-2026-07-10
+transformation: bump-lockfile
+pen_name: pen-bump-lockfile-2026-07-10
+selection: [testorg/widget, testorg/core]
+nave_version: "0.9.2"
+repo_outcomes:
+  testorg/widget: ok
+  testorg/core: ok
+reason: null
+errors: []

--- a/lib/pulse/scripts/tests/test_mutation_plan.py
+++ b/lib/pulse/scripts/tests/test_mutation_plan.py
@@ -1,0 +1,468 @@
+"""Tests for the mutation proposal shape and transformation registry."""
+
+import pytest
+
+from lib.pulse.scripts import mutation_plan
+
+
+def minimal_registry_data():
+    return {
+        "transformations": {
+            "format-python": {
+                "id": "format-python",
+                "command_argv": ["ruff", "format", "."],
+                "applies_to": ["profile:python"],
+                "validation": {"kind": "none"},
+                "allow_scheduled": True,
+            },
+            "interactive-only": {
+                "id": "interactive-only",
+                "command_argv": ["make", "risky"],
+                "applies_to": ["always"],
+                "validation": {"kind": "none"},
+                "allow_scheduled": False,
+            },
+        }
+    }
+
+
+def minimal_actor(mode="interactive"):
+    return {"gh_login": "octocat", "machine": "laptop", "mode": mode}
+
+
+# --- registry loading -----------------------------------------------------
+
+
+def test_loads_valid_registry():
+    registry = mutation_plan.load_registry(minimal_registry_data())
+
+    entry = registry.get("format-python")
+    assert entry.command_argv == ("ruff", "format", ".")
+    assert entry.applies_to == ("profile:python",)
+    assert entry.allow_scheduled is True
+    assert entry.validation.kind == "none"
+
+
+def test_loads_registry_from_yaml_file(tmp_path):
+    import yaml
+
+    path = tmp_path / "transformations.yaml"
+    path.write_text(yaml.safe_dump(minimal_registry_data(), sort_keys=False))
+
+    registry = mutation_plan.load_registry(path)
+
+    assert set(registry.transformations) == {"format-python", "interactive-only"}
+
+
+def test_missing_registry_file_raises():
+    with pytest.raises(mutation_plan.MutationPlanError, match="not found"):
+        mutation_plan.load_registry("/nonexistent/transformations.yaml")
+
+
+def test_registry_rejects_non_mapping_root():
+    with pytest.raises(mutation_plan.MutationPlanError, match="path or a mapping"):
+        mutation_plan.load_registry([])
+
+
+def test_registry_rejects_non_mapping_root_from_yaml_file(tmp_path):
+    path = tmp_path / "transformations.yaml"
+    path.write_text("- not\n- a\n- mapping\n")
+    with pytest.raises(mutation_plan.MutationPlanError, match="must be a mapping"):
+        mutation_plan.load_registry(path)
+
+
+def test_registry_rejects_unknown_top_level_key():
+    data = minimal_registry_data()
+    data["extra"] = {}
+    with pytest.raises(mutation_plan.MutationPlanError, match="unknown registry key"):
+        mutation_plan.load_registry(data)
+
+
+def test_registry_entry_id_must_match_key():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["id"] = "something-else"
+    with pytest.raises(mutation_plan.MutationPlanError, match="must match its registry key"):
+        mutation_plan.load_registry(data)
+
+
+def test_registry_rejects_empty_command_argv():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["command_argv"] = []
+    with pytest.raises(mutation_plan.MutationPlanError, match="non-empty list"):
+        mutation_plan.load_registry(data)
+
+
+def test_registry_rejects_nested_argv_element():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["command_argv"] = ["ruff", ["format"]]
+    with pytest.raises(mutation_plan.MutationPlanError, match=r"command_argv\[1\] must be a string"):
+        mutation_plan.load_registry(data)
+
+
+def test_registry_rejects_boolean_argv_element():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["command_argv"] = ["ruff", True]
+    with pytest.raises(mutation_plan.MutationPlanError, match=r"command_argv\[1\] must be a string"):
+        mutation_plan.load_registry(data)
+
+
+def test_registry_rejects_empty_applies_to():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["applies_to"] = []
+    with pytest.raises(mutation_plan.MutationPlanError, match="applies_to must be non-empty"):
+        mutation_plan.load_registry(data)
+
+
+def test_registry_rejects_invalid_applies_to_predicate():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["applies_to"] = ["nonsense"]
+    with pytest.raises(mutation_plan.MutationPlanError, match="invalid predicate"):
+        mutation_plan.load_registry(data)
+
+
+def test_registry_accepts_capability_and_evidence_path_predicates():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["applies_to"] = [
+        "capability:ci",
+        "evidence_path:**/*.py",
+    ]
+    registry = mutation_plan.load_registry(data)
+    assert registry.get("format-python").applies_to == (
+        "capability:ci",
+        "evidence_path:**/*.py",
+    )
+
+
+def test_registry_rejects_non_boolean_allow_scheduled():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["allow_scheduled"] = "yes"
+    with pytest.raises(mutation_plan.MutationPlanError, match="allow_scheduled must be a boolean"):
+        mutation_plan.load_registry(data)
+
+
+def test_registry_rejects_unknown_validation_kind():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["validation"] = {"kind": "vibes"}
+    with pytest.raises(mutation_plan.MutationPlanError, match="validation.kind invalid"):
+        mutation_plan.load_registry(data)
+
+
+def test_registry_json_schema_validation_requires_path_and_schema():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["validation"] = {"kind": "json_schema"}
+    with pytest.raises(mutation_plan.MutationPlanError, match="validation.path"):
+        mutation_plan.load_registry(data)
+
+
+def test_registry_json_schema_validation_loads_path_and_schema():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["validation"] = {
+        "kind": "json_schema",
+        "path": "package.json",
+        "schema": {"type": "object"},
+    }
+    registry = mutation_plan.load_registry(data)
+    validation = registry.get("format-python").validation
+    assert validation.kind == "json_schema"
+    assert validation.path == "package.json"
+    assert validation.schema == {"type": "object"}
+
+
+def test_registry_get_unknown_transformation_raises():
+    registry = mutation_plan.load_registry(minimal_registry_data())
+    with pytest.raises(mutation_plan.MutationPlanError, match="unknown transformation"):
+        registry.get("does-not-exist")
+
+
+# --- applicability ----------------------------------------------------
+
+
+def test_transformation_applies_matches_profile_predicate():
+    registry = mutation_plan.load_registry(minimal_registry_data())
+    entry = registry.get("format-python")
+
+    assert mutation_plan.transformation_applies(entry, profiles=("python",)) is True
+    assert mutation_plan.transformation_applies(entry, profiles=("nodejs",)) is False
+
+
+def test_transformation_applies_always_matches_regardless_of_evidence():
+    registry = mutation_plan.load_registry(minimal_registry_data())
+    entry = registry.get("interactive-only")
+
+    assert mutation_plan.transformation_applies(entry) is True
+
+
+def test_transformation_applies_matches_capability_and_evidence_path():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["applies_to"] = [
+        "capability:ci",
+        "evidence_path:**/*.py",
+    ]
+    entry = mutation_plan.load_registry(data).get("format-python")
+
+    assert mutation_plan.transformation_applies(entry, capabilities=("ci",)) is True
+    assert (
+        mutation_plan.transformation_applies(entry, evidence_paths=("src/app.py",)) is True
+    )
+    assert mutation_plan.transformation_applies(entry, evidence_paths=("README.md",)) is False
+
+
+# --- argv resolution: shell metacharacters stay literal --------------------
+
+
+def test_resolve_argv_returns_registered_argv_verbatim():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["command_argv"] = [
+        "sh",
+        "-c",
+        "$(rm -rf /)",
+    ]
+    entry = mutation_plan.load_registry(data).get("format-python")
+
+    argv = mutation_plan.resolve_argv(entry)
+
+    # The dangerous-looking element is passed through as an opaque literal
+    # string — it is never interpreted, expanded, or substituted.
+    assert argv == ("sh", "-c", "$(rm -rf /)")
+
+
+@pytest.mark.parametrize(
+    "dangerous",
+    [
+        "$(rm -rf /)",
+        "; rm -rf /",
+        "`rm -rf /`",
+        "$HOME && rm -rf /",
+        "a; b | c",
+    ],
+)
+def test_resolve_argv_treats_shell_metacharacters_as_literal_data(dangerous):
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["command_argv"] = ["echo", dangerous]
+    entry = mutation_plan.load_registry(data).get("format-python")
+
+    argv = mutation_plan.resolve_argv(entry)
+
+    assert argv[-1] == dangerous
+
+
+def test_resolve_argv_never_templates_proposal_data():
+    """No proposal field ever flows into the argv — it is registry-only."""
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["command_argv"] = ["ruff", "format", "{repo}"]
+    entry = mutation_plan.load_registry(data).get("format-python")
+
+    argv = mutation_plan.resolve_argv(entry)
+
+    # The literal placeholder text survives untouched - never substituted.
+    assert argv == ("ruff", "format", "{repo}")
+
+
+# --- proposal construction and validation ---------------------------------
+
+
+def test_build_proposal_constructs_valid_proposal():
+    proposal = mutation_plan.build_proposal(
+        id="run-1",
+        selection=["acme/api", "acme/web"],
+        transformation="format-python",
+        expected_shas={"acme/api": "abc123", "acme/web": "def456"},
+        actor=minimal_actor(),
+    )
+
+    assert proposal.id == "run-1"
+    assert proposal.selection == ("acme/api", "acme/web")
+    assert proposal.mutation_policy == "propose"
+    assert proposal.actor.gh_login == "octocat"
+    assert proposal.actor.mode == "interactive"
+
+
+def test_build_proposal_defaults_mutation_policy_to_propose():
+    proposal = mutation_plan.build_proposal(
+        id="run-1",
+        selection=["acme/api"],
+        transformation="format-python",
+        expected_shas={"acme/api": "abc123"},
+        actor=minimal_actor(),
+    )
+    assert proposal.mutation_policy == "propose"
+
+
+@pytest.mark.parametrize("policy", ["propose", "allow-listed", "allow"])
+def test_build_proposal_accepts_all_mutation_policy_values(policy):
+    proposal = mutation_plan.build_proposal(
+        id="run-1",
+        selection=["acme/api"],
+        transformation="format-python",
+        expected_shas={"acme/api": "abc123"},
+        actor=minimal_actor(),
+        mutation_policy=policy,
+    )
+    assert proposal.mutation_policy == policy
+
+
+def test_build_proposal_rejects_invalid_mutation_policy():
+    with pytest.raises(mutation_plan.MutationPlanError, match="mutation_policy invalid"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=["acme/api"],
+            transformation="format-python",
+            expected_shas={"acme/api": "abc123"},
+            actor=minimal_actor(),
+            mutation_policy="yolo",
+        )
+
+
+def test_build_proposal_rejects_empty_selection():
+    with pytest.raises(mutation_plan.MutationPlanError, match="selection must be non-empty"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=[],
+            transformation="format-python",
+            expected_shas={},
+            actor=minimal_actor(),
+        )
+
+
+def test_build_proposal_rejects_malformed_repo_name():
+    with pytest.raises(mutation_plan.MutationPlanError, match="must be owner/name"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=["not-owner-slash-name"],
+            transformation="format-python",
+            expected_shas={"not-owner-slash-name": "abc123"},
+            actor=minimal_actor(),
+        )
+
+
+def test_build_proposal_rejects_duplicate_selection_entries():
+    with pytest.raises(mutation_plan.MutationPlanError, match="duplicate"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=["acme/api", "acme/api"],
+            transformation="format-python",
+            expected_shas={"acme/api": "abc123"},
+            actor=minimal_actor(),
+        )
+
+
+def test_build_proposal_rejects_missing_expected_sha_for_selected_repo():
+    with pytest.raises(mutation_plan.MutationPlanError, match="expected_shas missing entry"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=["acme/api", "acme/web"],
+            transformation="format-python",
+            expected_shas={"acme/api": "abc123"},
+            actor=minimal_actor(),
+        )
+
+
+def test_build_proposal_rejects_expected_sha_outside_selection():
+    with pytest.raises(mutation_plan.MutationPlanError, match="entry outside selection"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=["acme/api"],
+            transformation="format-python",
+            expected_shas={"acme/api": "abc123", "acme/other": "zzz"},
+            actor=minimal_actor(),
+        )
+
+
+def test_build_proposal_rejects_invalid_actor_mode():
+    with pytest.raises(mutation_plan.MutationPlanError, match="actor.mode invalid"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=["acme/api"],
+            transformation="format-python",
+            expected_shas={"acme/api": "abc123"},
+            actor=minimal_actor(mode="whenever"),
+        )
+
+
+def test_build_proposal_accepts_actor_dataclass_directly():
+    actor = mutation_plan.Actor(gh_login="octocat", machine="laptop", mode="interactive")
+    proposal = mutation_plan.build_proposal(
+        id="run-1",
+        selection=["acme/api"],
+        transformation="format-python",
+        expected_shas={"acme/api": "abc123"},
+        actor=actor,
+    )
+    assert proposal.actor is actor
+
+
+# --- registry-backed validation: unknown transformation, scheduled gating -
+
+
+def test_build_proposal_with_registry_rejects_unknown_transformation():
+    registry = mutation_plan.load_registry(minimal_registry_data())
+    with pytest.raises(mutation_plan.MutationPlanError, match="unknown transformation"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=["acme/api"],
+            transformation="does-not-exist",
+            expected_shas={"acme/api": "abc123"},
+            actor=minimal_actor(),
+            registry=registry,
+        )
+
+
+def test_validate_proposal_rejects_unknown_transformation():
+    registry = mutation_plan.load_registry(minimal_registry_data())
+    proposal = mutation_plan.build_proposal(
+        id="run-1",
+        selection=["acme/api"],
+        transformation="format-python",
+        expected_shas={"acme/api": "abc123"},
+        actor=minimal_actor(),
+    )
+    # Mutate to reference an unregistered transformation post-construction.
+    forged = mutation_plan.Proposal(
+        id=proposal.id,
+        selection=proposal.selection,
+        transformation="does-not-exist",
+        expected_shas=proposal.expected_shas,
+        mutation_policy=proposal.mutation_policy,
+        actor=proposal.actor,
+    )
+    with pytest.raises(mutation_plan.MutationPlanError, match="unknown transformation"):
+        mutation_plan.validate_proposal(forged, registry)
+
+
+def test_scheduled_actor_allowed_for_allow_scheduled_transformation():
+    registry = mutation_plan.load_registry(minimal_registry_data())
+    proposal = mutation_plan.build_proposal(
+        id="run-1",
+        selection=["acme/api"],
+        transformation="format-python",
+        expected_shas={"acme/api": "abc123"},
+        actor=minimal_actor(mode="scheduled"),
+        registry=registry,
+    )
+    assert proposal.actor.mode == "scheduled"
+
+
+def test_scheduled_actor_disallowed_for_non_scheduled_transformation():
+    registry = mutation_plan.load_registry(minimal_registry_data())
+    with pytest.raises(mutation_plan.MutationPlanError, match="not allowed in scheduled mode"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=["acme/api"],
+            transformation="interactive-only",
+            expected_shas={"acme/api": "abc123"},
+            actor=minimal_actor(mode="scheduled"),
+            registry=registry,
+        )
+
+
+def test_interactive_actor_allowed_for_non_scheduled_transformation():
+    registry = mutation_plan.load_registry(minimal_registry_data())
+    proposal = mutation_plan.build_proposal(
+        id="run-1",
+        selection=["acme/api"],
+        transformation="interactive-only",
+        expected_shas={"acme/api": "abc123"},
+        actor=minimal_actor(mode="interactive"),
+        registry=registry,
+    )
+    assert proposal.transformation == "interactive-only"

--- a/lib/pulse/scripts/tests/test_nave_adapter.py
+++ b/lib/pulse/scripts/tests/test_nave_adapter.py
@@ -19,6 +19,18 @@ class RecordingRunner:
         return self.result
 
 
+class QueuedRunner:
+    """Fake runner that returns a distinct Completed per call, in order."""
+
+    def __init__(self, results):
+        self.calls = []
+        self._results = list(results)
+
+    def run(self, args):
+        self.calls.append(args)
+        return self._results.pop(0)
+
+
 def test_probe_detects_current_capabilities():
     runner = nave_adapter.NaveRunner(fixtures=FIXTURES)
     result = nave_adapter.probe(runner)
@@ -314,3 +326,350 @@ def test_cli_materialize_subcommand_does_not_leak_content(monkeypatch, capsys):
     for repo in output["repos"]:
         assert "artifacts" not in repo
     assert output["repos"][0]["artifacts_by_state"]["found"] >= 1
+
+
+# --- pen lifecycle ---
+
+PEN_FIXTURES = FIXTURES / "pen"
+
+
+def test_pen_show_builds_exact_command_with_name():
+    runner = RecordingRunner(nave_adapter.Completed(0, "{}", ""))
+
+    nave_adapter.pen_show(runner, name="nave/api-audit")
+
+    assert runner.calls == [["pen", "show", "nave/api-audit", "--json"]]
+
+
+def test_pen_show_builds_exact_command_with_filter_only():
+    runner = RecordingRunner(nave_adapter.Completed(0, "{}", ""))
+
+    nave_adapter.pen_show(runner, filter_regex="api.*")
+
+    assert runner.calls == [["pen", "show", "--filter", "api.*", "--json"]]
+
+
+def test_pen_status_builds_exact_command_and_normalizes_array_root():
+    status_json = json.dumps(
+        [
+            {
+                "owner": "acme",
+                "repo": "api",
+                "working_tree": "clean",
+                "freshness": "fresh",
+                "run_state": "not-run",
+                "divergence": "up-to-date",
+                "ahead": 0,
+                "behind": 0,
+            }
+        ]
+    )
+    runner = RecordingRunner(nave_adapter.Completed(0, status_json, ""))
+
+    result = nave_adapter.pen_status(runner, "nave/api-audit")
+
+    assert runner.calls == [["pen", "status", "nave/api-audit", "--json"]]
+    assert result == {
+        "repos": [
+            {
+                "owner": "acme",
+                "repo": "api",
+                "working_tree": "clean",
+                "freshness": "fresh",
+                "run_state": "not-run",
+                "divergence": "up-to-date",
+                "ahead": 0,
+                "behind": 0,
+            }
+        ]
+    }
+
+
+def test_pen_status_invalid_json_becomes_typed_adapter_error():
+    runner = RecordingRunner(nave_adapter.Completed(0, "not json", ""))
+
+    result = nave_adapter.pen_status(runner, "nave/api-audit")
+
+    assert result["adapter_state"] == "error"
+    assert "invalid JSON" in result["error"]
+
+
+def test_pen_status_non_array_root_becomes_typed_adapter_error():
+    runner = RecordingRunner(nave_adapter.Completed(0, "{}", ""))
+
+    result = nave_adapter.pen_status(runner, "nave/api-audit")
+
+    assert result["adapter_state"] == "error"
+    assert "not an array" in result["error"]
+
+
+def test_pen_create_builds_exact_command_then_calls_show():
+    show_json = json.dumps({"name": "nave/api-audit", "branch": "nave/api-audit"})
+    runner = QueuedRunner(
+        [
+            nave_adapter.Completed(0, "nave/api-audit\n  acme/api\n", ""),
+            nave_adapter.Completed(0, show_json, ""),
+        ]
+    )
+    query = nave_adapter.PenQuery(
+        terms=["workflow:pytest"], match_preds=["tool.pytest"], ignore_case=True
+    )
+
+    handle = nave_adapter.pen_create(runner, query, "nave/api-audit")
+
+    assert runner.calls == [
+        [
+            "pen",
+            "create",
+            "--name",
+            "nave/api-audit",
+            "--ignore-case",
+            "--match",
+            "tool.pytest",
+            "workflow:pytest",
+        ],
+        ["pen", "show", "nave/api-audit", "--json"],
+    ]
+    assert handle.name == "nave/api-audit"
+    assert handle.state == "ok"
+    assert handle.pen == {"name": "nave/api-audit", "branch": "nave/api-audit"}
+
+
+def test_pen_create_never_parses_human_text_as_data():
+    # The create command's stdout is deliberately gibberish/opaque; only the
+    # exit code and the subsequent `pen show --json` call may inform state.
+    show_json = json.dumps({"name": "nave/api-audit"})
+    runner = QueuedRunner(
+        [
+            nave_adapter.Completed(0, "not structured at all !!!", ""),
+            nave_adapter.Completed(0, show_json, ""),
+        ]
+    )
+
+    handle = nave_adapter.pen_create(runner, nave_adapter.PenQuery(), "nave/api-audit")
+
+    assert handle.state == "ok"
+    assert handle.pen == {"name": "nave/api-audit"}
+
+
+def test_pen_create_nonzero_exit_skips_show_call():
+    runner = QueuedRunner([nave_adapter.Completed(1, "", "boom")])
+
+    handle = nave_adapter.pen_create(runner, nave_adapter.PenQuery(), "nave/api-audit")
+
+    assert runner.calls == [
+        ["pen", "create", "--name", "nave/api-audit"],
+    ]
+    assert handle.state == "error"
+    assert handle.returncode == 1
+    assert handle.stderr == "boom"
+    assert handle.pen is None
+
+
+def test_pen_exec_default_never_passes_push_or_commit_flags():
+    status_json = "[]"
+    runner = QueuedRunner(
+        [
+            nave_adapter.Completed(0, "ok", ""),
+            nave_adapter.Completed(0, status_json, ""),
+        ]
+    )
+
+    result = nave_adapter.pen_exec(runner, "nave/api-audit", ["echo", "hi"])
+
+    exec_call = runner.calls[0]
+    assert "--push-changes" not in exec_call
+    assert "--commit" not in exec_call
+    assert exec_call == ["pen", "exec", "nave/api-audit", "--", "echo", "hi"]
+    assert result["adapter_state"] == "ok"
+    assert result["status"] == {"repos": []}
+
+
+def test_pen_exec_explicit_commit_adds_only_commit_flag():
+    runner = QueuedRunner(
+        [
+            nave_adapter.Completed(0, "ok", ""),
+            nave_adapter.Completed(0, "[]", ""),
+        ]
+    )
+
+    nave_adapter.pen_exec(
+        runner, "nave/api-audit", ["echo", "hi"], commit=True, message="update"
+    )
+
+    exec_call = runner.calls[0]
+    assert "--commit" in exec_call
+    assert "--push-changes" not in exec_call
+    assert exec_call == [
+        "pen",
+        "exec",
+        "nave/api-audit",
+        "--commit",
+        "-m",
+        "update",
+        "--",
+        "echo",
+        "hi",
+    ]
+
+
+def test_pen_exec_explicit_push_changes_adds_only_push_flag():
+    runner = QueuedRunner(
+        [
+            nave_adapter.Completed(0, "ok", ""),
+            nave_adapter.Completed(0, "[]", ""),
+        ]
+    )
+
+    nave_adapter.pen_exec(
+        runner, "nave/api-audit", ["echo", "hi"], commit=True, push_changes=True
+    )
+
+    exec_call = runner.calls[0]
+    # --push-changes already implies --commit on the real CLI; the adapter
+    # must not also emit a redundant --commit flag.
+    assert exec_call.count("--push-changes") == 1
+    assert "--commit" not in exec_call
+
+
+def test_pen_exec_supports_only_repo_filter():
+    runner = QueuedRunner(
+        [
+            nave_adapter.Completed(0, "ok", ""),
+            nave_adapter.Completed(0, "[]", ""),
+        ]
+    )
+
+    nave_adapter.pen_exec(runner, "nave/api-audit", ["echo", "hi"], only="acme/api")
+
+    assert runner.calls[0] == [
+        "pen",
+        "exec",
+        "nave/api-audit",
+        "--only",
+        "acme/api",
+        "--",
+        "echo",
+        "hi",
+    ]
+
+
+def test_pen_exec_command_is_argv_not_shell_string():
+    runner = QueuedRunner(
+        [
+            nave_adapter.Completed(0, "ok", ""),
+            nave_adapter.Completed(0, "[]", ""),
+        ]
+    )
+
+    nave_adapter.pen_exec(runner, "nave/api-audit", ["git", "grep", "-l", "TODO"])
+
+    exec_call = runner.calls[0]
+    tail = exec_call[exec_call.index("--") + 1 :]
+    assert tail == ["git", "grep", "-l", "TODO"]
+
+
+def test_pen_exec_rejects_empty_command():
+    runner = QueuedRunner([])
+
+    try:
+        nave_adapter.pen_exec(runner, "nave/api-audit", [])
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("expected ValueError for empty command")
+    assert runner.calls == []
+
+
+def test_pen_exec_calls_status_after_exec_for_verification():
+    status_json = json.dumps(
+        [
+            {
+                "owner": "acme",
+                "repo": "api",
+                "working_tree": "dirty",
+                "freshness": "fresh",
+                "run_state": "run-local",
+                "divergence": "up-to-date",
+                "ahead": 0,
+                "behind": 0,
+            }
+        ]
+    )
+    runner = QueuedRunner(
+        [
+            nave_adapter.Completed(0, "did the thing", ""),
+            nave_adapter.Completed(0, status_json, ""),
+        ]
+    )
+
+    result = nave_adapter.pen_exec(runner, "nave/api-audit", ["make", "fmt"])
+
+    assert runner.calls[1] == ["pen", "status", "nave/api-audit", "--json"]
+    assert result["stdout"] == "did the thing"
+    assert result["status"]["repos"][0]["run_state"] == "run-local"
+
+
+def test_pen_exec_nonzero_exit_still_records_status_and_marks_error():
+    runner = QueuedRunner(
+        [
+            nave_adapter.Completed(1, "", "command failed"),
+            nave_adapter.Completed(0, "[]", ""),
+        ]
+    )
+
+    result = nave_adapter.pen_exec(runner, "nave/api-audit", ["false"])
+
+    assert result["adapter_state"] == "error"
+    assert result["returncode"] == 1
+    assert result["stderr"] == "command failed"
+    assert result["status"] == {"repos": []}
+
+
+def test_fixture_pen_show_decodes_faithful_json():
+    runner = nave_adapter.NaveRunner(fixtures=FIXTURES)
+
+    result = nave_adapter.pen_show(runner, name="nave/api-audit")
+
+    assert result["name"] == "nave/api-audit"
+    assert result["repos"][0]["owner"] == "acme"
+    assert "content" not in result
+
+
+def test_fixture_pen_status_decodes_faithful_json():
+    runner = nave_adapter.NaveRunner(fixtures=FIXTURES)
+
+    result = nave_adapter.pen_status(runner, "nave/api-audit")
+
+    assert result["repos"][0]["owner"] == "acme"
+    assert result["repos"][0]["working_tree"] in {"clean", "dirty", "missing"}
+
+
+def test_fixture_pen_create_builds_handle_from_show():
+    runner = nave_adapter.NaveRunner(fixtures=FIXTURES)
+
+    handle = nave_adapter.pen_create(
+        runner, nave_adapter.PenQuery(terms=["workflow:pytest"]), "nave/api-audit"
+    )
+
+    assert handle.state == "ok"
+    assert handle.pen["name"] == "nave/api-audit"
+
+
+def test_fixture_pen_exec_is_opaque_and_reports_status():
+    runner = nave_adapter.NaveRunner(fixtures=FIXTURES)
+
+    result = nave_adapter.pen_exec(runner, "nave/api-audit", ["make", "fmt"])
+
+    assert result["adapter_state"] == "ok"
+    assert result["status"]["repos"]
+
+
+def test_cli_pen_show_and_status_use_fixtures(monkeypatch, capsys):
+    monkeypatch.setenv("PULSE_NAVE_FIXTURES", str(FIXTURES))
+
+    assert nave_adapter.main(["pen-show", "--name", "nave/api-audit"]) == 0
+    assert json.loads(capsys.readouterr().out)["name"] == "nave/api-audit"
+
+    assert nave_adapter.main(["pen-status", "--name", "nave/api-audit"]) == 0
+    assert json.loads(capsys.readouterr().out)["repos"][0]["owner"] == "acme"

--- a/lib/pulse/scripts/tests/test_pen_acceptance.py
+++ b/lib/pulse/scripts/tests/test_pen_acceptance.py
@@ -1,0 +1,294 @@
+"""End-to-end acceptance gate for the F6 Nave pen mutation stack.
+
+Proves the whole pipeline end-to-end via the offline fixture-driven fake
+runner (no network, no real `nave` binary): `mutation_plan.load_registry`
+loads the REAL `templates/transformations.yaml.template` registry (not a
+hand-built dataclass), `mutation_plan.build_proposal`/`validate_proposal`
+gate a `Proposal` against it, and `pen_orchestrator.execute` drives that
+proposal through the pen state machine using the injectable
+`read_repo_head`/`read_repo_file` seams `pen_orchestrator.py` (F6 Task 3)
+defines.
+
+1. A two-repo pen where one repo changes and one no-ops drives a full
+   propose-only run to state "proposed": no push command is ever issued,
+   the resulting `PenRunResult` converts to a `repo-mutation` result that
+   passes `validate_result.validate`, attribution is exact, and running
+   `execute()` again with the same inputs is idempotent (equal results, no
+   additional command beyond the same expected second-run set).
+2. A stale remote SHA (an `expected_shas` mismatch surfaced via
+   `read_repo_head`) blocks the run before `pen exec` is ever invoked, with
+   per-repo attribution naming which repo is stale.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lib.pulse.scripts import mutation_plan, nave_adapter, pen_orchestrator, validate_result
+
+
+@pytest.fixture(autouse=True)
+def _stub_probe(monkeypatch):
+    """`nave_adapter.probe` issues its own `--version`/`--help` calls,
+    noise unrelated to the scripted `QueuedRunner` sequences below — same
+    stub `test_pen_orchestrator.py` uses."""
+
+    def fake_probe(_runner):
+        return {"available": True, "version": "0.0.9", "protocol": 1}
+
+    monkeypatch.setattr(pen_orchestrator.nave_adapter, "probe", fake_probe)
+
+
+REGISTRY_PATH = Path("templates/transformations.yaml.template")
+TRANSFORMATION_ID = "format-python"  # command_argv: ruff format .; validation: none
+REPOS = [("acme", "api"), ("acme", "web")]
+SELECTION = ("acme/api", "acme/web")
+PEN_NAME = "nave/acceptance"
+WORKSPACE = "acme"
+RUN_AT = "2026-07-19T09:00:00Z"
+EXPECTED_SHAS = {"acme/api": "deadbeef00", "acme/web": "cafef00d00"}
+
+
+class QueuedRunner:
+    """Fake runner returning a distinct `Completed` per call, in order —
+    the same idiom `test_nave_adapter.py`/`test_pen_orchestrator.py`
+    already establish for scripted multi-call sequences. No subprocess,
+    no network, no real `nave` binary."""
+
+    def __init__(self, results):
+        self.calls = []
+        self._results = list(results)
+
+    def run(self, args):
+        self.calls.append(args)
+        return self._results.pop(0)
+
+
+def _pen_show_completed(repos):
+    payload = {
+        "name": PEN_NAME,
+        "created_at": "2026-07-19T08:00:00Z",
+        "branch": PEN_NAME,
+        "filter": {"terms": []},
+        "repos": [
+            {
+                "owner": owner,
+                "name": name,
+                "default_branch": "main",
+                "clone_url": "x",
+                "synced_at": "2026-07-19T08:00:00Z",
+            }
+            for owner, name in repos
+        ],
+        "ops": [],
+    }
+    return nave_adapter.Completed(0, json.dumps(payload), "")
+
+
+def _pen_status_completed(entries):
+    return nave_adapter.Completed(0, json.dumps(entries), "")
+
+
+def _repo_state(owner, repo, working_tree="clean", freshness="fresh", divergence="up-to-date"):
+    return {
+        "owner": owner,
+        "repo": repo,
+        "working_tree": working_tree,
+        "freshness": freshness,
+        "run_state": "not-run",
+        "divergence": divergence,
+        "ahead": 0,
+        "behind": 0,
+    }
+
+
+def _create_sequence(repos):
+    """`pen_create`'s two calls: `pen create`, then `pen show --json`."""
+    return [
+        nave_adapter.Completed(0, "created\n", ""),
+        _pen_show_completed(repos),
+    ]
+
+
+def _clean_preflight_status():
+    return _pen_status_completed([_repo_state("acme", "api"), _repo_state("acme", "web")])
+
+
+def _full_success_sequence():
+    """create -> preflight status (clean) -> exec (ok) -> post-exec status,
+    where `acme/api` ends dirty (the transformation changed it) and
+    `acme/web` ends clean (a no-op for that repo) — the "one repo changes,
+    one no-ops" scenario. Both still resolve to a single aggregate "ok"
+    exec outcome: `nave_pen::ops::exec_pen` has no per-repo success signal
+    (see `pen_orchestrator.py`'s NEEDS_CONTEXT docstring section), so a
+    per-repo diff is visible only in post-exec `working_tree`, never in
+    `repo_outcomes`."""
+    return [
+        *_create_sequence(REPOS),
+        _clean_preflight_status(),
+        nave_adapter.Completed(0, "reformatted acme/api\nacme/web: no changes\n", ""),
+        _pen_status_completed(
+            [
+                _repo_state("acme", "api", working_tree="dirty"),
+                _repo_state("acme", "web", working_tree="clean"),
+            ]
+        ),
+    ]
+
+
+def matching_head(repo: str) -> str:
+    return EXPECTED_SHAS[repo]
+
+
+def load_transformation():
+    """Load the REAL registry from `templates/transformations.yaml.template`
+    via the public `mutation_plan.load_registry` API — not a hand-built
+    `TransformationEntry` — so this test exercises the same registry file a
+    real deployment ships."""
+    registry = mutation_plan.load_registry(REGISTRY_PATH)
+    return registry, registry.get(TRANSFORMATION_ID)
+
+
+def build_plan(*, selection=SELECTION, expected_shas=None):
+    registry, entry = load_transformation()
+    proposal = mutation_plan.build_proposal(
+        id="acceptance-run-1",
+        selection=list(selection),
+        transformation=TRANSFORMATION_ID,
+        expected_shas=expected_shas if expected_shas is not None else dict(EXPECTED_SHAS),
+        actor={"gh_login": "octocat", "machine": "acceptance-mba", "mode": "interactive"},
+        mutation_policy="propose",
+        registry=registry,
+    )
+    plan = pen_orchestrator.PenPlan(
+        proposal=proposal,
+        entry=entry,
+        pen_name=PEN_NAME,
+        query=nave_adapter.PenQuery(terms=["workflow:pytest"]),
+    )
+    return plan
+
+
+def to_repo_mutation_result(result: pen_orchestrator.PenRunResult) -> dict:
+    """Build a `repo-mutation` result document from a `PenRunResult` plus
+    the envelope fields `lib/patterns/headless-contract.md` requires on
+    every kind — exactly what a headless caller writing
+    `repo-mutation-result.yaml` would assemble."""
+    return {
+        "contract_version": 1,
+        "kind": "repo-mutation",
+        "workspace": WORKSPACE,
+        "run_at": RUN_AT,
+        "actor": {
+            "gh_login": result.actor.gh_login,
+            "machine": result.actor.machine,
+            "mode": result.actor.mode,
+        },
+        "state": result.state,
+        "proposal_id": result.proposal_id,
+        "transformation": result.transformation,
+        "pen_name": result.pen_name,
+        "selection": list(result.selection),
+        "nave_version": result.nave_version,
+        "repo_outcomes": dict(result.repo_outcomes),
+        "reason": result.reason,
+        "errors": [],
+    }
+
+
+def _assert_no_push_or_commit(calls):
+    for call in calls:
+        assert "--push-changes" not in call, call
+        assert "--commit" not in call, call
+
+
+# --- 1. two-repo pen, one changes / one no-ops, propose-only, idempotent ---
+
+
+def test_two_repo_pen_propose_only_no_push_valid_and_attributed():
+    plan = build_plan()
+    runner = QueuedRunner(_full_success_sequence())
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=matching_head)
+
+    # (a) no push: every command argv issued to the runner is inspected.
+    assert runner.calls  # sanity: the fixture sequence was actually consumed
+    _assert_no_push_or_commit(runner.calls)
+
+    # terminal state
+    assert result.state == "proposed"
+    assert result.reason is None
+
+    # (b) the result converts to a repo-mutation document that validates.
+    document = to_repo_mutation_result(result)
+    assert validate_result.validate(document, "repo-mutation") == []
+
+    # (c) exact attribution.
+    assert result.actor.gh_login == "octocat"
+    assert result.actor.machine == "acceptance-mba"
+    assert result.actor.mode == "interactive"
+    assert result.pen_name == PEN_NAME
+    assert result.transformation == TRANSFORMATION_ID
+    assert result.selection == SELECTION
+    assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "ok"}
+
+
+def test_two_repo_pen_propose_only_repeat_is_idempotent():
+    plan = build_plan()
+
+    runner_1 = QueuedRunner(_full_success_sequence())
+    result_1 = pen_orchestrator.execute(plan, runner_1, read_repo_head=matching_head)
+
+    runner_2 = QueuedRunner(_full_success_sequence())
+    result_2 = pen_orchestrator.execute(plan, runner_2, read_repo_head=matching_head)
+
+    # Equal PenRunResults for equal inputs.
+    assert result_1 == result_2
+    assert result_1.state == "proposed"
+
+    # No additional mutating commands beyond the expected second-run set:
+    # the second run issues the identical shape of calls as the first
+    # (create, show, preflight status, exec, post-exec status) — never more
+    # — and neither run ever pushes or commits.
+    assert runner_2.calls == runner_1.calls
+    _assert_no_push_or_commit(runner_1.calls)
+    _assert_no_push_or_commit(runner_2.calls)
+
+
+# --- 2. stale remote SHA blocks before exec ---------------------------------
+
+
+def test_stale_remote_sha_blocks_before_exec_with_attribution():
+    plan = build_plan()
+    runner = QueuedRunner(
+        [
+            *_create_sequence(REPOS),
+            _clean_preflight_status(),
+        ]
+    )
+
+    def read_repo_head(repo: str) -> str:
+        if repo == "acme/api":
+            return EXPECTED_SHAS[repo]
+        return "0000000000"  # acme/web: remote moved since the proposal was built
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=read_repo_head)
+
+    assert result.state == "blocked"
+    assert result.reason is not None
+    assert "acme/web" in result.reason
+    assert "acme/api" not in result.reason
+
+    # pen exec must never be invoked once a stale SHA is detected.
+    assert not any("exec" in call for call in runner.calls)
+    _assert_no_push_or_commit(runner.calls)
+
+    # per-repo attribution: the stale repo is blocked, the fresh one is ok.
+    assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "blocked"}
+
+    # The result still converts to a valid (blocked) repo-mutation document.
+    document = to_repo_mutation_result(result)
+    assert validate_result.validate(document, "repo-mutation") == []

--- a/lib/pulse/scripts/tests/test_pen_acceptance.py
+++ b/lib/pulse/scripts/tests/test_pen_acceptance.py
@@ -235,6 +235,12 @@ def test_two_repo_pen_propose_only_no_push_valid_and_attributed():
     assert result.selection == SELECTION
     assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "ok"}
 
+    # The "one changes, one no-ops" scenario is load-bearing: the entire
+    # scripted sequence — including the post-exec status where acme/api is
+    # dirty and acme/web clean — was consumed, and the dirty-after-exec repo
+    # (the expected diff) still resolved to proposed/ok rather than a block.
+    assert runner._results == []
+
 
 def test_two_repo_pen_propose_only_repeat_is_idempotent():
     plan = build_plan()

--- a/lib/pulse/scripts/tests/test_pen_orchestrator.py
+++ b/lib/pulse/scripts/tests/test_pen_orchestrator.py
@@ -1,0 +1,374 @@
+"""Tests for the pen mutation orchestrator state machine."""
+
+import pytest
+
+from lib.pulse.scripts import mutation_plan, nave_adapter, pen_orchestrator
+
+
+@pytest.fixture(autouse=True)
+def _stub_probe(monkeypatch):
+    """`nave_adapter.probe` issues several `--help`/`--version` calls of its
+    own (version, help, `pen --help`, per-action `--help` probes) — noise
+    unrelated to what any given test's `QueuedRunner` sequence is checking.
+    Stub it to a fixed, cheap response by default; the one test that cares
+    about the probed version overrides this with its own monkeypatch."""
+
+    def fake_probe(_runner):
+        return {"available": True, "version": "0.0.8", "protocol": 1}
+
+    monkeypatch.setattr(pen_orchestrator.nave_adapter, "probe", fake_probe)
+
+
+class QueuedRunner:
+    """Fake runner that returns a distinct Completed per call, in order.
+
+    Mirrors the `QueuedRunner` idiom `test_nave_adapter.py` already
+    establishes for multi-call sequences.
+    """
+
+    def __init__(self, results):
+        self.calls = []
+        self._results = list(results)
+
+    def run(self, args):
+        self.calls.append(args)
+        return self._results.pop(0)
+
+
+class NoCallRunner:
+    """Fake runner that fails the test if `.run` is ever invoked — used to
+    prove a gate short-circuits before any Nave interaction."""
+
+    def run(self, args):  # pragma: no cover - should never be called
+        raise AssertionError(f"runner.run() called unexpectedly with {args}")
+
+
+def registry_data(validation=None):
+    return {
+        "transformations": {
+            "format-python": {
+                "id": "format-python",
+                "command_argv": ["ruff", "format", "."],
+                "applies_to": ["always"],
+                "validation": validation or {"kind": "none"},
+                "allow_scheduled": True,
+            }
+        }
+    }
+
+
+def make_entry(validation=None):
+    registry = mutation_plan.load_registry(registry_data(validation))
+    return registry.get("format-python")
+
+
+def make_proposal(selection=("acme/api", "acme/web"), mutation_policy="propose"):
+    return mutation_plan.build_proposal(
+        id="run-1",
+        selection=list(selection),
+        transformation="format-python",
+        expected_shas={repo: "deadbeef" for repo in selection},
+        actor={"gh_login": "octocat", "machine": "laptop", "mode": "interactive"},
+        mutation_policy=mutation_policy,
+    )
+
+
+def make_plan(selection=("acme/api", "acme/web"), mutation_policy="propose", request_push=False, validation=None):
+    proposal = make_proposal(selection=selection, mutation_policy=mutation_policy)
+    entry = make_entry(validation=validation)
+    return pen_orchestrator.PenPlan(
+        proposal=proposal,
+        entry=entry,
+        pen_name="nave/api-audit",
+        query=nave_adapter.PenQuery(terms=["workflow:pytest"]),
+        request_push=request_push,
+    )
+
+
+def pen_show_completed(repos):
+    import json
+
+    payload = {
+        "name": "nave/api-audit",
+        "created_at": "2026-07-15T10:00:00Z",
+        "branch": "nave/api-audit",
+        "filter": {"terms": []},
+        "repos": [{"owner": o, "name": n, "default_branch": "main", "clone_url": "x", "synced_at": "2026-07-15T10:00:00Z"} for o, n in repos],
+        "ops": [],
+    }
+    return nave_adapter.Completed(0, json.dumps(payload), "")
+
+
+def pen_status_completed(entries):
+    import json
+
+    return nave_adapter.Completed(0, json.dumps(entries), "")
+
+
+def repo_state(owner, repo, working_tree="clean", freshness="fresh", run_state="not-run", divergence="up-to-date", ahead=0, behind=0):
+    return {
+        "owner": owner,
+        "repo": repo,
+        "working_tree": working_tree,
+        "freshness": freshness,
+        "run_state": run_state,
+        "divergence": divergence,
+        "ahead": ahead,
+        "behind": behind,
+    }
+
+
+def create_sequence(repos, extra=()):
+    """Build the Completed queue for pen_create's two calls (create, show)."""
+    return [
+        nave_adapter.Completed(0, "created\n", ""),
+        pen_show_completed(repos),
+        *extra,
+    ]
+
+
+REPOS = [("acme", "api"), ("acme", "web")]
+SELECTION = ("acme/api", "acme/web")
+
+
+# --- forbidden push -----------------------------------------------------
+
+
+def test_forbidden_push_via_explicit_request_blocks_before_any_nave_call():
+    plan = make_plan(request_push=True)
+
+    result = pen_orchestrator.execute(plan, NoCallRunner())
+
+    assert result.state == "blocked"
+    assert "forbidden" in result.reason
+    assert result.repo_outcomes == {repo: "blocked" for repo in SELECTION}
+
+
+def test_forbidden_push_via_non_propose_policy_blocks_before_any_nave_call():
+    plan = make_plan(mutation_policy="allow")
+
+    result = pen_orchestrator.execute(plan, NoCallRunner())
+
+    assert result.state == "blocked"
+    assert "forbidden" in result.reason
+
+
+# --- stale pen ------------------------------------------------------------
+
+
+def test_stale_pen_blocks_before_exec():
+    plan = make_plan()
+    runner = QueuedRunner(
+        [
+            *create_sequence(REPOS),
+            pen_status_completed(
+                [
+                    repo_state("acme", "api"),
+                    repo_state("acme", "web", freshness="stale", divergence="behind", behind=2),
+                ]
+            ),
+        ]
+    )
+
+    result = pen_orchestrator.execute(plan, runner)
+
+    assert result.state == "blocked"
+    assert "stale" in result.reason
+    assert result.repo_outcomes == {repo: "blocked" for repo in SELECTION}
+    # Exec must never be reached: only create (2 calls) + status (1 call).
+    assert len(runner.calls) == 3
+    assert runner.calls[-1] == ["pen", "status", "nave/api-audit", "--json"]
+
+
+# --- dirty before run -------------------------------------------------------
+
+
+def test_dirty_working_tree_before_run_blocks_before_exec():
+    plan = make_plan()
+    runner = QueuedRunner(
+        [
+            *create_sequence(REPOS),
+            pen_status_completed(
+                [
+                    repo_state("acme", "api", working_tree="dirty"),
+                    repo_state("acme", "web"),
+                ]
+            ),
+        ]
+    )
+
+    result = pen_orchestrator.execute(plan, runner)
+
+    assert result.state == "blocked"
+    assert "dirty" in result.reason
+    assert result.repo_outcomes == {repo: "blocked" for repo in SELECTION}
+    assert len(runner.calls) == 3
+
+
+# --- command failure in one repo -------------------------------------------
+
+
+def test_command_failure_fails_whole_run_and_marks_every_repo_failed():
+    plan = make_plan()
+    runner = QueuedRunner(
+        [
+            *create_sequence(REPOS),
+            pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+            nave_adapter.Completed(1, "", "exec failed in acme/web"),
+            pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+        ]
+    )
+
+    result = pen_orchestrator.execute(plan, runner)
+
+    assert result.state == "failed"
+    assert "exec failed" in result.reason
+    assert result.repo_outcomes == {repo: "failed" for repo in SELECTION}
+    exec_call = runner.calls[3]
+    assert exec_call == [
+        "pen",
+        "exec",
+        "nave/api-audit",
+        "--",
+        "ruff",
+        "format",
+        ".",
+    ]
+    assert "--push-changes" not in exec_call
+    assert "--commit" not in exec_call
+
+
+# --- schema validation (NEEDS_CONTEXT: fails closed, no read capability) --
+
+
+def test_json_schema_validation_fails_closed_after_successful_exec():
+    plan = make_plan(
+        validation={
+            "kind": "json_schema",
+            "path": "package-lock.json",
+            "schema": {"type": "object", "required": ["lockfileVersion"]},
+        }
+    )
+    runner = QueuedRunner(
+        [
+            *create_sequence(REPOS),
+            pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+            nave_adapter.Completed(0, "ran ok", ""),
+            pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+        ]
+    )
+
+    result = pen_orchestrator.execute(plan, runner)
+
+    assert result.state == "failed"
+    assert "json_schema" in result.reason
+    assert "package-lock.json" in result.reason
+    assert result.repo_outcomes == {repo: "failed" for repo in SELECTION}
+
+
+# --- propose-only success --------------------------------------------------
+
+
+def test_propose_only_success_never_passes_push_or_commit_flags():
+    plan = make_plan()
+    runner = QueuedRunner(
+        [
+            *create_sequence(REPOS),
+            pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+            nave_adapter.Completed(0, "ran ok", ""),
+            pen_status_completed(
+                [
+                    repo_state("acme", "api", working_tree="dirty"),
+                    repo_state("acme", "web", working_tree="dirty"),
+                ]
+            ),
+        ]
+    )
+
+    result = pen_orchestrator.execute(plan, runner)
+
+    assert result.state == "proposed"
+    assert result.reason is None
+    assert result.repo_outcomes == {repo: "ok" for repo in SELECTION}
+    assert result.pen_name == "nave/api-audit"
+    assert result.proposal_id == "run-1"
+    assert result.transformation == "format-python"
+    assert result.selection == SELECTION
+    assert result.actor.gh_login == "octocat"
+    assert result.actor.machine == "laptop"
+    exec_call = runner.calls[3]
+    assert "--push-changes" not in exec_call
+    assert "--commit" not in exec_call
+
+
+def test_propose_only_success_records_probed_nave_version(monkeypatch):
+    plan = make_plan()
+    runner = QueuedRunner(
+        [
+            *create_sequence(REPOS),
+            pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+            nave_adapter.Completed(0, "ran ok", ""),
+            pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+        ]
+    )
+
+    def fake_probe(_runner):
+        return {"available": True, "version": "0.0.9"}
+
+    monkeypatch.setattr(pen_orchestrator.nave_adapter, "probe", fake_probe)
+
+    result = pen_orchestrator.execute(plan, runner)
+
+    assert result.nave_version == "0.0.9"
+    assert result.state == "proposed"
+
+
+# --- structural / safety-net checks not in the required matrix but real --
+
+
+def test_entry_proposal_mismatch_raises_programmer_error():
+    proposal = make_proposal()
+    other_entry = mutation_plan.load_registry(
+        {
+            "transformations": {
+                "other": {
+                    "id": "other",
+                    "command_argv": ["true"],
+                    "applies_to": ["always"],
+                    "validation": {"kind": "none"},
+                    "allow_scheduled": True,
+                }
+            }
+        }
+    ).get("other")
+    plan = pen_orchestrator.PenPlan(
+        proposal=proposal,
+        entry=other_entry,
+        pen_name="nave/api-audit",
+        query=nave_adapter.PenQuery(),
+    )
+
+    with pytest.raises(pen_orchestrator.PenOrchestratorError):
+        pen_orchestrator.execute(plan, NoCallRunner())
+
+
+def test_pen_create_failure_fails_the_run():
+    plan = make_plan()
+    runner = QueuedRunner([nave_adapter.Completed(1, "", "create failed")])
+
+    result = pen_orchestrator.execute(plan, runner)
+
+    assert result.state == "failed"
+    assert "create failed" in result.reason
+    assert result.repo_outcomes == {repo: "failed" for repo in SELECTION}
+
+
+def test_pen_selection_mismatch_blocks_the_run():
+    plan = make_plan()
+    runner = QueuedRunner(create_sequence([("acme", "api")]))  # missing acme/web
+
+    result = pen_orchestrator.execute(plan, runner)
+
+    assert result.state == "blocked"
+    assert "does not match" in result.reason or "do not match" in result.reason
+    assert result.repo_outcomes == {repo: "blocked" for repo in SELECTION}

--- a/lib/pulse/scripts/tests/test_pen_orchestrator.py
+++ b/lib/pulse/scripts/tests/test_pen_orchestrator.py
@@ -1,5 +1,7 @@
 """Tests for the pen mutation orchestrator state machine."""
 
+import dataclasses
+
 import pytest
 
 from lib.pulse.scripts import mutation_plan, nave_adapter, pen_orchestrator
@@ -230,7 +232,7 @@ def test_expected_shas_with_no_reader_blocks_with_explicit_message():
 
     assert result.state == "blocked"
     assert "read_repo_head" in result.reason
-    assert "expected_shas" in result.reason
+    assert "expected-SHA" in result.reason
     assert result.repo_outcomes == {repo: "blocked" for repo in SELECTION}
     # Exec must never be reached: only create (2 calls) + status (1 call).
     assert len(runner.calls) == 3
@@ -289,6 +291,27 @@ def test_expected_shas_reader_raising_for_a_repo_blocks_with_attribution():
     assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "blocked"}
     assert "acme/web" in result.reason
     assert "no checkout" in result.reason
+    assert len(runner.calls) == 3
+    assert not any("exec" in call for call in runner.calls)
+
+
+def test_expected_shas_missing_entry_for_selected_repo_blocks_before_exec():
+    # A hand-built Proposal (bypassing build_proposal's coverage check) with
+    # a selected repo absent from expected_shas must block, not skip the
+    # guard for that repo — an unguarded repo is exactly the stale-base
+    # mutation the guard exists to prevent.
+    plan = make_plan()
+    partial = dataclasses.replace(
+        plan.proposal, expected_shas={"acme/api": "deadbeef"}
+    )
+    plan = dataclasses.replace(plan, proposal=partial)
+    runner = QueuedRunner(_clean_preflight_sequence())
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=matching_head)
+
+    assert result.state == "blocked"
+    assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "blocked"}
+    assert "no expected_shas entry" in result.reason
     assert len(runner.calls) == 3
     assert not any("exec" in call for call in runner.calls)
 

--- a/lib/pulse/scripts/tests/test_pen_orchestrator.py
+++ b/lib/pulse/scripts/tests/test_pen_orchestrator.py
@@ -266,6 +266,75 @@ def test_json_schema_validation_fails_closed_after_successful_exec():
     assert result.repo_outcomes == {repo: "failed" for repo in SELECTION}
 
 
+# --- schema validation with an injected reader -----------------------------
+
+
+def _json_schema_plan():
+    return make_plan(
+        validation={
+            "kind": "json_schema",
+            "path": "package-lock.json",
+            "schema": {"type": "object", "required": ["lockfileVersion"]},
+        }
+    )
+
+
+def _exec_ok_sequence():
+    return [
+        *create_sequence(REPOS),
+        pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+        nave_adapter.Completed(0, "ran ok", ""),
+        pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+    ]
+
+
+def test_json_schema_with_reader_and_valid_file_proceeds_to_proposed():
+    plan = _json_schema_plan()
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    def read_repo_file(repo, path):
+        assert path == "package-lock.json"
+        return b'{"lockfileVersion": 3}'
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_file=read_repo_file)
+
+    assert result.state == "proposed"
+    assert result.reason is None
+    assert result.repo_outcomes == {repo: "ok" for repo in SELECTION}
+
+
+def test_json_schema_with_reader_and_invalid_file_fails_with_per_repo_attribution():
+    plan = _json_schema_plan()
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    def read_repo_file(repo, path):
+        if repo == "acme/api":
+            return b'{"lockfileVersion": 3}'
+        return b"{}"  # acme/web: missing required lockfileVersion
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_file=read_repo_file)
+
+    assert result.state == "failed"
+    assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "failed"}
+    assert "acme/web" in result.reason
+    assert "lockfileVersion" in result.reason
+    assert "acme/api" not in result.reason
+
+
+def test_json_schema_with_reader_and_missing_file_fails():
+    plan = _json_schema_plan()
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    def read_repo_file(repo, path):
+        raise FileNotFoundError(f"{repo}:{path} not found")
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_file=read_repo_file)
+
+    assert result.state == "failed"
+    assert result.repo_outcomes == {repo: "failed" for repo in SELECTION}
+    assert "not found" in result.reason
+
+
 # --- propose-only success --------------------------------------------------
 
 

--- a/lib/pulse/scripts/tests/test_pen_orchestrator.py
+++ b/lib/pulse/scripts/tests/test_pen_orchestrator.py
@@ -131,6 +131,13 @@ REPOS = [("acme", "api"), ("acme", "web")]
 SELECTION = ("acme/api", "acme/web")
 
 
+def matching_head(repo):
+    """`read_repo_head` stub returning the SHA `make_proposal` bakes into
+    every `expected_shas` entry ("deadbeef") — used by tests that must
+    clear the expected-SHA guard to reach exec/validation."""
+    return "deadbeef"
+
+
 # --- forbidden push -----------------------------------------------------
 
 
@@ -205,6 +212,87 @@ def test_dirty_working_tree_before_run_blocks_before_exec():
     assert len(runner.calls) == 3
 
 
+# --- expected-SHA guard (stale-base block) ---------------------------------
+
+
+def _clean_preflight_sequence():
+    return [
+        *create_sequence(REPOS),
+        pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+    ]
+
+
+def test_expected_shas_with_no_reader_blocks_with_explicit_message():
+    plan = make_plan()
+    runner = QueuedRunner(_clean_preflight_sequence())
+
+    result = pen_orchestrator.execute(plan, runner)
+
+    assert result.state == "blocked"
+    assert "read_repo_head" in result.reason
+    assert "expected_shas" in result.reason
+    assert result.repo_outcomes == {repo: "blocked" for repo in SELECTION}
+    # Exec must never be reached: only create (2 calls) + status (1 call).
+    assert len(runner.calls) == 3
+    assert not any("exec" in call for call in runner.calls)
+
+
+def test_expected_shas_all_matching_proceeds_to_proposed():
+    plan = make_plan()
+    runner = QueuedRunner(
+        [
+            *_clean_preflight_sequence(),
+            nave_adapter.Completed(0, "ran ok", ""),
+            pen_status_completed([repo_state("acme", "api"), repo_state("acme", "web")]),
+        ]
+    )
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=matching_head)
+
+    assert result.state == "proposed"
+    assert result.repo_outcomes == {repo: "ok" for repo in SELECTION}
+
+
+def test_expected_shas_one_mismatch_blocks_before_exec_with_attribution():
+    plan = make_plan()
+    runner = QueuedRunner(_clean_preflight_sequence())
+
+    def read_repo_head(repo):
+        if repo == "acme/api":
+            return "deadbeef"
+        return "0000000"  # acme/web: does not match expected "deadbeef"
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=read_repo_head)
+
+    assert result.state == "blocked"
+    assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "blocked"}
+    assert "acme/web" in result.reason
+    assert "deadbeef" in result.reason
+    assert "acme/api" not in result.reason
+    # Exec must never be reached: only create (2 calls) + status (1 call).
+    assert len(runner.calls) == 3
+    assert not any("exec" in call for call in runner.calls)
+
+
+def test_expected_shas_reader_raising_for_a_repo_blocks_with_attribution():
+    plan = make_plan()
+    runner = QueuedRunner(_clean_preflight_sequence())
+
+    def read_repo_head(repo):
+        if repo == "acme/api":
+            return "deadbeef"
+        raise FileNotFoundError(f"no checkout for {repo}")
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=read_repo_head)
+
+    assert result.state == "blocked"
+    assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "blocked"}
+    assert "acme/web" in result.reason
+    assert "no checkout" in result.reason
+    assert len(runner.calls) == 3
+    assert not any("exec" in call for call in runner.calls)
+
+
 # --- command failure in one repo -------------------------------------------
 
 
@@ -219,7 +307,7 @@ def test_command_failure_fails_whole_run_and_marks_every_repo_failed():
         ]
     )
 
-    result = pen_orchestrator.execute(plan, runner)
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=matching_head)
 
     assert result.state == "failed"
     assert "exec failed" in result.reason
@@ -258,7 +346,7 @@ def test_json_schema_validation_fails_closed_after_successful_exec():
         ]
     )
 
-    result = pen_orchestrator.execute(plan, runner)
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=matching_head)
 
     assert result.state == "failed"
     assert "json_schema" in result.reason
@@ -296,7 +384,9 @@ def test_json_schema_with_reader_and_valid_file_proceeds_to_proposed():
         assert path == "package-lock.json"
         return b'{"lockfileVersion": 3}'
 
-    result = pen_orchestrator.execute(plan, runner, read_repo_file=read_repo_file)
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_file=read_repo_file, read_repo_head=matching_head
+    )
 
     assert result.state == "proposed"
     assert result.reason is None
@@ -312,7 +402,9 @@ def test_json_schema_with_reader_and_invalid_file_fails_with_per_repo_attributio
             return b'{"lockfileVersion": 3}'
         return b"{}"  # acme/web: missing required lockfileVersion
 
-    result = pen_orchestrator.execute(plan, runner, read_repo_file=read_repo_file)
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_file=read_repo_file, read_repo_head=matching_head
+    )
 
     assert result.state == "failed"
     assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "failed"}
@@ -328,7 +420,9 @@ def test_json_schema_with_reader_and_missing_file_fails():
     def read_repo_file(repo, path):
         raise FileNotFoundError(f"{repo}:{path} not found")
 
-    result = pen_orchestrator.execute(plan, runner, read_repo_file=read_repo_file)
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_file=read_repo_file, read_repo_head=matching_head
+    )
 
     assert result.state == "failed"
     assert result.repo_outcomes == {repo: "failed" for repo in SELECTION}
@@ -354,7 +448,7 @@ def test_propose_only_success_never_passes_push_or_commit_flags():
         ]
     )
 
-    result = pen_orchestrator.execute(plan, runner)
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=matching_head)
 
     assert result.state == "proposed"
     assert result.reason is None
@@ -386,7 +480,7 @@ def test_propose_only_success_records_probed_nave_version(monkeypatch):
 
     monkeypatch.setattr(pen_orchestrator.nave_adapter, "probe", fake_probe)
 
-    result = pen_orchestrator.execute(plan, runner)
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=matching_head)
 
     assert result.nave_version == "0.0.9"
     assert result.state == "proposed"

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -751,6 +751,20 @@ def test_repo_mutation_selection_entries_must_be_strings(tmp_path):
     assert "selection[1] is not a string" in result.stderr
 
 
+def test_repo_mutation_invalid_fixture_reports_every_violation(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "repo-mutation-invalid.yaml").read_text())
+    path = tmp_path / "repo-mutation.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "repo-mutation")
+
+    assert result.returncode == 1
+    assert "missing required key: actor" in result.stderr
+    assert "missing required key: proposal_id" in result.stderr
+    assert "reason must not be null when state is blocked or failed" in result.stderr
+    assert "repo_outcomes.testorg/core invalid: exploded" in result.stderr
+
+
 def test_impact_legacy_string_edge_surfaces_as_unconfigured_finding(tmp_path):
     doc = yaml.safe_load((FIXTURES / "impact-valid.yaml").read_text())
     doc["findings"].append(

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -15,7 +15,10 @@ from lib.pulse.scripts.evaluate_checks import (
 
 SCRIPT = "lib/pulse/scripts/validate_result.py"
 FIXTURES = Path("lib/pulse/scripts/tests/fixtures")
-KINDS = ["status", "healthcheck", "refresh", "workflow-run", "fleet-membership", "impact"]
+KINDS = [
+    "status", "healthcheck", "refresh", "workflow-run", "fleet-membership",
+    "impact", "repo-mutation",
+]
 
 
 def run_validator(path, kind):
@@ -626,6 +629,126 @@ def test_impact_edge_tested_sha_and_remote_head_are_nullable(tmp_path):
     result = run_validator(path, "impact")
 
     assert result.returncode == 0, result.stderr
+
+
+def test_repo_mutation_rejects_invalid_state(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "repo-mutation-valid.yaml").read_text())
+    doc["state"] = "created"
+    path = tmp_path / "repo-mutation.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "repo-mutation")
+
+    assert result.returncode == 1
+    assert "state invalid: created" in result.stderr
+
+
+@pytest.mark.parametrize("state", ["proposed", "blocked", "failed"])
+def test_repo_mutation_accepts_exact_states(tmp_path, state):
+    doc = yaml.safe_load((FIXTURES / "repo-mutation-valid.yaml").read_text())
+    doc["state"] = state
+    if state != "proposed":
+        doc["reason"] = f"{state} for a reason"
+        doc["repo_outcomes"] = {repo: state for repo in doc["selection"]}
+    path = tmp_path / "repo-mutation.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "repo-mutation")
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize("state", ["blocked", "failed"])
+def test_repo_mutation_requires_reason_when_blocked_or_failed(tmp_path, state):
+    doc = yaml.safe_load((FIXTURES / "repo-mutation-valid.yaml").read_text())
+    doc["state"] = state
+    doc["reason"] = None
+    path = tmp_path / "repo-mutation.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "repo-mutation")
+
+    assert result.returncode == 1
+    assert "reason must not be null when state is blocked or failed" in result.stderr
+
+
+def test_repo_mutation_allows_null_reason_when_proposed(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "repo-mutation-valid.yaml").read_text())
+    assert doc["state"] == "proposed"
+    assert doc["reason"] is None
+    path = tmp_path / "repo-mutation.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "repo-mutation")
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_repo_mutation_rejects_invalid_repo_outcome_value(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "repo-mutation-valid.yaml").read_text())
+    doc["repo_outcomes"]["testorg/core"] = "exploded"
+    path = tmp_path / "repo-mutation.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "repo-mutation")
+
+    assert result.returncode == 1
+    assert "repo_outcomes.testorg/core invalid: exploded" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "state", "proposal_id", "transformation", "pen_name", "selection",
+        "nave_version", "repo_outcomes", "reason",
+    ],
+)
+def test_repo_mutation_requires_field(tmp_path, field):
+    doc = yaml.safe_load((FIXTURES / "repo-mutation-valid.yaml").read_text())
+    doc.pop(field)
+    path = tmp_path / "repo-mutation.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "repo-mutation")
+
+    assert result.returncode == 1
+    assert f"missing required key: {field}" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("state", 1),
+        ("proposal_id", 1),
+        ("transformation", 1),
+        ("pen_name", 1),
+        ("selection", "not-a-list"),
+        ("nave_version", 1),
+        ("repo_outcomes", "not-a-mapping"),
+        ("reason", 1),
+    ],
+)
+def test_repo_mutation_rejects_wrong_type(tmp_path, field, value):
+    doc = yaml.safe_load((FIXTURES / "repo-mutation-valid.yaml").read_text())
+    doc[field] = value
+    path = tmp_path / "repo-mutation.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "repo-mutation")
+
+    assert result.returncode == 1
+
+
+def test_repo_mutation_selection_entries_must_be_strings(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "repo-mutation-valid.yaml").read_text())
+    doc["selection"] = ["testorg/widget", 42]
+    path = tmp_path / "repo-mutation.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "repo-mutation")
+
+    assert result.returncode == 1
+    assert "selection[1] is not a string" in result.stderr
 
 
 def test_impact_legacy_string_edge_surfaces_as_unconfigured_finding(tmp_path):

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -5,7 +5,7 @@
 # ///
 """Validate a headless result file against the pulse result contract.
 
-Usage: validate_result.py <result.yaml> --kind status|healthcheck|refresh|workflow-run|fleet-membership|impact
+Usage: validate_result.py <result.yaml> --kind status|healthcheck|refresh|workflow-run|fleet-membership|impact|repo-mutation
 
 See lib/patterns/headless-contract.md for the schemas.
 
@@ -38,6 +38,8 @@ REFRESH_SECTION_STATUSES = {"refreshed", "skipped", "failed"}
 OUTCOMES = {"success", "failure", "skipped-cooldown", "aborted"}
 SEVERITIES = {"low", "medium", "high"}
 EDGE_STATES = {"current", "stale", "unknown"}
+REPO_MUTATION_STATES = {"proposed", "blocked", "failed"}
+REPO_OUTCOME_STATES = {"ok", "failed", "blocked"}
 
 
 def _err(errors, msg):
@@ -514,6 +516,23 @@ def validate(data, kind: str) -> list[str]:
         _require(data, "proposed_actions", list, errors)
         _require(data, "asks_recorded", list, errors)
 
+    elif kind == "repo-mutation":
+        state = _require_enum(data, "state", REPO_MUTATION_STATES, errors)
+        _require(data, "proposal_id", str, errors)
+        _require(data, "transformation", str, errors)
+        _require(data, "pen_name", str, errors)
+        _validate_string_list(data, "selection", errors)
+        _require_nullable(data, "nave_version", str, errors)
+        repo_outcomes = _require(data, "repo_outcomes", dict, errors)
+        for repo, outcome in (repo_outcomes or {}).items():
+            if not isinstance(repo, str):
+                _err(errors, "repo_outcomes keys must be strings")
+            if outcome not in REPO_OUTCOME_STATES:
+                _err(errors, f"repo_outcomes.{repo} invalid: {outcome}")
+        _require_nullable(data, "reason", str, errors)
+        if state in {"blocked", "failed"} and data.get("reason") is None:
+            _err(errors, "reason must not be null when state is blocked or failed")
+
     return errors
 
 
@@ -522,7 +541,7 @@ def main():
     parser.add_argument("file", help="Path to result YAML file")
     parser.add_argument("--kind", required=True,
                         choices=["status", "healthcheck", "refresh", "workflow-run",
-                                 "fleet-membership", "impact"])
+                                 "fleet-membership", "impact", "repo-mutation"])
     args = parser.parse_args()
 
     path = Path(args.file)

--- a/skills/gh-operations/SKILL.md
+++ b/skills/gh-operations/SKILL.md
@@ -143,6 +143,21 @@ Proceeding with fallback methods...
 
 **Fast path:** For common operations listed below, proceed directly to execution.
 
+### 2.5. Route by Mutation Target
+
+| Mutation targets | Route |
+|---|---|
+| A GitHub **object** (issue, PR, label, milestone, project item, branch protection, etc.) | Continue below — CLI/GraphQL/REST via this skill's normal enrichment flow. |
+| Repository **file content** (committing changes across one or more repos) | The Nave pen orchestrator, never a raw shell checkout/edit/push. See `{PLUGIN_ROOT}/lib/patterns/repository-mutations.md` and `{PLUGIN_ROOT}/lib/pulse/scripts/pen_orchestrator.py`. |
+
+A repository-file proposal is built as a typed `mutation_plan.Proposal`
+against the committed transformation registry
+(`{PLUGIN_ROOT}/templates/transformations.yaml.template`), then driven
+through `pen_orchestrator.execute()`. Arbitrary `nave pen exec` commands
+stay user-gated; only a registered transformation ID may run under
+`actor.mode: scheduled`. The run's terminal record is the `repo-mutation`
+result kind — see `{PLUGIN_ROOT}/lib/patterns/headless-contract.md`.
+
 ### 3. Execute with Enrichment
 
 1. **Resolve IDs** from cached config (project ID, field IDs, milestone ID)
@@ -291,6 +306,7 @@ For domains not in the routing guide:
 | `{PLUGIN_ROOT}/lib/patterns/graphql-execution.md` | Execute queries via temp file |
 | `{PLUGIN_ROOT}/lib/patterns/error-handling.md` | Handle API errors |
 | `{PLUGIN_ROOT}/lib/patterns/corpus-lookup.md` | Look up API syntax when uncertain |
+| `{PLUGIN_ROOT}/lib/patterns/repository-mutations.md` | Repository-file mutations via Nave pens |
 
 ### References (WHAT exists)
 

--- a/skills/gh-operations/SKILL.md
+++ b/skills/gh-operations/SKILL.md
@@ -154,8 +154,8 @@ A repository-file proposal is built as a typed `mutation_plan.Proposal`
 against the committed transformation registry
 (`{PLUGIN_ROOT}/templates/transformations.yaml.template`), then driven
 through `pen_orchestrator.execute()`. Arbitrary `nave pen exec` commands
-stay user-gated; only a registered transformation ID may run under
-`actor.mode: scheduled`. The run's terminal record is the `repo-mutation`
+stay user-gated; under `actor.mode: scheduled` a transformation must be
+registered **and** carry `allow_scheduled: true`. The run's terminal record is the `repo-mutation`
 result kind — see `{PLUGIN_ROOT}/lib/patterns/headless-contract.md`.
 
 ### 3. Execute with Enrichment

--- a/templates/transformations.yaml.template
+++ b/templates/transformations.yaml.template
@@ -1,0 +1,94 @@
+# hiivmind-pulse-gh - Repository-file transformation registry
+# Loaded by lib/pulse/scripts/mutation_plan.py (load_registry).
+# See lib/patterns/repository-mutations.md for the full contract this file
+# implements — proposal shape, gating rules, expected-SHA guarding.
+#
+# Every transformation here is a STRICT ARGV ARRAY. There is no shell
+# string, no template/command substitution of any kind: command_argv is
+# executed verbatim (subprocess, shell=False) via `nave pen exec ... --
+# <command_argv...>`. An argv element containing shell metacharacters
+# ($(...), backticks, ;, |, &&) is literal data to the executed process,
+# never interpreted by a shell — because no shell is ever invoked.
+#
+# `nave pen exec` with FREE-FORM commands (not one of these registered
+# IDs) always requires explicit human approval. Automatic/scheduled runs
+# (actor.mode: scheduled) may ONLY use a transformation with
+# allow_scheduled: true below.
+
+transformations:
+
+  # {{transformation_id}}:               # Registry key; must equal `id` below.
+  #   id: {{transformation_id}}          # Required, must match the key exactly.
+  #   command_argv:                      # Required, non-empty list of plain
+  #     - {{argv_element}}                # strings. No nested lists/dicts,
+  #     - {{argv_element}}                # no booleans, no interpolation.
+  #   applies_to:                        # Required, non-empty list of
+  #     - {{predicate}}                   # OR-matched eligibility predicates:
+  #                                        #   always
+  #                                        #   profile:<profile id>
+  #                                        #   capability:<capability id>
+  #                                        #   evidence_path:<glob>
+  #                                        # Same grammar as scorecard check
+  #                                        # applicability (profile_dispatch.py).
+  #   validation:
+  #     kind: none | json_schema          # Required. `none` takes no other
+  #                                        # keys. `json_schema` requires:
+  #     path: {{repo_relative_path}}      #   file the transformation is
+  #                                        #   expected to produce/modify
+  #     schema: {{inline_json_schema}}    #   parsed content must satisfy this
+  #   allow_scheduled: {{true|false}}     # Required. Whether an unattended
+  #                                        # (scheduled) run may select this
+  #                                        # transformation at all.
+
+  # Example: a formatting transformation with fixed argv, safe to run
+  # unattended because it only rewrites formatting and never touches
+  # dependency/lock files or repo configuration.
+  format-python:
+    id: format-python
+    command_argv:
+      - ruff
+      - format
+      - .
+    applies_to:
+      - profile:python
+    validation:
+      kind: none
+    allow_scheduled: true
+
+  # Example: a dependency-lock refresh. Applies only to repos carrying a
+  # capability signal (surfaced by their profile/scorecard evidence), and
+  # its result is checked against a JSON Schema before it can be proposed
+  # as a mutation. Not allowed to run unattended — a human reviews the
+  # lockfile diff before it can proceed.
+  refresh-node-lockfile:
+    id: refresh-node-lockfile
+    command_argv:
+      - npm
+      - install
+      - --package-lock-only
+    applies_to:
+      - profile:nodejs
+      - capability:npm
+    validation:
+      kind: json_schema
+      path: package-lock.json
+      schema:
+        type: object
+        required: [lockfileVersion]
+    allow_scheduled: false
+
+  # Example: a documentation-only transformation, scoped by evidence path
+  # rather than profile — applies to any repo that actually carries a
+  # mkdocs config, regardless of its assigned profile.
+  regenerate-docs-index:
+    id: regenerate-docs-index
+    command_argv:
+      - mkdocs
+      - build
+      - --site-dir
+      - .generated/docs
+    applies_to:
+      - evidence_path:mkdocs.yml
+    validation:
+      kind: none
+    allow_scheduled: true


### PR DESCRIPTION
Stacked on #129 (F5) — retarget to `develop` once #129 merges.

Routes repository-file mutations through Nave pen workspaces with freshness, cleanliness, validation, attribution, and mutation-policy gates. Propose-only by default: no commit or push ever happens without an explicit later apply path.

## What's in here

- **Nave adapter pen operations** (`nave_adapter.py`): `pen_create` / `pen_show` / `pen_status` / `pen_exec` with fixtures faithful to the real Nave CLI serde (create has no `--json`; show/status do; exec is opaque with argv after `--`).
- **Mutation proposal + transformation registry** (`mutation_plan.py`, `lib/patterns/repository-mutations.md`, `templates/transformations.yaml.template`): strict-argv registry — no shell strings, no template substitution; proposals carry `{id, selection, transformation, expected_shas, mutation_policy, actor}`.
- **Pen execution state machine** (`pen_orchestrator.py`): `planned -> created -> executed -> validated -> proposed | blocked | failed`, fail-closed throughout. Stale/dirty pens block; `request_push` or any policy other than `propose` blocks before a single Nave call; aggregate exec failure marks all repos failed (Nave exposes no per-repo blame). Two injectable seams — `read_repo_head` (expected-SHA stale-base guard, blocks before exec on mismatch or missing coverage) and `read_repo_file` (minimal structural JSON-schema output validation) — because Nave's pen JSON exposes neither SHAs nor workspace paths.
- **Result contract + routing** (`validate_result.py` kind `repo-mutation`, `headless-contract.md`, `gh-operations` SKILL routing): repository-file mutations route to the pen orchestrator; GitHub-object mutations stay on the existing gh flow.
- **End-to-end acceptance** (`test_pen_acceptance.py`): real registry template through the public API; two-repo propose-only run (one changes, one no-ops) with no push flags ever issued, validated result document, exact attribution, idempotent repeat; stale-SHA block before exec.

## Review

Per-task spec+quality reviews passed on Tasks 1–4; final whole-branch Opus review: Ready to merge YES, with its two recommended fixes (expected-SHA coverage fail-open, normative-doc drift) plus minor hardening landed in b3ef483.

**Tests:** 570 passed (baseline 453 on F5 head). `git diff --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)