### PR TITLE
docs: flesh out F7–F9 plans, retire per-task subagent execution

### DIFF
--- a/docs/superpowers/plans/2026-07-13-f4-dependency-adapters.md
+++ b/docs/superpowers/plans/2026-07-13-f4-dependency-adapters.md
@@ -1,6 +1,10 @@
 # F4: Dependency Coherence Adapter Family Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Execution mode (revised 2026-07-19):** execute directly in a single session on the
+> main thread — no per-task subagents, no per-task reviewers. TDD per task, one commit
+> per task, one adversarial whole-branch review at the end of the phase, then PR.
+> **Status note:** F4 is NOT merged (develop's latest is PR #128 "Pre-F4"); this plan is
+> still outstanding and should be sequenced after F9 or on user request.
 
 **Goal:** Detect repository-local manifest/lock inconsistency and policy-scoped fleet version divergence through explicit Python and Node adapters while reporting unsupported ecosystems and evidence gaps as coverage debt.
 

--- a/docs/superpowers/plans/2026-07-13-f7-binding-specializations.md
+++ b/docs/superpowers/plans/2026-07-13-f7-binding-specializations.md
@@ -1,21 +1,36 @@
 # F7: Generated Artifact and Contract Binding Specializations Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Execution mode (revised 2026-07-19):** execute directly in a single session on the
+> main thread — no per-task subagents, no per-task reviewers. TDD per task, one commit
+> per task, one adversarial whole-branch review at the end of the phase, then PR.
+> Stacked branch `feat/f7-binding-specializations` off the F6 head. The
+> subagent-per-task pattern used for F1–F6 spent most of its tokens on cold-start
+> context re-derivation and is retired.
 
 **Goal:** Add generic generated-artifact drift and contract-version propagation as adapter-driven specializations of the shared binding and Nave mutation infrastructure.
 
-**Architecture:** `.generated.yaml` records content-addressed template trees and generated-file bases. Generator adapters declare commands and outputs; F6 pens execute them. Contract edges extend F5 impact edges with explicit producer/consumer version parsers. Claude/corpus examples are deferred to F9 overlays.
+**Architecture:** `generated.yaml` (workspace config repo, template `templates/generated.yaml.template`) records content-addressed template trees and generated-file blob bases. Generator adapters declare source/output paths and reference a registered F6 transformation; F6 pens execute them. Contract edges extend F5 impact edges with explicit producer/consumer version parsers. Claude/corpus examples are deferred to F9 overlays.
 
-**Tech Stack:** Python 3.10+, PyYAML, `packaging`, pytest, git, Nave pens.
+**Tech Stack:** Python 3.10+, PyYAML, `packaging` (+ `tomli; python_version<'3.11'` — declare in the PEP 723 header; `tomllib` is stdlib only from 3.11), pytest, git, Nave pens.
+
+## What already exists (verified 2026-07-19, F6 head)
+
+- `lib/pulse/scripts/impact.py` — `_glob_to_regex` (where `*` never crosses `/`, `**` does), `audit(relationships, snapshot) -> ImpactReport`, `mark(...)` with `_atomic_write_yaml` temp+rename CAS marker patch, `propose_marks`/`apply_proposals`. Reuse these idioms verbatim.
+- `lib/pulse/scripts/impact_snapshot.py` — `default_runner` seam, `_valid_sha`/`_valid_branch` argv guards, `_resolve_fetched_head` (FETCH_HEAD is always the diff endpoint). Import `default_runner` from here; do not write a second runner.
+- `lib/pulse/scripts/mutation_plan.py` — `load_registry`, `build_proposal(id, selection, transformation, expected_shas, actor, mutation_policy)` (requires exact `expected_shas` coverage of `selection`), `resolve_argv` (byte-verbatim, no interpolation), `ValidationSpec` kinds `{none, json_schema}`.
+- `lib/pulse/scripts/pen_orchestrator.py` — `execute(plan, nave_adapter, *, read_repo_file=None, read_repo_head=None)`, propose-only, fail-closed; blocks on missing SHA coverage.
+- `lib/pulse/scripts/profile_dispatch.py` — `_is_applicable` grammar: `always`, `profile:<id>`, `capability:<id>`, `evidence_path:<glob>` (fnmatchcase). Generators reuse this grammar for `applies_to`.
+- `lib/pulse/scripts/validate_result.py` — kind-dispatched `validate(data, kind)`; common envelope (`contract_version`, `kind`, `workspace`, `run_at`, `actor`, `errors`) validated for every kind; no exact-top-level-key enforcement inside this file (deliberate — match siblings).
+- Content-addressing primitive: `git rev-parse <sha>:<dir>` yields the **tree object SHA** for a directory at a commit; `git rev-parse <sha>:<file>` yields the **blob SHA**. These are the template-tree and file-base hashes — no bespoke hashing.
 
 ## Global Constraints
 
 - Generated drift uses source directory tree hashes, never repository HEAD alone.
 - Generated files record blob bases; both-sides-changed is a conflict.
-- Generator identity, argv, source paths, output paths, and validation are explicit configuration.
+- Generator identity, source paths, output paths, and validation are explicit configuration; the executed argv lives **only** in the F6 transformation registry (the generator references a `transformation:` id — one argv source, no duplication; this refines the roadmap's `command_argv` field into a registry reference).
 - No LLM may infer or execute a generator.
 - Contract versions come from explicit files/parsers; prose inference is forbidden.
-- All repository-file application routes through F6.
+- All repository-file application routes through F6 (`build_proposal` → `pen_orchestrator.execute`).
 
 ---
 
@@ -28,12 +43,12 @@
 - Modify: `lib/pulse/scripts/tests/test_validate_result.py`
 
 **Interfaces:**
-- Binding: `{id, source, branch, template_path, template_tree, generator, files, generated_at}`.
-- File: `{path, blob}`.
-- Result kind `generated-artifact`.
+- Manifest binding: `{id, source (owner/repo), branch, template_path, template_tree (tree SHA), generator (generator id), files: [{path, blob}], generated_at (ISO)}`. `files[].path` are repo-relative output paths; duplicate paths across one binding are invalid; a binding with empty `files` is invalid (nothing to guard).
+- Result kind `generated-artifact`: envelope + `bindings_audited (int)`, `states (mapping binding id -> current|template-drift|local-customization|conflict|error)`, `findings (list, same finding shape as impact kind: {kind, repo, severity, detail})`, `proposals (list of {binding, transformation, proposal_id} — present only for template-drift)`.
 
-- [ ] **Step 1: Add manifest/result tests** for valid, duplicate paths, missing tree/blob, and unknown generator.
-- [ ] **Step 2: Implement schema/validator and docs**.
+**Steps:**
+- [ ] **Step 1: Tests** — valid manifest passes; duplicate `files[].path` fails; missing `template_tree`/`blob` fails; unknown-generator reference is a *load-time* error surfaced by the Task 3 loader (result-kind tests here cover: valid result, each missing/mistyped field, invalid state enum, findings shape). Follow the `repo-mutation` test additions (fixture + parametrized missing-key/wrong-type) added in F6 Task 4 as the template.
+- [ ] **Step 2: Implement** the `generated-artifact` branch in `validate_result.py` (style-match the `impact` and `repo-mutation` branches exactly) and write `generation-manifest.md` + the template with commented examples (mirror `relationships.yaml.template`'s comment-heavy style).
 - [ ] **Step 3: Run tests and commit** with `feat(contract): define generated artifact bindings`.
 
 ---
@@ -44,13 +59,15 @@
 - Create: `lib/pulse/scripts/generated_artifacts.py`
 - Create: `lib/pulse/scripts/tests/test_generated_artifacts.py`
 
-**Interfaces:**
-- `backfill(binding_input) -> ManifestEntry`.
-- `audit(manifest, snapshot) -> GeneratedReport`.
-- `advance(path, binding_id, expected_tree, new_tree, files, generated_at) -> MarkerResult`.
+**Interfaces (all pure; snapshot injected; the only I/O lives in `collect` and `advance`):**
+- `backfill(binding_input, snapshot) -> ManifestEntry` — resolves current tree/blob SHAs for a new binding from the snapshot (first registration records reality as the base).
+- `audit(manifest, snapshot) -> GeneratedReport` — per binding, compare `template_tree` vs snapshot tree and each `files[].blob` vs snapshot blob. Classification (fail-closed): tree same + all blobs same → `current`; tree changed + blobs same → `template-drift` (regeneration proposal warranted); tree same + any blob changed → `local-customization` (finding, **no** proposal); tree changed + any blob changed → `conflict` (finding, no proposal); any output path missing from snapshot → `error` + `missing_output` finding (no proposal); binding's repo/branch absent from snapshot → `error` + `snapshot_gap` finding.
+- `advance(path, binding_id, expected_tree, new_tree, files, generated_at) -> MarkerResult` — CAS marker patch: reject when the on-disk binding's `template_tree != expected_tree` (mirror `impact.mark()`'s guard + `_atomic_write_yaml` temp+rename exactly).
+- Snapshot shape (extends the F5 convention): `{repo: {branch: {head, trees: {path: tree_sha}, blobs: {path: blob_sha}}}}`. Collection: `collect(manifest, workdir=None, runner=default_runner)` in this module, reusing `impact_snapshot.default_runner` and its argv-guard style, and `git rev-parse FETCH_HEAD:<path>` after a single fetch per repo/branch. A path that does not exist at the head resolves to absent (drives `missing_output`), never an exception.
 
-- [ ] **Step 1: Write failing tests** for template-only drift, local-only customization, both-sides conflict, missing output, no-op same tree, guarded update, and repeat idempotence.
-- [ ] **Step 2: Verify red**, implement deterministic classification and atomic marker patch.
+**Steps:**
+- [ ] **Step 1: Write failing tests** for every classification cell above, plus: no-op same-tree audit produces zero findings; `advance` guarded update (stale `expected_tree` rejected, matching one applied); repeat `advance` idempotence; `backfill` of a repo missing from snapshot fails closed.
+- [ ] **Step 2: Verify red, implement.** Keep `audit` free of git calls.
 - [ ] **Step 3: Run tests and commit** with `feat: audit generated artifact currency`.
 
 ---
@@ -64,10 +81,13 @@
 - Create: `lib/pulse/scripts/tests/test_generator_dispatch.py`
 
 **Interfaces:**
-- Generator: `{id, applies_to, command_argv, source_paths, output_paths, validation}`.
+- Generator entry: `{id, applies_to (profile_dispatch grammar), transformation (registered F6 transformation id — the ONLY argv source), source_paths (list of globs), output_paths (list of globs — allowlist), validation (ValidationSpec shape)}`.
+- `load_generators(data, registry) -> dict[str, Generator]` — fail-closed: unknown `transformation` id, empty `output_paths`, or a shell-string `command` key (explicitly rejected with a message pointing at the registry) are load errors.
+- `dispatch(generator, binding, snapshot, actor, mutation_policy="propose") -> Proposal` — builds `mutation_plan.build_proposal` with `selection=[binding.source]`, `expected_shas={binding.source: snapshot head}`, the generator's `transformation`. Output-allowlist enforcement: the binding's `files[].path` must all match `output_paths` globs (share `impact._glob_to_regex` via a helper — do not re-implement glob matching); any path outside the allowlist is a dispatch-time error, no proposal.
 
-- [ ] **Step 1: Test explicit selection**, missing generator, output outside allowlist, shell string rejection, and profile mismatch.
-- [ ] **Step 2: Implement dispatcher producing an F6 mutation proposal**.
+**Steps:**
+- [ ] **Step 1: Tests** — explicit selection happy path; missing generator id; binding output outside allowlist; shell-string rejection; `applies_to` profile mismatch produces no dispatch; the built Proposal round-trips through `pen_orchestrator.execute`'s expected-SHA guard with a matching `read_repo_head` stub.
+- [ ] **Step 2: Implement** dispatcher producing an F6 mutation proposal. Register one neutral example transformation (e.g. `regenerate-from-template`) in `transformations.yaml.template` with `allow_scheduled: false`.
 - [ ] **Step 3: Verify and commit** with `feat: dispatch configured generators through Nave`.
 
 ---
@@ -81,10 +101,15 @@
 - Modify: `lib/pulse/scripts/impact.py`
 
 **Interfaces:**
-- Parsers v1: `regex` with one capture group; `toml` dotted key; `json` JSON pointer; `yaml` dotted key.
-- Consumer constraint uses PEP 440 only when parser declares `version_scheme: pep440`; adapters may later add semver.
+- Edge extension (optional `contract:` block on a `depends_on` object edge):
+  `contract: {producer: {path, parser}, consumer: {path, parser}, version_scheme: pep440}`.
+- Parser spec (v1): `{kind: regex, pattern}` — exactly one capture group, enforced at load; `{kind: toml, key}` — dotted key; `{kind: json, pointer}` — RFC 6901 JSON pointer; `{kind: yaml, key}` — dotted key. Any parse/extract failure → `unknown`, never a guess.
+- `extract(parser_spec, content_bytes) -> str | None` — pure.
+- `evaluate(edge, read_file) -> ContractState` — `read_file(repo, path) -> bytes` is an injectable reader (same seam shape as `pen_orchestrator.read_repo_file`); returns `compatible | gap | unknown` plus extracted versions for attribution. Comparison uses `packaging.specifiers` **only** when `version_scheme: pep440` is declared; no scheme → string equality, documented.
+- Composition with F5: `impact.audit` gains optional `contract_reader=None`; when an edge has a `contract:` block and a reader is supplied, the edge's result row gains `contract_state`; an edge BOTH path-stale and contract-gap yields **one** finding carrying both facts (dedupe test required). Contract block + no reader → `contract_state: unknown` + low-severity `unevaluated_contract` finding (fail-closed convention, mirrors `empty_watch_paths`).
 
-- [ ] **Step 1: Add parser/compatibility tests** for every parser, invalid version, missing path/key, compatible/gap, and dual impact finding de-duplication.
+**Steps:**
+- [ ] **Step 1: Tests** for every parser kind (valid, invalid version, missing path/key/pointer), regex with ≠1 capture group rejected at load, compatible/gap/unknown, dual-finding dedupe, no-reader unknown.
 - [ ] **Step 2: Implement pure extraction and compose with F5**; one edge counts stale once.
 - [ ] **Step 3: Run tests and commit** with `feat: specialize impact edges for contracts`.
 
@@ -98,11 +123,12 @@
 - Modify: `templates/workspace-gitignore.template`
 
 **Interfaces:**
-- Consumes: F7 audit report, configured generator, F6 mutation proposal/result.
-- Produces: `generated-artifact-result.yaml` and conflict/proposal records.
+- Skill phases: SNAPSHOT → AUDIT → CONFLICT/PROPOSE → optional F6 PEN → RECORD, writing `generated-artifact-result.yaml` validated by Task 1's kind. Model on `skills/gh-impact-audit-headless/SKILL.md` (structure, STOP conditions, explicit inputs, `validate_result.py` invocation) — same length band, orchestration-only, `See:` references.
+- Workflow template models on `templates/workflows/impact-audit.yaml`; must pass `workflow_lint.py`.
 
-- [ ] **Step 1: Write skill** SNAPSHOT → AUDIT → CONFLICT/PROPOSE → optional F6 PEN → RECORD.
-- [ ] **Step 2: Assert no references to Claude, corpus, skills, or plugin manifests** in generic files.
+**Steps:**
+- [ ] **Step 1: Write skill + workflow**; add the result file to `workspace-gitignore.template` (transient, like the other `*-result.yaml`).
+- [ ] **Step 2: Neutrality test** — assert the strings `claude`, `corpus`, `plugin manifest`, `SKILL.md` do not appear (case-insensitive) in `generated_artifacts.py`, `generator_dispatch.py`, the new skill, or the new workflow. Overlay specifics belong to F9.
 - [ ] **Step 3: Run full suite and commit** with `feat: add generic generated artifact workflow`.
 
 ---
@@ -115,9 +141,9 @@
 - Modify: `lib/pulse/scripts/tests/test_impact.py`
 
 **Interfaces:**
-- Consumes: F5 object edge and close-loop semantics.
-- Produces: reusable full-tree test-repository relationship overlay; no new workflow/result kind.
+- A reusable relationships overlay: test repo depends on source repo with `watch_paths: ["**"]` (full tree — `**` crosses `/` per `_glob_to_regex`) and a configured `integration_workflow`. No new workflow, no new result kind — this is configuration proving F5 already covers the split-repo case (e.g. `hiivmind-pulse-gh-tests` ← `hiivmind-pulse-gh`).
 
-- [ ] **Step 1: Add full-tree `watch_paths: ["**"]` fixture** and successful configured-workflow marker test.
-- [ ] **Step 2: Document this as configuration, not a new workflow**.
+**Steps:**
+- [ ] **Step 1: Fixture + tests** — full-tree edge goes stale on any upstream path change; successful configured-workflow evidence advances the marker via `propose_marks`/`apply_proposals`.
+- [ ] **Step 2: Document** in `workflow-execution.md` § loop-closure that this is configuration, not a new workflow.
 - [ ] **Step 3: Verify and commit** with `docs: add split repository impact binding`.

--- a/docs/superpowers/plans/2026-07-13-f8-plan-sync.md
+++ b/docs/superpowers/plans/2026-07-13-f8-plan-sync.md
@@ -1,21 +1,33 @@
 # F8: Generic Plan Synchronization Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Execution mode (revised 2026-07-19):** execute directly in a single session on the
+> main thread — no per-task subagents, no per-task reviewers. TDD per task, one commit
+> per task, one adversarial whole-branch review at the end of the phase, then PR.
+> Stacked branch `feat/f8-plan-sync` off the F7 head (F8 needs only F6, but the branch
+> stack is linear).
 
 **Goal:** Reconcile pushed planning-document fields bidirectionally with GitHub issues and milestones using per-field three-way merge bases and separate repository/GitHub mutation paths.
 
 **Architecture:** Artifact-carried frontmatter stores GitHub references, reconciled doc blob, and scalar bases. A pure merge engine produces doc patches, GitHub patches, or conflicts. Doc changes use a single-repo F6 Nave pen; GitHub changes use Pulse mutation policy. V1 excludes Projects custom fields.
 
-**Tech Stack:** Python 3.10+, `ruamel.yaml`, pytest, git, gh CLI, Nave pens.
+**Tech Stack:** Python 3.10+, `ruamel.yaml` (declare in the PEP 723 header — round-trip frontmatter editing; plain PyYAML destroys comments/ordering), pytest, git, gh CLI, Nave pens.
+
+## What already exists (verified 2026-07-19, F6 head)
+
+- F6 mutation path: `mutation_plan.build_proposal` → `pen_orchestrator.execute` (propose-only, `expected_shas` guard via `read_repo_head`, output validation via `read_repo_file`). Registry: `templates/transformations.yaml.template`.
+- `lib/pulse/scripts/poll.py` — per-source check functions with a `gh_api` seam; `branch_heads` (F5) is the model for a new trigger-only source.
+- `lib/pulse/scripts/impact_snapshot.py` — `default_runner`, argv guards, fetch-then-`FETCH_HEAD` discipline. Reuse for all git reads here.
+- `lib/pulse/scripts/validate_result.py` — kind-dispatch + common envelope; F6's `repo-mutation` branch is the freshest style model.
+- GitHub issue/milestone read/write syntax: `lib/references/domains/issues.md`, `milestones.md`; headless mutation policy vocabulary: `lib/patterns/workflow-execution.md` (`on_mutation`), proposal shapes in `lib/patterns/headless-contract.md`.
 
 ## Global Constraints
 
-- No environment is primary.
-- V1 fields: title, open/closed status, assignees, milestone, issue body.
-- Both-sides change conflicts unless explicit per-field policy resolves it.
-- Body base is retrieved by reconciled blob from pushed git history.
-- Local dirty/unpushed state is reported and excluded.
-- Doc changes use F6; GitHub changes use Pulse operations.
+- No environment is primary — the doc and GitHub are peers; the frontmatter base is the only arbiter.
+- V1 fields: `title`, open/closed `state`, `assignees`, `milestone`, issue `body`. Projects custom fields are explicitly out of scope (document in the pattern).
+- Both-sides-changed conflicts unless an explicit per-field policy (`prefer-doc` | `prefer-github`) resolves it; default policy for every field is `conflict`.
+- Body base is retrieved by reconciled blob SHA from pushed git history (`git cat-file blob <sha>`), never from a working tree.
+- Local dirty/unpushed doc state is reported (`excluded` + finding) and excluded from reconciliation — never merged.
+- Doc changes route through F6; GitHub changes route through Pulse operations under mutation policy. Neither path applies anything in `propose` mode.
 - Bases advance only after both sides confirm application.
 
 ---
@@ -29,10 +41,24 @@
 - Modify: `lib/patterns/headless-contract.md`
 
 **Interfaces:**
-- Produces: artifact-carried `sync` frontmatter and result kind `plan-sync`.
+- Artifact-carried frontmatter block (inside the doc's YAML frontmatter):
+  ```yaml
+  sync:
+    issue: {repo: owner/name, number: 42}
+    policy: {title: conflict, state: conflict, assignees: conflict, milestone: conflict, body: conflict}
+    base:
+      blob: <git blob SHA of the doc at last reconciliation>
+      title: "..."
+      state: open            # open | closed
+      assignees: [a, b]      # sorted, deduped
+      milestone: "v2.0"      # milestone title or null
+  ```
+  `policy` values: `conflict` (default) | `prefer-doc` | `prefer-github`. Unknown fields under `sync:` are a validation error; unknown frontmatter *outside* `sync:` is preserved untouched (Task 2's parser guarantees it).
+- Result kind `plan-sync`: envelope + `docs_scanned`, `in_sync`, `doc_patches`, `github_patches`, `conflicts`, `excluded` (all ints, required), `findings` (impact-style finding list; kinds include `dirty_doc`, `local_ahead`, `rename_detected`, `base_conflict`).
 
-- [ ] **Step 1: Add result/frontmatter tests** for issue ref, last synced blob/base, policy enum, and required counts.
-- [ ] **Step 2: Implement contract and document V1 exclusions**.
+**Steps:**
+- [ ] **Step 1: Tests** — valid result; each count missing/mistyped; frontmatter fixture valid/invalid (bad policy enum, missing base.blob, unknown sync key); style-match the F6 `repo-mutation` test block.
+- [ ] **Step 2: Implement** the kind branch + `plan-sync-binding.md` documenting the block, V1 field list, and the explicit V1 exclusions (Projects fields, labels, comments).
 - [ ] **Step 3: Run tests and commit** with `feat(contract): define plan sync bindings`.
 
 ---
@@ -44,11 +70,12 @@
 - Create: `lib/pulse/scripts/tests/test_plan_sync.py`
 
 **Interfaces:**
-- `parse_document(text) -> BoundDocument`.
-- `patch_document(text, doc_patch, sync_patch) -> str`.
+- `parse_document(text) -> BoundDocument` — splits frontmatter (`---` fences) from body; frontmatter parsed with `ruamel.yaml` round-trip mode; body kept as the exact byte string (including trailing newline style); `title` binding = first `# H1` line in the body. A doc with no `sync:` block parses fine with `binding=None` (not an error — unbound docs are simply not synced).
+- `patch_document(text, doc_patch, sync_patch) -> str` — applies field changes (title → H1 line, body → body replacement) and `sync:` base updates; **no-op patches must return byte-identical input** (the core lossless guarantee).
 
-- [ ] **Step 1: Write round-trip tests** preserving comments, unknown frontmatter, body bytes, newline style, and no-op byte identity.
-- [ ] **Step 2: Verify red**, implement ruamel round-trip parsing and first-H1 title binding.
+**Steps:**
+- [ ] **Step 1: Round-trip tests** — comments in frontmatter preserved; unknown frontmatter keys preserved; body bytes untouched; CRLF vs LF preserved; `patch_document(text, {}, {})` is byte-identical; H1 retitle touches only the H1 line.
+- [ ] **Step 2: Verify red, implement** with ruamel round-trip parsing.
 - [ ] **Step 3: Run tests and commit** with `feat: parse bound plan documents losslessly`.
 
 ---
@@ -60,11 +87,12 @@
 - Modify: `lib/pulse/scripts/tests/test_plan_sync.py`
 
 **Interfaces:**
-- `merge_field(field, base, doc, github, policy=None) -> FieldDecision`.
-- `compute(doc, github, binding, base_body) -> ReconciliationPlan`.
+- `merge_field(field, base, doc, github, policy=None) -> FieldDecision` — decisions: `noop` (neither changed), `apply_to_github` (doc-only change), `apply_to_doc` (GitHub-only change), `agree` (both changed to the same value → base advance only), `conflict` (both changed, differing, no policy), or policy-resolved apply. Normalization before comparison: assignees sorted+deduped; milestone `None` ≡ absent; title/body compared exactly (no whitespace forgiveness — a byte change is a change).
+- `compute(doc, github, binding, base_body) -> ReconciliationPlan` — per-field decisions over the V1 field set; aggregates into `{doc_patch, github_patch, base_patch, conflicts}`. Fields are independent: a conflict on `title` does not block an `assignees` apply, but ANY conflict marks the doc `conflicted` in the result and withholds the **base** advance for the conflicted field only.
 
-- [ ] **Step 1: Add full merge matrix tests**: neither, doc-only, GitHub-only, both-same, conflict, prefer-doc, prefer-github, independent fields.
-- [ ] **Step 2: Implement exact delta logic**, normalize assignee ordering and null milestone.
+**Steps:**
+- [ ] **Step 1: Full matrix tests** — for each field: neither/doc-only/github-only/both-same/both-differ(conflict)/prefer-doc/prefer-github; plus independence (conflict on one field, apply on another) and normalization (assignee order, null milestone).
+- [ ] **Step 2: Implement exact delta logic** as pure functions — no I/O in this task.
 - [ ] **Step 3: Verify and commit** with `feat: compute bidirectional plan reconciliation`.
 
 ---
@@ -78,11 +106,12 @@
 - Modify: `lib/pulse/scripts/tests/test_poll.py`
 
 **Interfaces:**
-- Consumes: pushed document refs, binding frontmatter, issue/milestone API state.
-- Produces: normalized doc/GitHub snapshots plus `docs` poll trigger state.
+- `collect(bindings, workdir=None, runner=default_runner, gh_api=None) -> SyncSnapshot` — per bound doc: fetch the repo's branch, resolve the doc's blob at `FETCH_HEAD` (`git rev-parse FETCH_HEAD:<path>`), fetch body-base blob content by SHA (`git cat-file blob <base.blob>` — from pushed history only); detect rename via `git log --follow --format=%H --name-only` when the path is absent at head (emit `rename_detected` finding with the new path, do not silently follow); detect dirty/local-ahead only when `workdir` points at a local checkout (report + exclude, never read the working tree as sync input). GitHub side via the injected `gh_api`: issue title/state/assignees/milestone + milestone catalog, normalized to the merge engine's shapes (assignees sorted, milestone by title, `null` normalized).
+- `poll.py` gains a `docs` trigger source: pushed head of each bound doc's repo/branch, mirroring `branch_heads` exactly (trigger-only — poll never diffs content; it reports "head moved since last poll" so the workflow wakes).
 
-- [ ] **Step 1: Add tests** for same blob across unrelated commits, changed blob, rename via `git log --follow`, dirty/local-ahead nudge, issue/milestone normalization, and `docs` trigger source.
-- [ ] **Step 2: Implement snapshot from pushed refs**. Nave evidence may locate files but historical blob lookup uses git.
+**Steps:**
+- [ ] **Step 1: Tests** — same blob across unrelated commits → `in_sync` short-circuit; changed blob detected; rename via `--follow` emits finding; dirty/local-ahead exclusion + nudge finding; issue/milestone normalization (unsorted assignees, missing milestone); `docs` poll source state round-trip in `test_poll.py` (mirror the `branch_heads` tests).
+- [ ] **Step 2: Implement** — git via runner seam only, GitHub via `gh_api` seam only; every subprocess argv guarded (`_valid_sha`/`_valid_branch` style, `--` separators).
 - [ ] **Step 3: Verify and commit** with `feat: snapshot pushed plan and GitHub state`.
 
 ---
@@ -93,14 +122,17 @@
 - Modify: `lib/pulse/scripts/plan_sync.py`
 - Modify: `lib/pulse/scripts/tests/test_plan_sync.py`
 - Modify: `templates/transformations.yaml.template`
+- Create: `lib/pulse/scripts/apply_doc_patch.py`
 
 **Interfaces:**
-- Consumes: `ReconciliationPlan` and expected document blob.
-- Produces: separate F6 `repo_mutation` and Pulse `github_mutation` proposals plus guarded finalize data.
+- Register transformation `plan-sync-doc-patch`: fixed argv `["uv", "run", "<script>", "--patch", ".hiivmind/plan-sync-patch.yaml"]` executing `apply_doc_patch.py` — a tiny PEP 723 script that reads the patch file from that well-known repo-relative path (written into the pen checkout by the caller before exec; F6 forbids argv templating, so the variable content travels via the file, not the command), applies it with `patch_document`, and exits non-zero on any mismatch (missing doc, base-blob mismatch embedded in the patch). `validation` on the entry checks the patch file's declared output path was modified; output allowlist is the bound doc path. `allow_scheduled: false` in the template.
+- `build_apply_plans(reconciliation, binding, snapshot, actor) -> ApplyPlans` — produces up to two proposals: a `repo_mutation` (F6 `Proposal` via `build_proposal`, `selection=[doc repo]`, `expected_shas={repo: pushed head}`) for the doc patch, and a `github_mutation` proposal (shaped like `workflow-run` `proposed_actions` in `headless-contract.md`) for the GitHub patch. Never a combined one — the two paths fail independently.
+- `finalize(reconciliation, doc_applied: bool, github_applied: bool) -> FinalizeDecision` — base advances (per field) only for values BOTH sides confirmed; partial application leaves the un-applied side's base untouched and emits a `partial_application` finding.
 
-- [ ] **Step 1: Add expected-blob and partial-application tests**.
-- [ ] **Step 2: Register `plan-sync-doc-patch` transformation** using a fixed argv tool and output allowlist.
-- [ ] **Step 3: Produce separate `repo_mutation` and `github_mutation` proposals**; finalize only confirmed common values.
+**Steps:**
+- [ ] **Step 1: Tests** — expected-blob mismatch blocks the doc proposal (round-trip the built Proposal through `pen_orchestrator.execute`'s guard with a stub); partial application (doc ok, GitHub failed and vice versa) advances only confirmed bases; `apply_doc_patch.py` exit codes (happy, missing doc, base mismatch).
+- [ ] **Step 2: Register the transformation**; keep `apply_doc_patch.py` dependency-light (ruamel + stdlib).
+- [ ] **Step 3: Produce separate proposals; finalize only confirmed values.**
 - [ ] **Step 4: Verify and commit** with `feat: apply plan reconciliation through safe mutation paths`.
 
 ---
@@ -111,11 +143,12 @@
 - Create: `skills/gh-plan-sync-headless/SKILL.md`
 - Create: `templates/workflows/plan-sync.yaml`
 - Create: `lib/pulse/scripts/tests/test_plan_sync_acceptance.py`
+- Modify: `templates/workspace-gitignore.template`
 
 **Interfaces:**
-- Consumes: F8 snapshots/merge plan and F6/Pulse mutation results.
-- Produces: validated `plan-sync-result.yaml` and idempotent finalized binding markers.
+- Skill phases: DISCOVER (bound docs from config) → SNAPSHOT → COMPUTE → APPLY_GITHUB / APPLY_DOC (policy-gated; in `propose` both become proposed actions) → FINALIZE → RECORD (`plan-sync-result.yaml`, validated). Model on `gh-impact-audit-headless` structure; workflow must pass `workflow_lint.py`.
 
-- [ ] **Step 1: Write skill** DISCOVER → SNAPSHOT → COMPUTE → APPLY_GITHUB/APPLY_DOC → FINALIZE → RECORD.
-- [ ] **Step 2: Add acceptance cases** for all merge outcomes, rename, local-ahead, concurrent base conflict, and repeat idempotence.
+**Steps:**
+- [ ] **Step 1: Write skill + workflow**; gitignore the result file.
+- [ ] **Step 2: Acceptance cases** (fixture-driven, no network — compose the real public functions like F6's `test_pen_acceptance.py`): every merge outcome lands in the right count bucket; rename; local-ahead exclusion; concurrent base conflict (base advanced remotely between snapshot and apply → blocked by expected-blob guard); repeat run after full sync is a no-op with identical result counts.
 - [ ] **Step 3: Run full suite and commit** with `feat: add generic plan synchronization`.

--- a/docs/superpowers/plans/2026-07-13-f9-dogfood-overlays.md
+++ b/docs/superpowers/plans/2026-07-13-f9-dogfood-overlays.md
@@ -1,19 +1,30 @@
 # F9: Hiivmind and Claude Dogfood Overlays Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Execution mode (revised 2026-07-19):** execute directly in a single session on the
+> main thread — no per-task subagents, no per-task reviewers. TDD per task, one commit
+> per task, one adversarial whole-branch review at the end of the phase, then PR.
+> Stacked branch `feat/f9-dogfood-overlays` off the F8 head.
 
 **Goal:** Add marketplace, Claude context, plugin layout, and corpus generated-skill behavior as explicitly enabled profiles and adapters without changing generic fleet semantics.
 
-**Architecture:** `claude-plugin-v1` and hiivmind overlay scorecards extend neutral scorecards with plugin-specific adapters. Marketplace sync is a release-artifact adapter; Claude context currency is `not_applicable` without the capability; corpus regeneration is an F7 generator executed through F6. All overlay fixtures live separately from neutral fleet fixtures.
+**Architecture:** A `claude-plugin-v1` scorecard extends the neutral scorecard set with plugin-specific adapters. Marketplace sync is a release-artifact comparator emitting an F6 mutation proposal; Claude context currency is `not_applicable` without the capability; corpus regeneration is one configured F7 generator executed through F6. All overlay fixtures live under `tests/fixtures/overlays/`, separate from neutral fleet fixtures.
 
 **Tech Stack:** Python 3.10+, PyYAML, pytest, gh CLI, F1/F3/F6/F7.
 
+## What already exists (verified 2026-07-19, F6 head)
+
+- `lib/pulse/scripts/profile_dispatch.py` — `load_profiles`, `resolve_scorecard`, `dispatch(repo, evidence, config) -> DispatchPlan`; applicability grammar `always | profile:<id> | capability:<id> | evidence_path:<glob>`.
+- `lib/pulse/scripts/adapters/` — `generic.py` (adapters take `CheckContext`, return dicts folded into `CheckBlock` with evidence citations); explicit registration in `adapters/__init__.py::register_universal_adapters(registry)`. New overlay adapters follow this exact registration pattern — a separate `register_claude_adapters(registry)` entry point, called only when the overlay is enabled.
+- `templates/profiles.yaml.template` — `scorecards:` with per-check `{id, adapter, applicability, weight}`; `proposal_rules:` already contains `claude-plugin-layout` (profile `claude-plugin`, `all_paths: [.claude-plugin/plugin.json, "skills/*/SKILL.md"]`) — Task 1 gives that profile its scorecard.
+- `lib/pulse/scripts/check_adapters.py` — `AdapterRegistry.evaluate` wraps adapter output into `CheckBlock`; `status` vocabulary includes `not_applicable`.
+- F6: `mutation_plan.build_proposal` / `pen_orchestrator.execute`; F7 (once landed): `generators.yaml.template` + `generator_dispatch.dispatch`, `generated_artifacts.audit`.
+
 ## Global Constraints
 
-- No overlay runs without an explicit profile/capability.
-- Missing `CLAUDE.md` is fail only when the selected scorecard requires Claude context; otherwise no check is dispatched.
-- Marketplace sync applies only to repositories with configured marketplace binding.
-- Generated-skill regeneration is one configured generator, not the generic F7 default.
+- No overlay runs without an explicit profile/capability — nothing in the neutral path may import an overlay module.
+- Missing `CLAUDE.md` fails only when the selected scorecard requires Claude context; otherwise no Claude check block is dispatched at all (not even `not_applicable` noise on non-Claude repos — the dispatch filter handles it).
+- Marketplace sync applies only to repositories with a configured marketplace binding.
+- Generated-skill regeneration is one configured F7 generator, not a generic default.
 - Overlay scores identify their scorecard and are never merged into a neutral scorecard denominator.
 
 ---
@@ -23,15 +34,22 @@
 **Files:**
 - Modify: `templates/profiles.yaml.template`
 - Create: `lib/pulse/scripts/adapters/claude_plugin.py`
+- Modify: `lib/pulse/scripts/adapters/__init__.py`
 - Create: `lib/pulse/scripts/tests/test_claude_plugin_adapter.py`
 - Create: `lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/`
 
 **Interfaces:**
-- Adapters: `claude.plugin_manifest`, `claude.skills`, `claude.context`.
+- Adapters (each `(context: CheckContext) -> dict`, registered via a new `register_claude_adapters(registry)`):
+  - `claude.plugin_manifest` — `.claude-plugin/plugin.json` exists, parses, has `name` + `version`; malformed JSON → fail with cited evidence path.
+  - `claude.skills` — every `skills/*/SKILL.md` has frontmatter with `name` + `description`; malformed frontmatter → fail citing the file; no skills dir on a plugin repo → fail (a plugin claims skills by layout).
+  - `claude.context` — `CLAUDE.md` present and its inventory claims current (delegates detail to Task 3; in Task 1 it checks presence only, returns `not_applicable` when the scorecard doesn't require it).
+- Scorecard `claude-plugin-v1` in the template: extends the generic checks (documentation, ci, license…) plus the three adapters above with `applicability: profile:claude-plugin`.
+- Evidence source: the same evidence snapshot shape `dispatch` already consumes (file lists + file content via `CheckContext`); fixtures provide it — no live git/gh in tests.
 
-- [ ] **Step 1: Add fixtures/tests** for valid plugin, missing manifest, malformed skill frontmatter, stale CLAUDE inventory, and normal Python repo without any Claude files.
-- [ ] **Step 2: Verify red**, implement adapters with cited evidence.
-- [ ] **Step 3: Assert normal Python repo receives no Claude check blocks**.
+**Steps:**
+- [ ] **Step 1: Fixtures/tests** — valid plugin; missing manifest; malformed skill frontmatter; stale CLAUDE inventory (Task 3 wires the real check; here a placeholder fixture); plain Python repo.
+- [ ] **Step 2: Verify red, implement** adapters with cited evidence (match `generic.py`'s `_result`/citation idioms).
+- [ ] **Step 3: Isolation assertion** — dispatch a plain Python repo (profile `python`) against the full config: the DispatchPlan contains zero `claude.*` checks.
 - [ ] **Step 4: Run tests and commit** with `feat: add explicit Claude plugin scorecard`.
 
 ---
@@ -43,14 +61,17 @@
 - Create: `lib/pulse/scripts/tests/test_marketplace_sync.py`
 - Create: `skills/gh-marketplace-sync-headless/SKILL.md`
 - Create: `templates/workflows/marketplace-sync.yaml`
+- Modify: `templates/transformations.yaml.template`
 
 **Interfaces:**
-- Binding: `{plugin_id, repo, marketplace_repo, marketplace_file}`.
-- Comparator emits guarded one-file F6 mutation proposal.
+- Binding (workspace config): `{plugin_id, repo (owner/name), marketplace_repo, marketplace_file}`.
+- `compare(binding, releases, marketplace_doc) -> MarketplaceDrift` — pure. `releases` is the plugin repo's release list (gh shapes, fixture-driven); the newest **stable** release (exclude `prerelease: true` and `draft: true`) is compared to the version recorded for `plugin_id` in `marketplace_doc` (parsed YAML/JSON of `marketplace_file`). Outcomes: `in_sync`, `drift` (+ F6 proposal), `missing_entry` (plugin absent from the file → drift with an add), `not_applicable` (no binding for the repo), `unknown` (no stable release / unparseable file — fail closed, no proposal).
+- Drift proposal: `build_proposal` with `selection=[marketplace_repo]`, `expected_shas={marketplace_repo: current head}` (expected-base conflict → blocked by F6's guard — test it), transformation `marketplace-entry-update` registered with fixed argv + patch-file convention (same pattern as F8's `plan-sync-doc-patch`; if F8 hasn't landed yet, this task establishes the pattern), output allowlist `[marketplace_file]`, `allow_scheduled: false`.
 
-- [ ] **Step 1: Write tests** for stable release drift, prerelease/draft exclusion, missing binding not-applicable, missing entry, expected-base conflict, and no-op.
-- [ ] **Step 2: Implement pure comparator and F6 proposal**.
-- [ ] **Step 3: Write profile-gated skill/workflow**.
+**Steps:**
+- [ ] **Step 1: Tests** — stable release drift; prerelease/draft excluded; missing binding → `not_applicable`; missing entry; expected-base conflict blocks; no-op.
+- [ ] **Step 2: Implement pure comparator + proposal builder.**
+- [ ] **Step 3: Profile-gated skill/workflow** (`applies_to: profile:claude-plugin` or explicit binding presence; workflow passes `workflow_lint.py`).
 - [ ] **Step 4: Run tests and commit** with `feat: add profile-gated marketplace sync`.
 
 ---
@@ -63,11 +84,14 @@
 - Modify: `lib/pulse/scripts/adapters/claude_plugin.py`
 
 **Interfaces:**
-- Facts include configured claims only: skill paths, plugin files, declared commands.
-- Inference output is validated and always `inferred: true`.
+- `facts(evidence) -> RepoFacts` — deterministic, from **configured claims only**: skill paths that exist, plugin manifest fields, declared commands (`commands/*.md`). No inference here.
+- `check_claims(claude_md_text, facts) -> list[ClaimFinding]` — verifies CLAUDE.md's checkable claims against facts: a referenced skill path that doesn't exist → `missing_claimed_skill`; a documented command absent from `commands/` → `stale_command`; a claim referencing an evidence kind the checker doesn't support → `unsupported_evidence` (surfaced, never guessed at).
+- Inference (extracting claims from CLAUDE.md prose) is the one non-deterministic step: its output is validated against the same `ClaimFinding` schema and every finding it produces carries `inferred: true`; a validation failure of inferred output → adapter status `unknown`, never a fabricated pass/fail.
+- `claude.context` adapter wiring: scorecard `applicability` decides requiredness — under `profile:claude-plugin` a missing `CLAUDE.md` fails; under an optional capability it's `not_applicable`.
 
-- [ ] **Step 1: Add tests** for missing claimed skill, stale command, unsupported evidence reference, missing CLAUDE under required/optional profiles, and inference failure unknown.
-- [ ] **Step 2: Implement deterministic facts and inference validator**.
+**Steps:**
+- [ ] **Step 1: Tests** — missing claimed skill; stale command; unsupported evidence reference; missing CLAUDE.md under required vs optional applicability; inference-validation failure → `unknown`.
+- [ ] **Step 2: Implement deterministic facts + inference validator.**
 - [ ] **Step 3: Run tests and commit** with `feat: audit opt-in Claude context currency`.
 
 ---
@@ -81,12 +105,12 @@
 - Create: `lib/pulse/scripts/tests/test_corpus_generator_overlay.py`
 
 **Interfaces:**
-- Consumes: F7 generator schema and F6 transformation registry.
-- Produces: explicit `hiivmind.corpus-navigate-skill` generator overlay and isolated fixtures.
+- Generator overlay entry `hiivmind.corpus-navigate-skill`: `applies_to: profile:claude-plugin` (or a dedicated `capability:corpus`), explicit `source_paths` (corpus template tree), `output_paths` (the generated navigate SKILL.md), `transformation` referencing a registered fixed-argv entry, `validation: {kind: json_schema | none}` per F7's spec. This is **configuration of F7 machinery** — zero new engine code; the test proves the F7 generic path handles it.
 
-- [ ] **Step 1: Define explicit generator** with source template path, fixed argv, output paths, and skill validation.
-- [ ] **Step 2: Test F7 audit + F6 proposal**, including local customization conflict.
-- [ ] **Step 3: Assert the generic generated-artifact workflow contains no corpus-specific branch**.
+**Steps:**
+- [ ] **Step 1: Define the generator** in the template with source template path, fixed argv (via its transformation), output paths, and skill validation.
+- [ ] **Step 2: Tests** — F7 `audit` classifies corpus fixture drift correctly (template-drift → proposal; local customization → conflict, no proposal); `generator_dispatch.dispatch` builds a valid F6 proposal for it.
+- [ ] **Step 3: Neutrality assertion** — the generic generated-artifact workflow/skill files contain no corpus-specific branch (extend F7 Task 5's neutrality test to cover the overlay id).
 - [ ] **Step 4: Run tests and commit** with `feat: configure corpus skill generation overlay`.
 
 ---
@@ -96,14 +120,15 @@
 **Files:**
 - Modify: `skills/gh-healthcheck-headless/SKILL.md`
 - Modify: `README.md`
-- Modify: `SKILL.md`
+- Modify: `SKILL.md` (root, if present — else the healthcheck skill only)
 - Create: `lib/pulse/scripts/tests/test_dogfood_isolation.py`
 
 **Interfaces:**
-- Consumes: F3 scorecard-grouped healthcheck output and all F9 adapters.
-- Produces: separate overlay subtotals and regression proof that generic fleet behavior is overlay-independent.
+- Report grouping: healthcheck output groups by `scorecard`; overlay scorecards (`claude-plugin-v1`) get their own subtotal block, never merged into a neutral scorecard's denominator (the F3 scorecard-grouped output already keeps grades scorecard-specific — this task adds the explicit `overlay: true` marking and subtotals in the skill's REPORT phase).
+- Isolation proof: neutral behavior must be provably overlay-independent.
 
-- [ ] **Step 1: Add isolation test** proving removal of all overlay fixtures/adapters leaves neutral acceptance suite passing.
-- [ ] **Step 2: Add report grouping** by `scorecard` and `overlay`; dogfood findings remain visible but separately subtotaled.
+**Steps:**
+- [ ] **Step 1: Isolation test** — two assertions: (a) no neutral module (`profile_dispatch`, `check_adapters`, `adapters/generic.py`, `evaluate_checks.py`, `generated_artifacts.py`, `generator_dispatch.py`) imports `adapters.claude_plugin`, `marketplace_sync`, or `repo_claims` (walk the import graph via `ast`); (b) running the neutral acceptance tests with the overlay fixture directories absent (tmp copy minus `fixtures/overlays/`) passes — proving no neutral test depends on overlay fixtures.
+- [ ] **Step 2: Report grouping** in the healthcheck skill: subtotals by `scorecard`, overlay findings visible but separately subtotaled; document the overlay model in README.
 - [ ] **Step 3: Run `uv run pytest -q` and `git diff --check`** → clean.
 - [ ] **Step 4: Commit** with `docs: expose dogfood overlays explicitly`.


### PR DESCRIPTION
Stacked on #130 (F6) — retarget down the stack as PRs merge.

The F7/F8/F9 plans were ~110–125 lines each and thin on interfaces; execution kept paying to re-derive the missing detail. This PR fleshes each out once (~180–200 lines each):

- **Grounding sections** citing the real F5/F6 symbols to reuse (`impact.mark` CAS pattern, `default_runner` seam, `build_proposal` coverage rules, `pen_orchestrator` injectable readers, `_is_applicable` grammar).
- **Exact interfaces per task**: manifest/binding/frontmatter shapes, function signatures, result-kind field lists, classification matrices with every fail-closed cell named.
- **Resolved design decisions** that would otherwise burn execution time: generators reference a registered transformation id (one argv source, no duplication); variable patch content travels via a well-known repo file, not argv templating; `git rev-parse <sha>:<path>` as the content-addressing primitive; overlay isolation via import-graph + fixture-removal proofs; `tomllib`/3.10 and ruamel round-trip gotchas flagged.
- **Execution mode revised** on all four outstanding plans (F4, F7–F9): direct main-thread TDD, one commit per task, single adversarial whole-branch review per phase — the per-task subagent pattern is retired. F4's header also records that it is NOT merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)