### PR TITLE
F7: Generated Artifact & Contract Binding Specializations

### DIFF
--- a/lib/patterns/generation-manifest.md
+++ b/lib/patterns/generation-manifest.md
@@ -1,0 +1,82 @@
+# Pattern: Generation Manifest
+
+Generated artifacts are files in a repository that are produced from a
+committed template source and are guarded against drift. This document defines
+the manifest that records those bindings and the rules the audit engine uses
+to classify them. The companion result kind is `generated-artifact`
+(`lib/patterns/headless-contract.md` § generated-artifact-result.yaml), validated
+by `lib/pulse/scripts/validate_result.py`.
+
+## Binding shape
+
+Each binding is stored in `templates/generated.yaml.template` and loaded by the
+F7 Task 2/3 loaders. A binding is a mapping with these fields:
+
+```text
+{id, source, branch, template_path, template_tree, generator, files, generated_at}
+```
+
+| Field | Shape | Meaning |
+|---|---|---|
+| `id` | non-empty string | Stable binding identifier, unique within the workspace manifest. |
+| `source` | `owner/repo` string | Repository that owns the template source. |
+| `branch` | string | Branch in the source repo where the template is resolved. |
+| `template_path` | string | Repo-relative path to the template file within `source`. |
+| `template_tree` | tree SHA | Git tree SHA of the source repo at the point the files were generated; used to detect template drift. |
+| `generator` | string | Registered generator id that produced the files; unknown ids are a load-time error. |
+| `files` | non-empty list of `{path, blob}` | Output files guarded by this binding. `path` is repo-relative in the target repo; `blob` is the blob SHA at generation time. |
+| `generated_at` | ISO 8601 timestamp | When the files were last generated. |
+
+## Binding validity rules
+
+The following are manifest errors; the loader rejects a binding that violates
+any of them. The result validator does not enforce these — it validates the
+`generated-artifact` result shape, not the committed manifest.
+
+1. **No duplicate `files[].path` within a binding.** A path may appear only once
+   per binding; a duplicate path makes the binding ambiguous.
+2. **No empty `files` list.** A binding with nothing to guard is invalid.
+3. **`template_tree` must be present.** Drift detection needs a known source tree
+   SHA.
+4. **Every `files[].blob` must be present.** Customization detection needs the
+   blob SHA recorded at generation time.
+
+Validity is computed per binding, so one repository may have multiple bindings
+(e.g. one per generator or template source).
+
+## Audit states
+
+For each binding, the audit engine computes one of these states:
+
+| State | Meaning |
+|---|---|
+| `current` | The generated files match the recorded blobs and the source template tree has not changed. |
+| `template-drift` | The source template tree or template path content changed since `generated_at`; the generated files need to be regenerated. |
+| `local-customization` | The target file blobs differ from the recorded blobs but the source template did not change; a local edit was made. |
+| `conflict` | Both template drift and local customization are present; the generated files cannot be safely regenerated without reconciling the local changes. |
+| `error` | The audit could not determine the state (e.g. missing source or target blob, unreachable ref). |
+
+## Findings and proposals
+
+The `generated-artifact` result kind records:
+
+- `bindings_audited`: total number of bindings audited.
+- `states`: mapping from binding id to one of the five states above.
+- `findings`: typed findings with the same shape as the `impact` kind
+  (`{kind, repo, severity, detail}` plus optional `ref` and `inferred`).
+- `proposals`: list of `{binding, transformation, proposal_id}` entries. A
+  proposal is emitted only when a binding is in `template-drift` state, because
+  only template drift can be resolved by re-running a registered generator.
+  `local-customization` and `conflict` findings are surfaced without a proposal.
+
+## Result validation
+
+```text
+uv run lib/pulse/scripts/validate_result.py generated-artifact-result.yaml --kind generated-artifact
+```
+
+## Related patterns
+
+- `lib/patterns/headless-contract.md` — the `generated-artifact` result kind.
+- `lib/pulse/scripts/validate_result.py` — result-kind validator.
+- `templates/generated.yaml.template` — manifest template with commented examples.

--- a/lib/patterns/headless-contract.md
+++ b/lib/patterns/headless-contract.md
@@ -15,6 +15,7 @@ retained for human-readable logs only — orchestrators MUST read the file.
 | workflow-run | workflow-run-result.yaml | `{workspace_root}/.hiivmind/github/workflow-run-result.yaml` |
 | impact | impact-result.yaml | `{workspace_root}/.hiivmind/github/impact-result.yaml` |
 | repo-mutation | repo-mutation-result.yaml | `{workspace_root}/.hiivmind/github/repo-mutation-result.yaml` |
+| generated-artifact | generated-artifact-result.yaml | `{workspace_root}/.hiivmind/github/generated-artifact-result.yaml` |
 
 Result files are per-machine transient run artifacts (never authority — see
 `workspace-detection.md` § Multi-machine topology). The workspace repo's
@@ -34,7 +35,7 @@ not kinds they were not asked to validate.
 
 ```yaml
 contract_version: 1                   # int, required
-kind: status | healthcheck | fleet-membership | refresh | workflow-run | impact | repo-mutation
+kind: status | healthcheck | fleet-membership | refresh | workflow-run | impact | repo-mutation | generated-artifact
 workspace: <login>                    # str, required — org/user login
 run_at: <ISO 8601 timestamp>          # str, required
 actor:                                # required on ALL kinds (I4)
@@ -57,6 +58,7 @@ profiles, and machines: identity-sensitive logic resolves against the
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py workflow-run-result.yaml --kind workflow-run
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py impact-result.yaml --kind impact
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py repo-mutation-result.yaml --kind repo-mutation
+    uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py generated-artifact-result.yaml --kind generated-artifact
 
 Orchestrators validate before consuming and treat exit 1/2 as a failed run
 (report, do not commit). Exit codes: 0 valid, 1 invalid (errors on stderr),
@@ -343,6 +345,45 @@ success, meaning a commit/push/PR action is proposed for something else to
 apply later, never performed by the run itself. `reason` is required
 (non-null) whenever `state` is `blocked` or `failed`, and optional (may be
 null) when `state` is `proposed`.
+
+### generated-artifact-result.yaml (written by the generation audit, F7)
+
+Reports the drift state of committed generated-artifact bindings
+(`templates/generated.yaml.template`). For each binding the audit compares the
+source template tree SHA, the target file blobs recorded at generation time,
+and the current state of the target repository. The manifest format and audit
+rules are documented in `lib/patterns/generation-manifest.md`; this section only
+covers the result shape.
+
+```yaml
+contract_version: 1
+kind: generated-artifact
+workspace: <login>
+run_at: <ISO 8601>
+actor: { gh_login: <str>, machine: <str>, mode: <enum> }
+bindings_audited: <int>                # required, non-negative — total bindings audited
+states:                                # required: binding id -> state
+  <binding id>: current | template-drift | local-customization | conflict | error
+findings:                              # list, required (may be empty) — typed data
+  - kind: <str>                        # required, e.g. template-drift, local-customization,
+                                       #   conflict, unresolvable_source
+    repo: <owner/name>                 # str, required — target repository
+    severity: low | medium | high        # required enum
+    detail: <str>                      # optional human-readable
+    ref: { type: <str>, id: <any>, url: <str> }   # optional locator
+    inferred: <bool>                  # optional — true when LLM judgment produced it
+proposals:                             # list, required (may be empty)
+  - binding: <binding id>              # str, required — binding in template-drift state
+    transformation: <generator id>     # str, required — registered generator to re-run
+    proposal_id: <str>                 # str, required — stable proposal identifier
+errors: []
+```
+
+`states` keys must be strings and values must be one of the five allowed
+states. `proposals` are emitted only for `template-drift` bindings, because only
+template drift can be resolved by re-running a registered generator. Findings
+for `local-customization`, `conflict`, and `error` states are surfaced without a
+proposal.
 
 ## Related patterns
 

--- a/lib/patterns/headless-contract.md
+++ b/lib/patterns/headless-contract.md
@@ -376,6 +376,7 @@ proposals:                             # list, required (may be empty)
   - binding: <binding id>              # str, required — binding in template-drift state
     transformation: <generator id>     # str, required — registered generator to re-run
     proposal_id: <str>                 # str, required — stable proposal identifier
+proposed_actions: [<str>, ...]        # list, required (may be empty) — withheld mutations, e.g. scheduled-gated regenerations awaiting human approval
 errors: []
 ```
 

--- a/lib/patterns/workflow-execution.md
+++ b/lib/patterns/workflow-execution.md
@@ -400,6 +400,15 @@ Severity inference (breaking vs. additive, `lib/patterns/headless-contract.md`
 edge's findings but never changes `state`, and has no bearing on whether a
 marker advances.
 
+> **Split-repo binding is configuration, not a new workflow.** A test repository
+> that lives in its own repo (e.g. `hiivmind-pulse-gh-tests`) and validates its
+> upstream source repo (`hiivmind-pulse-gh`) is expressed as a standard object
+> edge with `watch_paths: ["**"]` and a configured `integration_workflow`. The
+> existing F5 object-edge audit and marker-advancement machinery covers it
+> completely — no new workflow kind, no new result kind, and no new Python is
+> required. See `templates/relationships/split-repo-tests.yaml` for a reusable
+> overlay fragment.
+
 ---
 
 ## Cooldown Check

--- a/lib/pulse/scripts/contract_versions.py
+++ b/lib/pulse/scripts/contract_versions.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0", "packaging>=23.0", "tomli>=2.0; python_version<'3.11'"]
+# ///
+"""Pure contract-version extraction and comparison for dependency edges.
+
+An edge may declare a `contract:` block that names a producer version file
+(in the upstream repo) and a consumer requirement file (also in the upstream
+repo), plus a parser for each and an optional version scheme.
+
+Parser specs (v1):
+  - {kind: regex, pattern} — pattern must contain EXACTLY ONE capture group;
+    the extracted value is the first match's first group.
+  - {kind: toml, key} — dotted key path into a TOML document, e.g.
+    `project.version`.
+  - {kind: json, pointer} — RFC 6901 JSON pointer, e.g. `/version` or
+    `/deps/foo`.
+  - {kind: yaml, key} — dotted key path into a YAML document.
+
+Any failure to read, parse, or locate the requested value returns `None` from
+`extract()` and ultimately produces `state: unknown` from `evaluate()` — the
+module never guesses.
+
+Version comparison:
+  - `version_scheme: pep440` — parse the producer value with
+    `packaging.version.Version` and the consumer value with
+    `packaging.specifiers.SpecifierSet`. If the consumer value parses as a
+    specifier set, compatibility is `Version(producer) in SpecifierSet(consumer)`;
+    if it is a bare version, compatibility is an exact equality comparison of
+    the two parsed versions. Any `InvalidVersion` or `InvalidSpecifier` results
+    in `unknown`.
+  - No `version_scheme` (or any non-pep440 scheme) — compatibility is plain
+    string equality of the two extracted values.
+
+The module is pure: it performs no network or disk I/O directly. The caller
+injects a `read_file(repo, path) -> bytes` reader.
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+
+import yaml
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as tomllib
+
+
+# --------------------------------------------------------------------------
+# Parser spec validation
+# --------------------------------------------------------------------------
+
+def validate_parser_spec(parser_spec: dict) -> None:
+    """Validate a parser spec at load time.
+
+    Raises ValueError with a clear message if the spec is malformed.
+    """
+    kind = parser_spec.get("kind")
+    if kind == "regex":
+        pattern = parser_spec.get("pattern", "")
+        try:
+            compiled = re.compile(pattern)
+        except re.error as exc:
+            raise ValueError(f"invalid regex pattern: {exc}") from None
+        if compiled.groups != 1:
+            raise ValueError(
+                f"regex parser pattern must have exactly one capture group, "
+                f"got {compiled.groups}: {pattern!r}"
+            )
+    elif kind in ("toml", "yaml", "json"):
+        key_name = "key" if kind in ("toml", "yaml") else "pointer"
+        if key_name not in parser_spec:
+            raise ValueError(f"{kind} parser spec must include a '{key_name}'")
+    else:
+        raise ValueError(f"unsupported parser kind: {kind!r}")
+
+
+# --------------------------------------------------------------------------
+# Value extraction
+# --------------------------------------------------------------------------
+
+def extract(parser_spec: dict, content_bytes: bytes) -> str | None:
+    """Extract a string value from `content_bytes` according to
+    `parser_spec`. Returns None on any failure."""
+    try:
+        validate_parser_spec(parser_spec)
+    except ValueError:
+        return None
+
+    kind = parser_spec["kind"]
+    if kind == "regex":
+        return _extract_regex(parser_spec, content_bytes)
+    if kind == "toml":
+        return _extract_toml(parser_spec, content_bytes)
+    if kind == "json":
+        return _extract_json(parser_spec, content_bytes)
+    if kind == "yaml":
+        return _extract_yaml(parser_spec, content_bytes)
+    return None
+
+
+def _extract_regex(parser_spec: dict, content_bytes: bytes) -> str | None:
+    try:
+        text = content_bytes.decode("utf-8")
+    except UnicodeDecodeError:
+        return None
+    compiled = re.compile(parser_spec["pattern"])
+    match = compiled.search(text)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _extract_toml(parser_spec: dict, content_bytes: bytes) -> str | None:
+    try:
+        text = content_bytes.decode("utf-8")
+        data = tomllib.loads(text)
+    except (UnicodeDecodeError, tomllib.TOMLDecodeError):
+        return None
+    return _get_dotted(data, parser_spec["key"])
+
+
+def _extract_yaml(parser_spec: dict, content_bytes: bytes) -> str | None:
+    try:
+        text = content_bytes.decode("utf-8")
+        data = yaml.safe_load(text)
+    except (UnicodeDecodeError, yaml.YAMLError):
+        return None
+    return _get_dotted(data, parser_spec["key"])
+
+
+def _extract_json(parser_spec: dict, content_bytes: bytes) -> str | None:
+    try:
+        text = content_bytes.decode("utf-8")
+        data = json.loads(text)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    return _resolve_json_pointer(data, parser_spec["pointer"])
+
+
+def _get_dotted(data, key_path: str) -> str | None:
+    if data is None:
+        return None
+    current = data
+    for part in key_path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    if isinstance(current, str):
+        return current
+    if current is None:
+        return None
+    return str(current)
+
+
+def _resolve_json_pointer(data, pointer: str) -> str | None:
+    """Resolve a simple RFC 6901 JSON pointer (no escaped characters)."""
+    if pointer == "" or pointer == "/":
+        return None
+    parts = pointer.lstrip("/").split("/")
+    current = data
+    for part in parts:
+        if part == "":
+            return None
+        if isinstance(current, dict):
+            if part not in current:
+                return None
+            current = current[part]
+        elif isinstance(current, list):
+            try:
+                index = int(part)
+                current = current[index]
+            except (ValueError, IndexError):
+                return None
+        else:
+            return None
+    if isinstance(current, str):
+        return current
+    if current is None:
+        return None
+    return str(current)
+
+
+# --------------------------------------------------------------------------
+# Contract evaluation
+# --------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class ContractState:
+    state: str  # compatible | gap | unknown
+    producer_version: str | None
+    consumer_requirement: str | None
+
+
+def evaluate(edge: dict, read_file) -> ContractState:
+    """Evaluate the contract declared on a `depends_on` object edge.
+
+    `read_file(repo, path) -> bytes` is an injectable reader. Any I/O or
+    parse failure, or an unsupported version scheme, returns `unknown`.
+    """
+    contract = edge.get("contract") or {}
+    if not contract:
+        return ContractState("unknown", None, None)
+
+    upstream = edge.get("repo")
+    producer_spec = contract.get("producer") or {}
+    consumer_spec = contract.get("consumer") or {}
+    version_scheme = contract.get("version_scheme")
+
+    producer_version = _read_and_extract(upstream, producer_spec, read_file)
+    consumer_requirement = _read_and_extract(upstream, consumer_spec, read_file)
+
+    if producer_version is None or consumer_requirement is None:
+        return ContractState("unknown", producer_version, consumer_requirement)
+
+    if version_scheme == "pep440":
+        return _evaluate_pep440(producer_version, consumer_requirement)
+
+    return ContractState(
+        "compatible" if producer_version == consumer_requirement else "gap",
+        producer_version,
+        consumer_requirement,
+    )
+
+
+def _read_and_extract(repo: str, spec: dict, read_file) -> str | None:
+    if not spec:
+        return None
+    path = spec.get("path")
+    parser_spec = spec.get("parser")
+    if not path or not parser_spec:
+        return None
+    try:
+        content = read_file(repo, path)
+    except Exception:
+        return None
+    if content is None:
+        return None
+    return extract(parser_spec, content)
+
+
+def _evaluate_pep440(producer_version: str, consumer_requirement: str) -> ContractState:
+    try:
+        producer = Version(producer_version)
+    except InvalidVersion:
+        return ContractState("unknown", producer_version, consumer_requirement)
+
+    try:
+        spec = SpecifierSet(consumer_requirement)
+        compatible = producer in spec
+    except InvalidSpecifier:
+        try:
+            consumer = Version(consumer_requirement)
+            compatible = producer == consumer
+        except InvalidVersion:
+            return ContractState("unknown", producer_version, consumer_requirement)
+
+    return ContractState(
+        "compatible" if compatible else "gap",
+        producer_version,
+        consumer_requirement,
+    )

--- a/lib/pulse/scripts/generated_artifacts.py
+++ b/lib/pulse/scripts/generated_artifacts.py
@@ -243,6 +243,35 @@ def _audit_binding(binding: dict, snapshot: dict) -> tuple[BindingResult, Findin
     trees = branch_snap.get("trees") or {}
     blobs = branch_snap.get("blobs") or {}
     snapshot_tree = trees.get(template_path)
+
+    if snapshot_tree is None or snapshot_tree == ABSENT:
+        file_results = [
+            FileResult(f["path"], f.get("blob"), None, "unknown")
+            for f in files_config
+        ]
+        finding = Finding(
+            kind="missing_template",
+            repo=source,
+            severity="high",
+            detail=(
+                f"binding {binding_id!r}: template path {template_path!r} "
+                "not resolved in snapshot"
+            ),
+            ref={"template_path": template_path},
+            inferred=False,
+        )
+        return BindingResult(
+            id=binding_id,
+            state="error",
+            source=source,
+            branch=branch,
+            template_path=template_path,
+            stored_tree=stored_tree,
+            snapshot_tree=snapshot_tree,
+            files=file_results,
+            proposal=None,
+        ), finding
+
     tree_changed = snapshot_tree != stored_tree
 
     file_results: list[FileResult] = []

--- a/lib/pulse/scripts/generated_artifacts.py
+++ b/lib/pulse/scripts/generated_artifacts.py
@@ -1,0 +1,539 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Generated-artifact binding audit engine (F7 Task 2).
+
+This module classifies each generated-artifact binding as current,
+template-drift, local-customization, conflict, or error from a pre-collected
+`snapshot` data structure. It also provides guarded marker advancement for
+the manifest (`templates/generated.yaml`) and the collector that builds the
+snapshot.
+
+Snapshot shape (produced by `collect()`, consumed verbatim by `audit()`):
+
+    {
+      "<repo>": {
+        "<branch>": {
+          "head": "<sha>" | None,
+          "trees": {"<path>": "<tree_sha>" | "ABSENT", ...},
+          "blobs": {"<path>": "<blob_sha>" | "ABSENT", ...},
+        }
+      }
+    }
+
+`audit()` is pure: no network, no git commands. `collect()` and `advance()`
+are the only I/O paths.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable
+
+import yaml
+
+from lib.pulse.scripts.impact import Finding, _atomic_write_yaml
+from lib.pulse.scripts.impact_snapshot import (
+    default_runner,
+    _repo_url,
+    _slug,
+    _valid_branch,
+    _resolve_fetched_head,
+    _workdir_ctx,
+)
+
+# Sentinel for a path that does not exist at the fetched head.
+ABSENT = "ABSENT"
+
+Runner = Callable[..., "subprocess.CompletedProcess[str] | object"]
+
+
+# --------------------------------------------------------------------------
+# Dataclasses
+# --------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class GeneratedFile:
+    path: str
+    blob: str
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    id: str
+    source: str
+    branch: str
+    template_path: str
+    template_tree: str
+    generator: str
+    files: list[GeneratedFile]
+    generated_at: str
+
+
+@dataclass(frozen=True)
+class FileResult:
+    path: str
+    stored_blob: str
+    snapshot_blob: str | None
+    state: str  # current | changed | missing
+
+
+@dataclass(frozen=True)
+class BindingProposal:
+    binding_id: str
+    expected_tree: str
+    new_tree: str
+    files: list[GeneratedFile]
+    generated_at: str
+
+
+@dataclass(frozen=True)
+class BindingResult:
+    id: str
+    state: str  # current | template-drift | local-customization | conflict | error
+    source: str
+    branch: str
+    template_path: str
+    stored_tree: str
+    snapshot_tree: str | None
+    files: list[FileResult]
+    proposal: BindingProposal | None = None
+
+
+@dataclass(frozen=True)
+class GeneratedReport:
+    bindings: list[BindingResult] = field(default_factory=list)
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def bindings_checked(self) -> int:
+        return len(self.bindings)
+
+    @property
+    def bindings_drift(self) -> int:
+        return sum(1 for b in self.bindings if b.state == "template-drift")
+
+
+@dataclass(frozen=True)
+class MarkerResult:
+    status: str  # updated | noop | conflict | not_found
+    binding_id: str
+    previous_tree: str | None
+    new_tree: str | None
+    detail: str | None = None
+
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+def _failed(result) -> bool:
+    return getattr(result, "returncode", 1) != 0
+
+
+def _lines(result) -> list[str]:
+    stdout = getattr(result, "stdout", "") or ""
+    return [line for line in stdout.splitlines() if line.strip()]
+
+
+# --------------------------------------------------------------------------
+# backfill()
+# --------------------------------------------------------------------------
+
+def backfill(binding_input: dict, snapshot: dict) -> ManifestEntry:
+    """Resolve current tree/blob SHAs for a new binding from `snapshot`."""
+    source = binding_input["source"]
+    branch = binding_input["branch"]
+    repo_snap = snapshot.get(source)
+    if repo_snap is None:
+        raise ValueError(
+            f"binding {binding_input.get('id')!r}: source repo {source!r} "
+            f"branch {branch!r} not found in snapshot"
+        )
+    branch_snap = repo_snap.get(branch)
+    if branch_snap is None:
+        raise ValueError(
+            f"binding {binding_input.get('id')!r}: source repo {source!r} "
+            f"branch {branch!r} not found in snapshot"
+        )
+
+    template_path = binding_input["template_path"]
+    trees = branch_snap.get("trees") or {}
+    template_tree = trees.get(template_path)
+    if template_tree is None or template_tree == ABSENT:
+        raise ValueError(
+            f"binding {binding_input.get('id')!r}: template path {template_path!r} "
+            "not resolved in snapshot"
+        )
+
+    files: list[GeneratedFile] = []
+    blobs = branch_snap.get("blobs") or {}
+    for f in binding_input.get("files") or []:
+        path = f["path"]
+        blob = blobs.get(path)
+        if blob is None or blob == ABSENT:
+            raise ValueError(
+                f"binding {binding_input.get('id')!r}: output path {path!r} "
+                "not resolved in snapshot"
+            )
+        files.append(GeneratedFile(path, blob))
+
+    return ManifestEntry(
+        id=binding_input["id"],
+        source=source,
+        branch=branch,
+        template_path=template_path,
+        template_tree=template_tree,
+        generator=binding_input.get("generator", ""),
+        files=files,
+        generated_at=binding_input.get("generated_at", ""),
+    )
+
+
+# --------------------------------------------------------------------------
+# audit()
+# --------------------------------------------------------------------------
+
+def _audit_binding(binding: dict, snapshot: dict) -> tuple[BindingResult, Finding | None]:
+    binding_id = binding["id"]
+    source = binding["source"]
+    branch = binding["branch"]
+    template_path = binding["template_path"]
+    stored_tree = binding.get("template_tree")
+    files_config = binding.get("files") or []
+    generated_at = binding.get("generated_at", "")
+
+    repo_snap = snapshot.get(source)
+    branch_snap = repo_snap.get(branch) if repo_snap else None
+
+    if branch_snap is None or branch_snap.get("head") is None:
+        file_results = [
+            FileResult(f["path"], f.get("blob"), None, "unknown")
+            for f in files_config
+        ]
+        finding = Finding(
+            kind="snapshot_gap",
+            repo=source,
+            severity="high",
+            detail=(
+                f"binding {binding_id!r}: repo {source!r} branch {branch!r} "
+                "absent from snapshot"
+            ),
+            inferred=False,
+        )
+        return BindingResult(
+            id=binding_id,
+            state="error",
+            source=source,
+            branch=branch,
+            template_path=template_path,
+            stored_tree=stored_tree,
+            snapshot_tree=None,
+            files=file_results,
+            proposal=None,
+        ), finding
+
+    trees = branch_snap.get("trees") or {}
+    blobs = branch_snap.get("blobs") or {}
+    snapshot_tree = trees.get(template_path)
+    tree_changed = snapshot_tree != stored_tree
+
+    file_results: list[FileResult] = []
+    any_blob_changed = False
+    any_missing = False
+
+    for f in files_config:
+        path = f["path"]
+        stored_blob = f.get("blob")
+        snapshot_blob = blobs.get(path)
+        if snapshot_blob is None or snapshot_blob == ABSENT:
+            file_state = "missing"
+            any_missing = True
+        elif snapshot_blob != stored_blob:
+            file_state = "changed"
+            any_blob_changed = True
+        else:
+            file_state = "current"
+        file_results.append(
+            FileResult(path, stored_blob, snapshot_blob, file_state)
+        )
+
+    if any_missing:
+        state = "error"
+        finding = Finding(
+            kind="missing_output",
+            repo=source,
+            severity="high",
+            detail=(
+                f"binding {binding_id!r}: output path(s) missing at head: "
+                f"{', '.join(fr.path for fr in file_results if fr.state == 'missing')}"
+            ),
+            ref={"paths": [fr.path for fr in file_results if fr.state == "missing"]},
+            inferred=False,
+        )
+        proposal = None
+    elif tree_changed and not any_blob_changed:
+        state = "template-drift"
+        finding = None
+        proposal_files = [
+            GeneratedFile(fr.path, fr.snapshot_blob)
+            for fr in file_results
+        ]
+        proposal = BindingProposal(
+            binding_id=binding_id,
+            expected_tree=stored_tree,
+            new_tree=snapshot_tree,
+            files=proposal_files,
+            generated_at=generated_at,
+        )
+    elif not tree_changed and any_blob_changed:
+        state = "local-customization"
+        finding = Finding(
+            kind="local_customization",
+            repo=source,
+            severity="medium",
+            detail=f"binding {binding_id!r}: generated file(s) changed locally",
+            ref={"paths": [fr.path for fr in file_results if fr.state == "changed"]},
+            inferred=False,
+        )
+        proposal = None
+    elif tree_changed and any_blob_changed:
+        state = "conflict"
+        finding = Finding(
+            kind="conflict",
+            repo=source,
+            severity="high",
+            detail=f"binding {binding_id!r}: template drift and local customization",
+            inferred=False,
+        )
+        proposal = None
+    else:
+        state = "current"
+        finding = None
+        proposal = None
+
+    return BindingResult(
+        id=binding_id,
+        state=state,
+        source=source,
+        branch=branch,
+        template_path=template_path,
+        stored_tree=stored_tree,
+        snapshot_tree=snapshot_tree,
+        files=file_results,
+        proposal=proposal,
+    ), finding
+
+
+def audit(manifest: dict, snapshot: dict) -> GeneratedReport:
+    """Classify every binding in `manifest` against `snapshot`. Pure."""
+    bindings: list[BindingResult] = []
+    findings: list[Finding] = []
+
+    for binding in (manifest or {}).get("bindings") or []:
+        if not isinstance(binding, dict):
+            continue
+        result, finding = _audit_binding(binding, snapshot or {})
+        bindings.append(result)
+        if finding is not None:
+            findings.append(finding)
+
+    return GeneratedReport(bindings=bindings, findings=findings)
+
+
+# --------------------------------------------------------------------------
+# advance()
+# --------------------------------------------------------------------------
+
+def _find_binding(config: dict, binding_id: str) -> dict | None:
+    for binding in (config.get("bindings") or []):
+        if isinstance(binding, dict) and binding.get("id") == binding_id:
+            return binding
+    return None
+
+
+def advance(path: Path | str, binding_id: str, expected_tree: str,
+            new_tree: str, files: list[dict], generated_at: str) -> MarkerResult:
+    """CAS marker patch on `templates/generated.yaml`.
+
+    Guard rules (mirror impact.mark()):
+      - current binding.template_tree == expected_tree -> apply, "updated".
+      - current binding.template_tree == new_tree -> "noop" (idempotent).
+      - current binding.template_tree != expected_tree and != new_tree ->
+        "conflict", no write.
+      - binding not found -> "not_found".
+    """
+    path = Path(path)
+    config = yaml.safe_load(path.read_text()) or {}
+
+    binding = _find_binding(config, binding_id)
+    if binding is None:
+        return MarkerResult(
+            "not_found", binding_id, None, None,
+            detail=f"binding {binding_id!r} not found in manifest",
+        )
+
+    current_tree = binding.get("template_tree")
+
+    if current_tree == new_tree:
+        return MarkerResult(
+            "noop", binding_id, current_tree, new_tree,
+            detail="marker already at new_tree; no write",
+        )
+
+    if current_tree != expected_tree:
+        return MarkerResult(
+            "conflict", binding_id, current_tree, new_tree,
+            detail=f"expected tree {expected_tree!r} but found {current_tree!r}",
+        )
+
+    binding["template_tree"] = new_tree
+    binding["files"] = files
+    binding["generated_at"] = generated_at
+    _atomic_write_yaml(path, config)
+    return MarkerResult("updated", binding_id, current_tree, new_tree)
+
+
+# --------------------------------------------------------------------------
+# collect()
+# --------------------------------------------------------------------------
+
+def _watched_bindings(manifest: dict) -> dict[tuple[str, str], list[dict]]:
+    """Group bindings by (source, branch) for a single fetch per pair."""
+    grouped: dict[tuple[str, str], list[dict]] = {}
+    for binding in (manifest or {}).get("bindings") or []:
+        if not isinstance(binding, dict):
+            continue
+        source = binding.get("source")
+        branch = binding.get("branch")
+        if source and branch:
+            grouped.setdefault((source, branch), []).append(binding)
+    return grouped
+
+
+def _resolve_path(run, repo_dir: Path, path: str) -> str:
+    """Resolve a path via `git rev-parse FETCH_HEAD:<path>`.
+
+    A path that does not exist at the fetched head resolves to `ABSENT`,
+    never raises.
+    """
+    result = run(["git", "rev-parse", f"FETCH_HEAD:{path}"], repo_dir)
+    if _failed(result):
+        return ABSENT
+    lines = _lines(result)
+    return lines[0].strip() if lines else ABSENT
+
+
+def _collect_branch(run, base_dir: Path, source: str, branch: str,
+                    bindings: list[dict]) -> dict:
+    """Collect snapshot for one source repo/branch."""
+    url = _repo_url(source)
+    repo_dir = base_dir / _slug(source, branch)
+
+    init = run(["git", "init", "--bare", "-q", str(repo_dir)], None)
+    if _failed(init):
+        return {"head": None, "trees": {}, "blobs": {}}
+
+    if not _valid_branch(branch):
+        return {"head": None, "trees": {}, "blobs": {}}
+
+    fetch = run(["git", "fetch", "--filter=blob:none", "-q", "--", url, branch],
+                repo_dir)
+    if _failed(fetch):
+        return {"head": None, "trees": {}, "blobs": {}}
+
+    head = _resolve_fetched_head(run, repo_dir)
+    if head is None:
+        return {"head": None, "trees": {}, "blobs": {}}
+
+    template_paths: set[str] = set()
+    file_paths: set[str] = set()
+    for binding in bindings:
+        template_path = binding.get("template_path")
+        if template_path:
+            template_paths.add(template_path)
+        for f in binding.get("files") or []:
+            file_path = f.get("path")
+            if file_path:
+                file_paths.add(file_path)
+
+    trees: dict[str, str] = {}
+    blobs: dict[str, str] = {}
+    for path in sorted(template_paths):
+        trees[path] = _resolve_path(run, repo_dir, path)
+    for path in sorted(file_paths):
+        blobs[path] = _resolve_path(run, repo_dir, path)
+
+    return {"head": head, "trees": trees, "blobs": blobs}
+
+
+def collect(manifest: dict, workdir: str | Path | None = None,
+            runner: Runner | None = None) -> dict:
+    """Collect the snapshot for every binding in `manifest`.
+
+    Reuses `impact_snapshot.default_runner` and its argv-guard style. One
+    fetch is performed per (source, branch) pair; every path is resolved via
+    `git rev-parse FETCH_HEAD:<path>`. Paths that do not exist at the head
+    resolve to `ABSENT` and drive `missing_output` findings in `audit()`.
+    """
+    run = runner or default_runner
+    grouped = _watched_bindings(manifest)
+    if not grouped:
+        return {}
+
+    snapshot: dict = {}
+    with _workdir_ctx(workdir) as base_dir:
+        for source, branch in sorted(grouped):
+            bindings = grouped[(source, branch)]
+            branch_snap = _collect_branch(run, base_dir, source, branch, bindings)
+            snapshot.setdefault(source, {})[branch] = branch_snap
+    return snapshot
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    audit_p = sub.add_parser("audit", help="Audit generated-artifact bindings")
+    audit_p.add_argument("--manifest", required=True, type=Path)
+    audit_p.add_argument("--snapshot", required=True, type=Path)
+
+    mark_p = sub.add_parser("advance", help="Advance a binding marker")
+    mark_p.add_argument("--manifest", required=True, type=Path)
+    mark_p.add_argument("--binding-id", required=True)
+    mark_p.add_argument("--expected-tree", required=True)
+    mark_p.add_argument("--new-tree", required=True)
+    mark_p.add_argument("--generated-at", required=True)
+    mark_p.add_argument("--files", required=True, type=json.loads)
+
+    args = parser.parse_args()
+
+    if args.command == "audit":
+        manifest = yaml.safe_load(args.manifest.read_text()) or {}
+        snapshot = json.loads(args.snapshot.read_text())
+        report = audit(manifest, snapshot)
+        print(json.dumps({
+            "bindings_checked": report.bindings_checked,
+            "bindings_drift": report.bindings_drift,
+            "bindings": [vars(b) for b in report.bindings],
+            "findings": [vars(f) for f in report.findings],
+        }, indent=2))
+    elif args.command == "advance":
+        result = advance(args.manifest, args.binding_id, args.expected_tree,
+                         args.new_tree, args.files, args.generated_at)
+        print(json.dumps(vars(result), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/pulse/scripts/generator_dispatch.py
+++ b/lib/pulse/scripts/generator_dispatch.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import yaml
 
-from lib.pulse.scripts import impact, profile_dispatch
+from lib.pulse.scripts import impact, mutation_plan, profile_dispatch
 from lib.pulse.scripts.mutation_plan import (
     MutationPlanError,
     TransformationRegistry,

--- a/lib/pulse/scripts/generator_dispatch.py
+++ b/lib/pulse/scripts/generator_dispatch.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Generator adapter dispatch (F7 Task 3).
+
+Turns a drifted generated-artifact binding into an F6 Nave mutation `Proposal`.
+Generators are registered adapters: each one names a registered transformation
+(the only source of argv), declares which repositories it applies to, and
+maintains an output-path allowlist that guards where generated files may be
+written.
+
+Pure module: no subprocess calls, no filesystem writes, no Nave interaction.
+See `lib/patterns/repository-mutations.md` for the mutation contract and
+`templates/generators.yaml.template` for the committed registry shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from lib.pulse.scripts import impact, profile_dispatch
+from lib.pulse.scripts.mutation_plan import (
+    MutationPlanError,
+    TransformationRegistry,
+    ValidationSpec,
+    _load_validation,
+    build_proposal,
+)
+from lib.pulse.scripts.profile_dispatch import RepositoryProfile, _is_applicable
+
+
+@dataclass(frozen=True)
+class Generator:
+    """One registered generator adapter.
+
+    `applies_to` uses the same predicate grammar as scorecard checks and
+    transformations (`always`, `profile:<id>`, `capability:<id>`,
+    `evidence_path:<glob>`). `output_paths` is an allowlist: every file a
+    binding asks this generator to produce must match at least one glob.
+    """
+
+    id: str
+    applies_to: tuple[str, ...]
+    transformation: str
+    source_paths: tuple[str, ...]
+    output_paths: tuple[str, ...]
+    validation: ValidationSpec
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise MutationPlanError(f"{label} must be a mapping")
+    if not all(isinstance(key, str) for key in value):
+        raise MutationPlanError(f"{label} keys must be strings")
+    return value
+
+
+def _list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise MutationPlanError(f"{label} must be a list")
+    return value
+
+
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise MutationPlanError(f"{label} must be a non-empty string")
+    return value
+
+
+def _only_keys(data: dict[str, Any], allowed: set[str], label: str) -> None:
+    unknown = set(data) - allowed
+    if unknown:
+        raise MutationPlanError(f"unknown {label} key: {sorted(unknown)[0]}")
+
+
+def _applicability_predicate(predicate: str, generator_id: str) -> str:
+    """Validate one `applies_to` predicate against the profile_dispatch grammar.
+
+    Reuses `profile_dispatch._is_applicable` on a deliberately empty profile
+    and evidence set: any syntactically valid predicate either matches
+    immediately (`always`) or returns `False` without raising. Invalid
+    predicates raise `ConfigError`, which we translate into a load-time
+    `MutationPlanError`.
+    """
+    predicate = _string(predicate, f"generator {generator_id}.applies_to entry")
+    try:
+        _is_applicable(
+            predicate,
+            RepositoryProfile(profiles=(), scorecard=""),
+            {},
+        )
+    except profile_dispatch.ConfigError as exc:
+        raise MutationPlanError(
+            f"generator {generator_id}.applies_to invalid predicate: {predicate}"
+        ) from exc
+    return predicate
+
+
+def _load_generator(
+    raw: Any,
+    generator_id: str,
+    registry: TransformationRegistry,
+) -> Generator:
+    item = _mapping(raw, f"generator {generator_id}")
+    # `command`/`command_argv` are not valid generator fields, but we allow
+    # them here so we can reject them with an explicit, helpful message that
+    # points callers at the transformation registry.
+    _only_keys(
+        item,
+        {
+            "id",
+            "applies_to",
+            "transformation",
+            "source_paths",
+            "output_paths",
+            "validation",
+            "command",
+            "command_argv",
+        },
+        f"generator {generator_id}",
+    )
+
+    declared_id = _string(item.get("id"), f"generator {generator_id}.id")
+    if declared_id != generator_id:
+        raise MutationPlanError(
+            f"generator {generator_id}.id must match its registry key: {declared_id}"
+        )
+
+    applies_to_raw = _list(item.get("applies_to"), f"generator {generator_id}.applies_to")
+    if not applies_to_raw:
+        raise MutationPlanError(
+            f"generator {generator_id}.applies_to must be non-empty"
+        )
+    applies_to = tuple(
+        _applicability_predicate(predicate, generator_id) for predicate in applies_to_raw
+    )
+
+    transformation_id = _string(
+        item.get("transformation"), f"generator {generator_id}.transformation"
+    )
+    # Fail closed on an unknown transformation id. The registry lookup also
+    # gives us the entry later callers (e.g. pen_orchestrator) need.
+    registry.get(transformation_id)
+
+    # Generators never carry their own command line; the transformation
+    # registry is the only source of argv.
+    for forbidden in ("command", "command_argv"):
+        if forbidden in item:
+            raise MutationPlanError(
+                f"generator {generator_id} must not declare a '{forbidden}' key; "
+                "the transformation registry is the only argv source"
+            )
+
+    source_paths = tuple(
+        _string(path, f"generator {generator_id}.source_paths[{index}]")
+        for index, path in enumerate(
+            _list(item.get("source_paths"), f"generator {generator_id}.source_paths")
+        )
+    )
+    if not source_paths:
+        raise MutationPlanError(
+            f"generator {generator_id}.source_paths must be non-empty"
+        )
+
+    output_paths = tuple(
+        _string(path, f"generator {generator_id}.output_paths[{index}]")
+        for index, path in enumerate(
+            _list(item.get("output_paths"), f"generator {generator_id}.output_paths")
+        )
+    )
+    if not output_paths:
+        raise MutationPlanError(
+            f"generator {generator_id}.output_paths must be non-empty"
+        )
+
+    validation = _load_validation(item.get("validation"), generator_id)
+
+    return Generator(
+        id=generator_id,
+        applies_to=applies_to,
+        transformation=transformation_id,
+        source_paths=source_paths,
+        output_paths=output_paths,
+        validation=validation,
+    )
+
+
+def load_generators(
+    data: dict[str, Any] | str | Path,
+    registry: TransformationRegistry,
+) -> dict[str, Generator]:
+    """Load and cross-validate a generator registry.
+
+    `data` is either a path to a YAML file or an already-parsed mapping.
+    A top-level `generators:` key is accepted and unwrapped, so the same
+    file shape `templates/generators.yaml.template` uses loads directly.
+
+    Fail-closed errors:
+      - unknown `transformation` id
+      - empty `output_paths` (or `source_paths`)
+      - presence of a `command` or `command_argv` key
+      - invalid `applies_to` predicate grammar
+    """
+    if isinstance(data, dict):
+        root = data
+    elif isinstance(data, (str, Path)):
+        path = Path(data)
+        try:
+            root = yaml.safe_load(path.read_text())
+        except FileNotFoundError as exc:
+            raise MutationPlanError(f"generators not found: {path}") from exc
+        except (OSError, UnicodeError, yaml.YAMLError) as exc:
+            raise MutationPlanError(f"could not load generators: {exc}") from exc
+    else:
+        raise MutationPlanError("generators source must be a path or a mapping")
+
+    root = _mapping(root, "generators")
+    if "generators" in root and isinstance(root["generators"], dict):
+        root = _mapping(root["generators"], "generators.generators")
+
+    return {
+        generator_id: _load_generator(raw, generator_id, registry)
+        for generator_id, raw in root.items()
+    }
+
+
+# ---------------------------------------------------------------------------
+# Output-path allowlist matching
+# ---------------------------------------------------------------------------
+
+
+def path_matches_allowlist(path: str, output_paths: tuple[str, ...]) -> bool:
+    """Return True when `path` matches at least one `output_paths` glob.
+
+    Uses `impact._glob_to_regex` so the allowlist semantics exactly match the
+    watch-path semantics used elsewhere in Pulse (`*` never crosses `/`,
+    `**` does).
+    """
+    return any(impact._glob_to_regex(pattern).match(path) for pattern in output_paths)
+
+
+# ---------------------------------------------------------------------------
+# Applicability
+# ---------------------------------------------------------------------------
+
+
+def generator_applies(
+    generator: Generator,
+    repository: RepositoryProfile,
+    evidence: dict[str, Any],
+) -> bool:
+    """Return True if any of the generator's `applies_to` predicates match.
+
+    This is the pure, side-effect-free gate the caller checks before invoking
+    `dispatch`. It reuses `profile_dispatch._is_applicable` verbatim.
+    """
+    for predicate in generator.applies_to:
+        if _is_applicable(predicate, repository, evidence):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+
+def dispatch(
+    generator: Generator,
+    binding: dict[str, Any],
+    snapshot: dict[str, Any],
+    actor: dict[str, Any] | mutation_plan.Actor,
+    mutation_policy: str = "propose",
+) -> mutation_plan.Proposal:
+    """Turn a drifted binding into a validated Nave mutation `Proposal`.
+
+    `selection` is exactly `[binding["source"]]` and `expected_shas` maps
+    that repo to `snapshot[binding["source"]][binding["branch"]]["head"]`.
+    Every path in `binding["files"]` must match at least one of the
+    generator's `output_paths` globs; any path outside the allowlist raises
+    `MutationPlanError` without producing a proposal.
+    """
+    source = _string(binding.get("source"), "binding.source")
+    branch = _string(binding.get("branch"), "binding.branch")
+    binding_id = _string(binding.get("id"), "binding.id")
+
+    repo_snap = snapshot.get(source)
+    if repo_snap is None:
+        raise MutationPlanError(
+            f"dispatch: source repo {source!r} not found in snapshot"
+        )
+    branch_snap = repo_snap.get(branch)
+    if branch_snap is None:
+        raise MutationPlanError(
+            f"dispatch: branch {branch!r} not found for {source!r} in snapshot"
+        )
+    head = branch_snap.get("head")
+    if not isinstance(head, str) or not head.strip():
+        raise MutationPlanError(
+            f"dispatch: no head resolved for {source!r} {branch!r}"
+        )
+
+    files = binding.get("files") or []
+    files = _list(list(files), "binding.files")
+    for index, file_entry in enumerate(files):
+        file_item = _mapping(file_entry, f"binding.files[{index}]")
+        path = _string(file_item.get("path"), f"binding.files[{index}].path")
+        if not path_matches_allowlist(path, generator.output_paths):
+            raise MutationPlanError(
+                f"dispatch: binding file {path!r} is outside generator "
+                f"{generator.id!r} output_paths allowlist"
+            )
+
+    proposal_id = f"generate-{generator.id}-{binding_id}"
+    return build_proposal(
+        id=proposal_id,
+        selection=[source],
+        transformation=generator.transformation,
+        expected_shas={source: head},
+        actor=actor,
+        mutation_policy=mutation_policy,
+    )

--- a/lib/pulse/scripts/impact.py
+++ b/lib/pulse/scripts/impact.py
@@ -81,6 +81,8 @@ from pathlib import Path
 
 import yaml
 
+from lib.pulse.scripts.contract_versions import evaluate
+
 # --------------------------------------------------------------------------
 # Watch-path glob matching
 # --------------------------------------------------------------------------
@@ -153,6 +155,7 @@ class EdgeResult:
     tested_sha: str | None
     remote_head: str | None
     changed_paths: list[str] = field(default_factory=list)
+    contract_state: str | None = None
 
 
 @dataclass(frozen=True)
@@ -187,11 +190,35 @@ def _branch_snapshot(snapshot: dict, repo: str, branch: str) -> dict | None:
 
 
 def _audit_edge(dependent: str, edge_config: dict,
-                 snapshot: dict) -> tuple[EdgeResult, Finding | None]:
+                 snapshot: dict,
+                 contract_reader=None) -> tuple[EdgeResult, Finding | None]:
     upstream = edge_config["repo"]
     watch_branch = edge_config["watch_branch"]
     watch_paths = edge_config.get("watch_paths") or []
     tested_sha = edge_config.get("integration_tested_sha")
+
+    # Contract-version evaluation is independent of path currency.
+    contract_state: str | None = None
+    contract_finding: Finding | None = None
+    contract_eval = None
+    contract_block = edge_config.get("contract")
+    if contract_block:
+        if contract_reader is None:
+            contract_state = "unknown"
+            contract_finding = Finding(
+                kind="unevaluated_contract",
+                repo=dependent,
+                severity="low",
+                detail=(
+                    f"depends_on edge to '{upstream}' on branch '{watch_branch}' has a "
+                    "contract block but no contract_reader was supplied; contract "
+                    "compatibility cannot be evaluated"
+                ),
+                inferred=False,
+            )
+        else:
+            contract_eval = evaluate(edge_config, contract_reader)
+            contract_state = contract_eval.state
 
     if not watch_paths:
         finding = Finding(
@@ -205,12 +232,12 @@ def _audit_edge(dependent: str, edge_config: dict,
             inferred=False,
         )
         return EdgeResult(dependent, upstream, watch_branch, "unknown",
-                           tested_sha, None, []), finding
+                           tested_sha, None, [], contract_state), finding
 
     branch_snap = _branch_snapshot(snapshot, upstream, watch_branch)
     if branch_snap is None:
         return EdgeResult(dependent, upstream, watch_branch, "unknown",
-                           tested_sha, None, []), None
+                           tested_sha, None, [], contract_state), None
 
     remote_head = branch_snap.get("head")
     changed_files_by_base = branch_snap.get("changed_files_by_base") or {}
@@ -223,19 +250,45 @@ def _audit_edge(dependent: str, edge_config: dict,
         or tested_sha not in changed_files_by_base
     ):
         return EdgeResult(dependent, upstream, watch_branch, "unknown",
-                           tested_sha, remote_head, []), None
+                           tested_sha, remote_head, [], contract_state), None
 
     changed_paths = _matched_paths(changed_files_by_base[tested_sha], watch_paths)
     state = "stale" if changed_paths else "current"
+
+    if state == "stale" and contract_state == "gap" and contract_eval is not None:
+        contract_finding = Finding(
+            kind="stale_with_contract_gap",
+            repo=dependent,
+            severity="high",
+            detail=(
+                f"depends_on edge to '{upstream}' on branch '{watch_branch}' is "
+                f"path stale and has a contract gap"
+            ),
+            ref={
+                "upstream": upstream,
+                "watch_branch": watch_branch,
+                "changed_paths": changed_paths,
+                "producer_version": contract_eval.producer_version,
+                "consumer_requirement": contract_eval.consumer_requirement,
+            },
+            inferred=False,
+        )
+
     return EdgeResult(dependent, upstream, watch_branch, state,
-                       tested_sha, remote_head, changed_paths), None
+                       tested_sha, remote_head, changed_paths,
+                       contract_state), contract_finding
 
 
-def audit(relationships: dict, snapshot: dict) -> ImpactReport:
+def audit(relationships: dict, snapshot: dict,
+          contract_reader=None) -> ImpactReport:
     """Classify every configured `depends_on[]` object edge as
     current/stale/unknown from pre-collected snapshot evidence. Pure: no
     network, no git commands. Legacy string edges produce an
-    `unconfigured_edge` finding instead of an edges[] verdict."""
+    `unconfigured_edge` finding instead of an edges[] verdict.
+
+    If `contract_reader(repo, path) -> bytes` is supplied, any edge with a
+    `contract:` block is evaluated for producer/consumer version compatibility
+    and the resulting `contract_state` is attached to the edge row."""
     edges: list[EdgeResult] = []
     findings: list[Finding] = []
 
@@ -255,10 +308,12 @@ def audit(relationships: dict, snapshot: dict) -> ImpactReport:
                     inferred=False,
                 ))
                 continue
-            edge_result, empty_watch_paths_finding = _audit_edge(dependent, depends_on, snapshot)
+            edge_result, contract_finding = _audit_edge(
+                dependent, depends_on, snapshot, contract_reader=contract_reader
+            )
             edges.append(edge_result)
-            if empty_watch_paths_finding is not None:
-                findings.append(empty_watch_paths_finding)
+            if contract_finding is not None:
+                findings.append(contract_finding)
 
     return ImpactReport(edges=edges, findings=findings)
 

--- a/lib/pulse/scripts/impact.py
+++ b/lib/pulse/scripts/impact.py
@@ -191,7 +191,7 @@ def _branch_snapshot(snapshot: dict, repo: str, branch: str) -> dict | None:
 
 def _audit_edge(dependent: str, edge_config: dict,
                  snapshot: dict,
-                 contract_reader=None) -> tuple[EdgeResult, Finding | None]:
+                 contract_reader=None) -> tuple[EdgeResult, list[Finding]]:
     upstream = edge_config["repo"]
     watch_branch = edge_config["watch_branch"]
     watch_paths = edge_config.get("watch_paths") or []
@@ -199,13 +199,13 @@ def _audit_edge(dependent: str, edge_config: dict,
 
     # Contract-version evaluation is independent of path currency.
     contract_state: str | None = None
-    contract_finding: Finding | None = None
     contract_eval = None
+    contract_findings: list[Finding] = []
     contract_block = edge_config.get("contract")
     if contract_block:
         if contract_reader is None:
             contract_state = "unknown"
-            contract_finding = Finding(
+            contract_findings.append(Finding(
                 kind="unevaluated_contract",
                 repo=dependent,
                 severity="low",
@@ -215,13 +215,13 @@ def _audit_edge(dependent: str, edge_config: dict,
                     "compatibility cannot be evaluated"
                 ),
                 inferred=False,
-            )
+            ))
         else:
             contract_eval = evaluate(edge_config, contract_reader)
             contract_state = contract_eval.state
 
     if not watch_paths:
-        finding = Finding(
+        empty_watch_paths_finding = Finding(
             kind="empty_watch_paths",
             repo=dependent,
             severity="low",
@@ -232,12 +232,12 @@ def _audit_edge(dependent: str, edge_config: dict,
             inferred=False,
         )
         return EdgeResult(dependent, upstream, watch_branch, "unknown",
-                           tested_sha, None, [], contract_state), finding
+                           tested_sha, None, [], contract_state), contract_findings + [empty_watch_paths_finding]
 
     branch_snap = _branch_snapshot(snapshot, upstream, watch_branch)
     if branch_snap is None:
         return EdgeResult(dependent, upstream, watch_branch, "unknown",
-                           tested_sha, None, [], contract_state), None
+                           tested_sha, None, [], contract_state), contract_findings
 
     remote_head = branch_snap.get("head")
     changed_files_by_base = branch_snap.get("changed_files_by_base") or {}
@@ -250,13 +250,13 @@ def _audit_edge(dependent: str, edge_config: dict,
         or tested_sha not in changed_files_by_base
     ):
         return EdgeResult(dependent, upstream, watch_branch, "unknown",
-                           tested_sha, remote_head, [], contract_state), None
+                           tested_sha, remote_head, [], contract_state), contract_findings
 
     changed_paths = _matched_paths(changed_files_by_base[tested_sha], watch_paths)
     state = "stale" if changed_paths else "current"
 
     if state == "stale" and contract_state == "gap" and contract_eval is not None:
-        contract_finding = Finding(
+        contract_findings.append(Finding(
             kind="stale_with_contract_gap",
             repo=dependent,
             severity="high",
@@ -272,11 +272,11 @@ def _audit_edge(dependent: str, edge_config: dict,
                 "consumer_requirement": contract_eval.consumer_requirement,
             },
             inferred=False,
-        )
+        ))
 
     return EdgeResult(dependent, upstream, watch_branch, state,
                        tested_sha, remote_head, changed_paths,
-                       contract_state), contract_finding
+                       contract_state), contract_findings
 
 
 def audit(relationships: dict, snapshot: dict,
@@ -308,12 +308,11 @@ def audit(relationships: dict, snapshot: dict,
                     inferred=False,
                 ))
                 continue
-            edge_result, contract_finding = _audit_edge(
+            edge_result, edge_findings = _audit_edge(
                 dependent, depends_on, snapshot, contract_reader=contract_reader
             )
             edges.append(edge_result)
-            if contract_finding is not None:
-                findings.append(contract_finding)
+            findings.extend(edge_findings)
 
     return ImpactReport(edges=edges, findings=findings)
 

--- a/lib/pulse/scripts/tests/fixtures/generated-artifact-invalid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/generated-artifact-invalid.yaml
@@ -1,0 +1,15 @@
+contract_version: 1
+kind: generated-artifact
+workspace: testorg
+run_at: "2026-07-10T09:15:00Z"
+states:
+  binding-1: current
+  binding-2: exploded
+findings:
+  - kind: template-drift
+    repo: testorg/widget
+    detail: "missing severity"
+proposals:
+  - binding: binding-2
+    transformation: bump-template
+errors: []

--- a/lib/pulse/scripts/tests/fixtures/generated-artifact-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/generated-artifact-valid.yaml
@@ -19,4 +19,5 @@ proposals:
   - binding: binding-2
     transformation: bump-template
     proposal_id: proposal-binding-2-001
+proposed_actions: []
 errors: []

--- a/lib/pulse/scripts/tests/fixtures/generated-artifact-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/generated-artifact-valid.yaml
@@ -1,0 +1,22 @@
+contract_version: 1
+kind: generated-artifact
+workspace: testorg
+run_at: "2026-07-10T09:15:00Z"
+actor:
+  gh_login: octocat
+  machine: mba-m4
+  mode: scheduled
+bindings_audited: 2
+states:
+  binding-1: current
+  binding-2: template-drift
+findings:
+  - kind: template-drift
+    repo: testorg/widget
+    severity: medium
+    detail: "generated file README.md drifted from template"
+proposals:
+  - binding: binding-2
+    transformation: bump-template
+    proposal_id: proposal-binding-2-001
+errors: []

--- a/lib/pulse/scripts/tests/test_contract_versions.py
+++ b/lib/pulse/scripts/tests/test_contract_versions.py
@@ -1,0 +1,362 @@
+"""Tests for contract_versions.py — pure contract-version extraction/evaluation."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lib.pulse.scripts.contract_versions import (
+    ContractState,
+    evaluate,
+    extract,
+    validate_parser_spec,
+)
+
+
+# --- parser spec validation ---
+
+
+def test_regex_with_exactly_one_capture_group_is_valid():
+    validate_parser_spec({"kind": "regex", "pattern": r"version = \"(\d+\.\d+)\""})
+
+
+def test_regex_with_zero_capture_groups_rejected_at_load():
+    with pytest.raises(ValueError, match="exactly one capture group"):
+        validate_parser_spec({"kind": "regex", "pattern": r"version = \"\d+\.\d+\""})
+
+
+def test_regex_with_two_capture_groups_rejected_at_load():
+    with pytest.raises(ValueError, match="exactly one capture group"):
+        validate_parser_spec({"kind": "regex", "pattern": r"(version) = \"(\d+\.\d+)\""})
+
+
+def test_toml_parser_spec_is_valid():
+    validate_parser_spec({"kind": "toml", "key": "project.version"})
+
+
+def test_json_parser_spec_is_valid():
+    validate_parser_spec({"kind": "json", "pointer": "/version"})
+
+
+def test_yaml_parser_spec_is_valid():
+    validate_parser_spec({"kind": "yaml", "key": "version"})
+
+
+# --- regex extraction ---
+
+
+def test_regex_extracts_capture_group():
+    spec = {"kind": "regex", "pattern": r"version = \"(\d+\.\d+\.\d+)\""}
+    content = b'\n# comment\nversion = "1.2.3"\n'
+    assert extract(spec, content) == "1.2.3"
+
+
+def test_regex_no_match_returns_none():
+    spec = {"kind": "regex", "pattern": r"version = \"(\d+\.\d+\.\d+)\""}
+    assert extract(spec, b"no version here") is None
+
+
+def test_regex_bad_bytes_returns_none():
+    spec = {"kind": "regex", "pattern": r"version = \"(\d+\.\d+\.\d+)\""}
+    assert extract(spec, b"\xff\xfe") is None
+
+
+# --- toml extraction ---
+
+
+def test_toml_extracts_dotted_key():
+    spec = {"kind": "toml", "key": "project.version"}
+    content = b'[project]\nname = "example"\nversion = "2.0.0"\n'
+    assert extract(spec, content) == "2.0.0"
+
+
+def test_toml_missing_key_returns_none():
+    spec = {"kind": "toml", "key": "project.version"}
+    assert extract(spec, b'[project]\nname = "example"\n') is None
+
+
+def test_toml_bad_bytes_returns_none():
+    spec = {"kind": "toml", "key": "project.version"}
+    assert extract(spec, b"\xff\xfe not valid utf8") is None
+
+
+# --- json pointer extraction ---
+
+
+def test_json_pointer_extracts_top_level_value():
+    spec = {"kind": "json", "pointer": "/version"}
+    content = json.dumps({"version": "3.1.4"}).encode()
+    assert extract(spec, content) == "3.1.4"
+
+
+def test_json_pointer_extracts_nested_value():
+    spec = {"kind": "json", "pointer": "/deps/foo"}
+    content = json.dumps({"deps": {"foo": "1.0.0"}}).encode()
+    assert extract(spec, content) == "1.0.0"
+
+
+def test_json_pointer_missing_returns_none():
+    spec = {"kind": "json", "pointer": "/missing"}
+    content = json.dumps({"version": "1.0.0"}).encode()
+    assert extract(spec, content) is None
+
+
+def test_json_pointer_bad_bytes_returns_none():
+    spec = {"kind": "json", "pointer": "/version"}
+    assert extract(spec, b"{not json") is None
+
+
+# --- yaml extraction ---
+
+
+def test_yaml_extracts_dotted_key():
+    spec = {"kind": "yaml", "key": "version"}
+    content = b'version: "4.5.6"\n'
+    assert extract(spec, content) == "4.5.6"
+
+
+def test_yaml_extracts_nested_dotted_key():
+    spec = {"kind": "yaml", "key": "project.version"}
+    content = b'project:\n  version: "7.8.9"\n'
+    assert extract(spec, content) == "7.8.9"
+
+
+def test_yaml_missing_key_returns_none():
+    spec = {"kind": "yaml", "key": "project.version"}
+    content = b'other:\n  value: 1\n'
+    assert extract(spec, content) is None
+
+
+def test_yaml_bad_bytes_returns_none():
+    spec = {"kind": "yaml", "key": "version"}
+    assert extract(spec, b"\xff\xfe") is None
+
+
+# --- evaluate() ---
+
+
+def fake_reader(files: dict) -> callable:
+    def read(repo: str, path: str) -> bytes:
+        return files[(repo, path)]
+    return read
+
+
+def test_evaluate_pep440_compatible():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {
+                "path": "pyproject.toml",
+                "parser": {"kind": "toml", "key": "project.version"},
+            },
+                "consumer": {
+                    "path": "requirements.txt",
+                    "parser": {"kind": "regex", "pattern": r"upstream(>=[^\s]+)"},
+                },
+            "version_scheme": "pep440",
+        },
+    }
+    files = {
+        ("upstream", "pyproject.toml"): b'[project]\nversion = "1.5.0"\n',
+        ("upstream", "requirements.txt"): b"upstream>=1.0,<2.0\n",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result == ContractState("compatible", "1.5.0", ">=1.0,<2.0")
+
+
+def test_evaluate_pep440_gap():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {
+                "path": "version.json",
+                "parser": {"kind": "json", "pointer": "/version"},
+            },
+            "consumer": {
+                "path": "consumer.yaml",
+                "parser": {"kind": "yaml", "key": "requires"},
+            },
+            "version_scheme": "pep440",
+        },
+    }
+    files = {
+        ("upstream", "version.json"): b'{"version": "2.0.0"}',
+        ("upstream", "consumer.yaml"): b"requires: \">=1.0,<2.0\"\n",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result == ContractState("gap", "2.0.0", ">=1.0,<2.0")
+
+
+def test_evaluate_pep440_bare_version_equal():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {
+                "path": "version.txt",
+                "parser": {"kind": "regex", "pattern": r"version:\s*(\S+)"},
+            },
+            "consumer": {
+                "path": "pin.txt",
+                "parser": {"kind": "regex", "pattern": r"version:\s*(\S+)"},
+            },
+            "version_scheme": "pep440",
+        },
+    }
+    files = {
+        ("upstream", "version.txt"): b"version: 1.2.3",
+        ("upstream", "pin.txt"): b"version: 1.2.3",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result == ContractState("compatible", "1.2.3", "1.2.3")
+
+
+def test_evaluate_pep440_bare_version_gap():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {"path": "v.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "consumer": {"path": "p.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "version_scheme": "pep440",
+        },
+    }
+    files = {
+        ("upstream", "v.txt"): b"1.2.3",
+        ("upstream", "p.txt"): b"1.2.4",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result == ContractState("gap", "1.2.3", "1.2.4")
+
+
+def test_evaluate_no_scheme_string_equality_compatible():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {"path": "a.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "consumer": {"path": "b.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+        },
+    }
+    files = {
+        ("upstream", "a.txt"): b"abc123",
+        ("upstream", "b.txt"): b"abc123",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result == ContractState("compatible", "abc123", "abc123")
+
+
+def test_evaluate_no_scheme_string_equality_gap():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {"path": "a.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "consumer": {"path": "b.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+        },
+    }
+    files = {
+        ("upstream", "a.txt"): b"abc123",
+        ("upstream", "b.txt"): b"def456",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result == ContractState("gap", "abc123", "def456")
+
+
+def test_evaluate_non_pep440_scheme_uses_string_equality():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {"path": "a.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "consumer": {"path": "b.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "version_scheme": "semver",
+        },
+    }
+    files = {
+        ("upstream", "a.txt"): b"abc123",
+        ("upstream", "b.txt"): b"abc123",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result == ContractState("compatible", "abc123", "abc123")
+
+
+def test_evaluate_unknown_when_producer_missing():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {"path": "missing.toml", "parser": {"kind": "toml", "key": "version"}},
+            "consumer": {"path": "b.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+        },
+    }
+    files = {
+        ("upstream", "b.txt"): b"1.2.3",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result.state == "unknown"
+    assert result.producer_version is None
+    assert result.consumer_requirement == "1.2.3"
+
+
+def test_evaluate_unknown_when_consumer_missing():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {"path": "a.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "consumer": {"path": "missing.yaml", "parser": {"kind": "yaml", "key": "version"}},
+        },
+    }
+    files = {
+        ("upstream", "a.txt"): b"1.2.3",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result.state == "unknown"
+    assert result.producer_version == "1.2.3"
+    assert result.consumer_requirement is None
+
+
+def test_evaluate_unknown_when_reader_raises():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {"path": "a.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "consumer": {"path": "b.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+        },
+    }
+
+    def read(_repo: str, _path: str) -> bytes:
+        raise FileNotFoundError("nope")
+
+    result = evaluate(edge, read)
+    assert result.state == "unknown"
+    assert result.producer_version is None
+    assert result.consumer_requirement is None
+
+
+def test_evaluate_unknown_on_invalid_pep440_version():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {"path": "a.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "consumer": {"path": "b.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "version_scheme": "pep440",
+        },
+    }
+    files = {
+        ("upstream", "a.txt"): b"not-a-version",
+        ("upstream", "b.txt"): b">=1.0",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result.state == "unknown"
+
+
+def test_evaluate_unknown_on_invalid_pep440_specifier():
+    edge = {
+        "repo": "upstream",
+        "contract": {
+            "producer": {"path": "a.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "consumer": {"path": "b.txt", "parser": {"kind": "regex", "pattern": r"(\S+)"}},
+            "version_scheme": "pep440",
+        },
+    }
+    files = {
+        ("upstream", "a.txt"): b"1.2.3",
+        ("upstream", "b.txt"): b"not-a-specifier",
+    }
+    result = evaluate(edge, fake_reader(files))
+    assert result.state == "unknown"

--- a/lib/pulse/scripts/tests/test_generated_artifact_skill.py
+++ b/lib/pulse/scripts/tests/test_generated_artifact_skill.py
@@ -1,0 +1,59 @@
+"""Contract checks for the headless generated-artifact orchestration skill."""
+
+from pathlib import Path
+
+
+SKILL = Path("skills/gh-generated-artifact-headless/SKILL.md")
+WORKFLOW = Path("templates/workflows/generated-artifact-audit.yaml")
+GENERATED_ARTIFACTS = Path("lib/pulse/scripts/generated_artifacts.py")
+GENERATOR_DISPATCH = Path("lib/pulse/scripts/generator_dispatch.py")
+
+
+def read_skill() -> str:
+    return SKILL.read_text()
+
+
+def read_workflow() -> str:
+    return WORKFLOW.read_text()
+
+
+def test_neutrality_forbidden_strings_absent():
+    for path in (GENERATED_ARTIFACTS, GENERATOR_DISPATCH, SKILL, WORKFLOW):
+        content = path.read_text().lower()
+        for forbidden in ("claude", "corpus", "plugin manifest", "skill.md"):
+            assert forbidden not in content, f"{forbidden!r} found in {path}"
+
+
+def test_phases_are_present_in_order():
+    skill = read_skill()
+    for phase in ("Phase 1: VALIDATE", "Phase 2: SNAPSHOT", "Phase 3: AUDIT",
+                  "Phase 4: CONFLICT/PROPOSE", "Phase 5: RECORD"):
+        assert phase in skill
+    normalized = " ".join(skill.split())
+    order = [
+        normalized.index("Phase 1: VALIDATE"),
+        normalized.index("Phase 2: SNAPSHOT"),
+        normalized.index("Phase 3: AUDIT"),
+        normalized.index("Phase 4: CONFLICT/PROPOSE"),
+        normalized.index("Phase 5: RECORD"),
+    ]
+    assert order == sorted(order)
+
+
+def test_result_kind_is_generated_artifact_and_validated():
+    skill = read_skill()
+    assert "kind: generated-artifact" in skill
+    assert "validate_result.py" in skill
+    assert '--kind generated-artifact' in skill
+
+
+def test_scheduled_gating_blocks_non_scheduled_transformations():
+    skill = read_skill()
+    normalized = " ".join(skill.split())
+    assert (
+        "Under mode: scheduled, a generator whose transformation has "
+        "allow_scheduled: false MUST NOT be dispatched"
+    ) in normalized
+    assert (
+        "Only allow_scheduled: true transformations may be dispatched unattended"
+    ) in normalized

--- a/lib/pulse/scripts/tests/test_generated_artifacts.py
+++ b/lib/pulse/scripts/tests/test_generated_artifacts.py
@@ -54,8 +54,8 @@ def snapshot_for(source="hiivmind/template-repo", branch="main", head="head999",
         source: {
             branch: {
                 "head": head,
-                "trees": trees or {"templates/repo-readme.md": "tree1111"},
-                "blobs": blobs or {"README.md": "blob1111"},
+                "trees": trees if trees is not None else {"templates/repo-readme.md": "tree1111"},
+                "blobs": blobs if blobs is not None else {"README.md": "blob1111"},
             }
         }
     }
@@ -198,6 +198,38 @@ def test_audit_missing_output_error():
     assert finding.kind == "missing_output"
     assert finding.severity == "high"
     assert "README.md" in (finding.detail or "")
+
+
+def test_audit_missing_template_error():
+    snap = snapshot_for(trees={"templates/repo-readme.md": ga.ABSENT})
+    report = ga.audit(manifest([binding()]), snap)
+
+    result = report.bindings[0]
+    assert result.state == "error"
+    assert result.snapshot_tree == ga.ABSENT
+    assert result.proposal is None
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.kind == "missing_template"
+    assert finding.severity == "high"
+    assert "templates/repo-readme.md" in (finding.detail or "")
+    assert finding.ref == {"template_path": "templates/repo-readme.md"}
+
+
+def test_audit_none_template_error():
+    snap = snapshot_for(trees={})
+    report = ga.audit(manifest([binding()]), snap)
+
+    result = report.bindings[0]
+    assert result.state == "error"
+    assert result.snapshot_tree is None
+    assert result.proposal is None
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.kind == "missing_template"
+    assert finding.severity == "high"
+    assert "templates/repo-readme.md" in (finding.detail or "")
+    assert finding.ref == {"template_path": "templates/repo-readme.md"}
 
 
 def test_audit_snapshot_gap_error():

--- a/lib/pulse/scripts/tests/test_generated_artifacts.py
+++ b/lib/pulse/scripts/tests/test_generated_artifacts.py
@@ -1,0 +1,451 @@
+"""Tests for generated_artifacts.py — generated-artifact binding audit engine."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import yaml
+
+from lib.pulse.scripts import generated_artifacts as ga
+from lib.pulse.scripts.impact import Finding
+
+
+@dataclass
+class Completed:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+class RecordingRunner:
+    """Fake `runner(argv, cwd) -> Completed` seam."""
+
+    def __init__(self, responses: dict[tuple, Completed] | None = None):
+        self.responses = responses or {}
+        self.calls: list[tuple[tuple, str | None]] = []
+
+    def __call__(self, argv, cwd=None):
+        key = tuple(argv)
+        self.calls.append((key, str(cwd) if cwd is not None else None))
+        return self.responses.get(key, Completed(1, "", f"no fixture for {argv}"))
+
+
+def binding(**overrides):
+    b = {
+        "id": "widget-readme",
+        "source": "hiivmind/template-repo",
+        "branch": "main",
+        "template_path": "templates/repo-readme.md",
+        "template_tree": "tree1111",
+        "generator": "readme-from-template",
+        "files": [{"path": "README.md", "blob": "blob1111"}],
+        "generated_at": "2026-07-10T09:15:00Z",
+    }
+    b.update(overrides)
+    return b
+
+
+def manifest(bindings_list):
+    return {"bindings": bindings_list}
+
+
+def snapshot_for(source="hiivmind/template-repo", branch="main", head="head999",
+                 trees=None, blobs=None):
+    return {
+        source: {
+            branch: {
+                "head": head,
+                "trees": trees or {"templates/repo-readme.md": "tree1111"},
+                "blobs": blobs or {"README.md": "blob1111"},
+            }
+        }
+    }
+
+
+# --- backfill() ---
+
+def test_backfill_resolves_tree_and_blobs_from_snapshot():
+    snap = snapshot_for(
+        trees={"templates/repo-readme.md": "tree2222"},
+        blobs={"README.md": "blob2222"},
+    )
+    inp = binding()
+    del inp["template_tree"]
+    inp["files"] = [{"path": "README.md"}]
+
+    entry = ga.backfill(inp, snap)
+
+    assert entry.id == "widget-readme"
+    assert entry.source == "hiivmind/template-repo"
+    assert entry.branch == "main"
+    assert entry.template_path == "templates/repo-readme.md"
+    assert entry.template_tree == "tree2222"
+    assert entry.files == [ga.GeneratedFile("README.md", "blob2222")]
+
+
+def test_backfill_missing_repo_in_snapshot_fails_closed():
+    inp = binding()
+    del inp["template_tree"]
+    inp["files"] = [{"path": "README.md"}]
+
+    try:
+        ga.backfill(inp, {})
+    except ValueError as exc:
+        assert "hiivmind/template-repo" in str(exc)
+        assert "main" in str(exc)
+    else:
+        raise AssertionError("backfill must raise when repo/branch is missing")
+
+
+def test_backfill_missing_branch_in_snapshot_fails_closed():
+    inp = binding()
+    del inp["template_tree"]
+    inp["files"] = [{"path": "README.md"}]
+    snap = {"hiivmind/template-repo": {"develop": {}}}
+
+    try:
+        ga.backfill(inp, snap)
+    except ValueError as exc:
+        assert "hiivmind/template-repo" in str(exc)
+        assert "main" in str(exc)
+    else:
+        raise AssertionError("backfill must raise when repo/branch is missing")
+
+
+# --- audit(): classification ---
+
+def test_audit_current_tree_same_blobs_same():
+    report = ga.audit(manifest([binding()]), snapshot_for())
+
+    assert len(report.bindings) == 1
+    result = report.bindings[0]
+    assert result.id == "widget-readme"
+    assert result.state == "current"
+    assert result.stored_tree == "tree1111"
+    assert result.snapshot_tree == "tree1111"
+    assert result.files[0].state == "current"
+    assert result.files[0].stored_blob == "blob1111"
+    assert result.files[0].snapshot_blob == "blob1111"
+    assert result.proposal is None
+
+
+def test_audit_current_produces_zero_findings():
+    report = ga.audit(manifest([binding()]), snapshot_for())
+
+    assert report.findings == []
+    assert report.bindings_checked == 1
+    assert report.bindings_drift == 0
+
+
+def test_audit_template_drift_tree_changed_blobs_same():
+    snap = snapshot_for(trees={"templates/repo-readme.md": "tree2222"})
+    report = ga.audit(manifest([binding()]), snap)
+
+    result = report.bindings[0]
+    assert result.state == "template-drift"
+    assert result.snapshot_tree == "tree2222"
+    assert result.files[0].state == "current"
+    assert report.findings == []
+    assert result.proposal is not None
+    assert result.proposal.binding_id == "widget-readme"
+    assert result.proposal.expected_tree == "tree1111"
+    assert result.proposal.new_tree == "tree2222"
+    assert result.proposal.files == [ga.GeneratedFile("README.md", "blob1111")]
+
+
+def test_audit_local_customization_tree_same_blob_changed():
+    snap = snapshot_for(blobs={"README.md": "blob2222"})
+    report = ga.audit(manifest([binding()]), snap)
+
+    result = report.bindings[0]
+    assert result.state == "local-customization"
+    assert result.files[0].state == "changed"
+    assert result.files[0].snapshot_blob == "blob2222"
+    assert result.proposal is None
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.kind == "local_customization"
+    assert finding.repo == "hiivmind/template-repo"
+    assert finding.severity == "medium"
+
+
+def test_audit_conflict_tree_changed_blob_changed():
+    snap = snapshot_for(
+        trees={"templates/repo-readme.md": "tree2222"},
+        blobs={"README.md": "blob2222"},
+    )
+    report = ga.audit(manifest([binding()]), snap)
+
+    result = report.bindings[0]
+    assert result.state == "conflict"
+    assert result.files[0].state == "changed"
+    assert result.proposal is None
+    assert len(report.findings) == 1
+    assert report.findings[0].kind == "conflict"
+    assert report.findings[0].severity == "high"
+
+
+def test_audit_missing_output_error():
+    snap = snapshot_for(blobs={"README.md": ga.ABSENT})
+    report = ga.audit(manifest([binding()]), snap)
+
+    result = report.bindings[0]
+    assert result.state == "error"
+    assert result.files[0].state == "missing"
+    assert result.files[0].snapshot_blob == ga.ABSENT
+    assert result.proposal is None
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.kind == "missing_output"
+    assert finding.severity == "high"
+    assert "README.md" in (finding.detail or "")
+
+
+def test_audit_snapshot_gap_error():
+    report = ga.audit(manifest([binding()]), {})
+
+    result = report.bindings[0]
+    assert result.state == "error"
+    assert result.snapshot_tree is None
+    assert result.proposal is None
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.kind == "snapshot_gap"
+    assert finding.severity == "high"
+    assert "hiivmind/template-repo" in (finding.detail or "")
+    assert "main" in (finding.detail or "")
+
+
+def test_audit_multiple_files_one_missing_one_changed():
+    b = binding(files=[
+        {"path": "README.md", "blob": "blob1111"},
+        {"path": "LICENSE", "blob": "blob2222"},
+    ])
+    snap = snapshot_for(blobs={
+        "README.md": "blob1111",
+        "LICENSE": "blob3333",
+    })
+    report = ga.audit(manifest([b]), snap)
+
+    result = report.bindings[0]
+    assert result.state == "local-customization"
+    assert len(result.files) == 2
+    assert result.files[0].state == "current"
+    assert result.files[1].state == "changed"
+
+
+def test_audit_empty_manifest():
+    report = ga.audit(manifest([]), {})
+
+    assert report.bindings == []
+    assert report.findings == []
+    assert report.bindings_checked == 0
+
+
+# --- advance() ---
+
+def make_manifest_file(tmp_path, bindings_list):
+    path = tmp_path / "generated.yaml"
+    path.write_text(yaml.safe_dump(manifest(bindings_list), sort_keys=False))
+    return path
+
+
+def test_advance_updates_when_expected_matches(tmp_path):
+    path = make_manifest_file(tmp_path, [binding()])
+    new_files = [{"path": "README.md", "blob": "blob2222"}]
+
+    result = ga.advance(
+        path,
+        binding_id="widget-readme",
+        expected_tree="tree1111",
+        new_tree="tree2222",
+        files=new_files,
+        generated_at="2026-07-19T00:00:00Z",
+    )
+
+    assert result.status == "updated"
+    assert result.previous_tree == "tree1111"
+    assert result.new_tree == "tree2222"
+
+    on_disk = yaml.safe_load(path.read_text())
+    b = on_disk["bindings"][0]
+    assert b["template_tree"] == "tree2222"
+    assert b["files"] == new_files
+    assert b["generated_at"] == "2026-07-19T00:00:00Z"
+
+
+def test_advance_conflict_when_expected_mismatches(tmp_path):
+    path = make_manifest_file(tmp_path, [binding()])
+    before = path.read_text()
+
+    result = ga.advance(
+        path,
+        binding_id="widget-readme",
+        expected_tree="wrong-tree",
+        new_tree="tree2222",
+        files=[{"path": "README.md", "blob": "blob2222"}],
+        generated_at="2026-07-19T00:00:00Z",
+    )
+
+    assert result.status == "conflict"
+    assert result.previous_tree == "tree1111"
+    assert path.read_text() == before
+
+
+def test_advance_idempotent_repeat_is_noop(tmp_path):
+    path = make_manifest_file(tmp_path, [binding()])
+    args = dict(
+        binding_id="widget-readme",
+        expected_tree="tree1111",
+        new_tree="tree2222",
+        files=[{"path": "README.md", "blob": "blob2222"}],
+        generated_at="2026-07-19T00:00:00Z",
+    )
+
+    first = ga.advance(path, **args)
+    second = ga.advance(path, **args)
+
+    assert first.status == "updated"
+    assert second.status == "noop"
+    assert second.previous_tree == "tree2222"
+
+    on_disk = yaml.safe_load(path.read_text())
+    assert on_disk["bindings"][0]["template_tree"] == "tree2222"
+
+
+def test_advance_not_found_for_unknown_binding(tmp_path):
+    path = make_manifest_file(tmp_path, [binding()])
+    before = path.read_text()
+
+    result = ga.advance(
+        path,
+        binding_id="unknown-binding",
+        expected_tree="tree1111",
+        new_tree="tree2222",
+        files=[{"path": "README.md", "blob": "blob2222"}],
+        generated_at="2026-07-19T00:00:00Z",
+    )
+
+    assert result.status == "not_found"
+    assert path.read_text() == before
+
+
+def test_advance_preserves_other_bindings(tmp_path):
+    other = binding(id="other-binding", template_tree="tree9999")
+    path = make_manifest_file(tmp_path, [binding(), other])
+
+    ga.advance(
+        path,
+        binding_id="widget-readme",
+        expected_tree="tree1111",
+        new_tree="tree2222",
+        files=[{"path": "README.md", "blob": "blob2222"}],
+        generated_at="2026-07-19T00:00:00Z",
+    )
+
+    on_disk = yaml.safe_load(path.read_text())
+    bindings = on_disk["bindings"]
+    assert bindings[0]["template_tree"] == "tree2222"
+    assert bindings[1]["template_tree"] == "tree9999"
+
+
+# --- collect() ---
+
+def test_collect_happy_path(tmp_path):
+    b = binding()
+    repo_dir = tmp_path / "work" / "hiivmind_template-repo_main"
+    url = "https://github.com/hiivmind/template-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): Completed(0, "", ""),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "main"): Completed(0, "", ""),
+        ("git", "rev-parse", "FETCH_HEAD"): Completed(0, "head999\n", ""),
+        ("git", "rev-parse", "FETCH_HEAD:templates/repo-readme.md"): Completed(0, "tree1111\n", ""),
+        ("git", "rev-parse", "FETCH_HEAD:README.md"): Completed(0, "blob1111\n", ""),
+    })
+
+    result = ga.collect(manifest([b]), workdir=tmp_path / "work", runner=runner)
+
+    assert result == {
+        "hiivmind/template-repo": {
+            "main": {
+                "head": "head999",
+                "trees": {"templates/repo-readme.md": "tree1111"},
+                "blobs": {"README.md": "blob1111"},
+            }
+        }
+    }
+
+
+def test_collect_missing_path_records_absent(tmp_path):
+    b = binding()
+    repo_dir = tmp_path / "work" / "hiivmind_template-repo_main"
+    url = "https://github.com/hiivmind/template-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): Completed(0, "", ""),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "main"): Completed(0, "", ""),
+        ("git", "rev-parse", "FETCH_HEAD"): Completed(0, "head999\n", ""),
+        ("git", "rev-parse", "FETCH_HEAD:templates/repo-readme.md"): Completed(0, "tree1111\n", ""),
+        ("git", "rev-parse", "FETCH_HEAD:README.md"): Completed(128, "", "fatal: Not a valid object name"),
+    })
+
+    result = ga.collect(manifest([b]), workdir=tmp_path / "work", runner=runner)
+
+    assert result["hiivmind/template-repo"]["main"]["blobs"]["README.md"] == ga.ABSENT
+
+
+def test_collect_fetch_failure_records_head_none(tmp_path):
+    b = binding()
+    repo_dir = tmp_path / "work" / "hiivmind_template-repo_main"
+    url = "https://github.com/hiivmind/template-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): Completed(0, "", ""),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "main"): Completed(128, "", "fatal"),
+    })
+
+    result = ga.collect(manifest([b]), workdir=tmp_path / "work", runner=runner)
+
+    branch_snap = result["hiivmind/template-repo"]["main"]
+    assert branch_snap["head"] is None
+    assert branch_snap["trees"] == {}
+    assert branch_snap["blobs"] == {}
+
+
+def test_collect_groups_bindings_by_repo_branch_single_fetch(tmp_path):
+    b1 = binding(id="widget-readme")
+    b2 = binding(id="widget-ci", files=[{"path": ".github/workflows/ci.yml", "blob": "blob2222"}])
+    repo_dir = tmp_path / "work" / "hiivmind_template-repo_main"
+    url = "https://github.com/hiivmind/template-repo.git"
+    runner = RecordingRunner({
+        ("git", "init", "--bare", "-q", str(repo_dir)): Completed(0, "", ""),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", url, "main"): Completed(0, "", ""),
+        ("git", "rev-parse", "FETCH_HEAD"): Completed(0, "head999\n", ""),
+        ("git", "rev-parse", "FETCH_HEAD:templates/repo-readme.md"): Completed(0, "tree1111\n", ""),
+        ("git", "rev-parse", "FETCH_HEAD:README.md"): Completed(0, "blob1111\n", ""),
+        ("git", "rev-parse", "FETCH_HEAD:.github/workflows/ci.yml"): Completed(0, "blob2222\n", ""),
+    })
+
+    ga.collect(manifest([b1, b2]), workdir=tmp_path / "work", runner=runner)
+
+    fetch_calls = [c for c in runner.calls if c[0][1] == "fetch"]
+    assert len(fetch_calls) == 1
+
+
+def test_collect_invalid_branch_never_invokes_fetch():
+    b = binding(branch="-evil")
+    runner = RecordingRunner()
+
+    result = ga.collect(manifest([b]), runner=runner)
+
+    branch_snap = result["hiivmind/template-repo"]["-evil"]
+    assert branch_snap["head"] is None
+    assert branch_snap["trees"] == {}
+    assert branch_snap["blobs"] == {}
+    fetch_calls = [c for c in runner.calls if c[0][1] == "fetch"]
+    assert fetch_calls == []
+
+
+def test_collect_empty_manifest():
+    runner = RecordingRunner()
+    result = ga.collect(manifest([]), runner=runner)
+
+    assert result == {}
+    assert runner.calls == []

--- a/lib/pulse/scripts/tests/test_generator_dispatch.py
+++ b/lib/pulse/scripts/tests/test_generator_dispatch.py
@@ -1,0 +1,319 @@
+"""Tests for generator adapter dispatch.
+
+Task 3 registers GENERATOR adapters and routes a drifted generated-artifact
+binding into an F6 Nave mutation `Proposal`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from lib.pulse.scripts import generator_dispatch, mutation_plan, nave_adapter, pen_orchestrator
+from lib.pulse.scripts.profile_dispatch import RepositoryProfile
+
+
+@pytest.fixture
+def registry():
+    return mutation_plan.load_registry(
+        {
+            "transformations": {
+                "regenerate-from-template": {
+                    "id": "regenerate-from-template",
+                    "command_argv": ["nave", "generate", "--from-template"],
+                    "applies_to": ["always"],
+                    "validation": {"kind": "none"},
+                    "allow_scheduled": False,
+                }
+            }
+        }
+    )
+
+
+@pytest.fixture
+def generator_data():
+    return {
+        "id": "readme-from-template",
+        "applies_to": ["always"],
+        "transformation": "regenerate-from-template",
+        "source_paths": ["templates/repo-readme.md"],
+        "output_paths": ["README.md", "docs/**/*.md"],
+        "validation": {"kind": "none"},
+    }
+
+
+@pytest.fixture
+def binding():
+    return {
+        "id": "widget-readme",
+        "source": "hiivmind/template-repo",
+        "branch": "main",
+        "files": [{"path": "README.md"}],
+    }
+
+
+@pytest.fixture
+def snapshot():
+    return {
+        "hiivmind/template-repo": {
+            "main": {"head": "abc1234"},
+        }
+    }
+
+
+@pytest.fixture
+def actor():
+    return {"gh_login": "octocat", "machine": "laptop", "mode": "interactive"}
+
+
+# --- helpers copied/condensed from test_pen_orchestrator.py ------------------
+
+
+class QueuedRunner:
+    def __init__(self, results):
+        self.calls = []
+        self._results = list(results)
+
+    def run(self, args):
+        self.calls.append(args)
+        return self._results.pop(0)
+
+
+def _repo_state(owner, repo, working_tree="clean", freshness="fresh", divergence="up-to-date"):
+    return {
+        "owner": owner,
+        "repo": repo,
+        "working_tree": working_tree,
+        "freshness": freshness,
+        "divergence": divergence,
+    }
+
+
+def _pen_show_completed(repo_tuple):
+    owner, repo = repo_tuple
+    payload = {
+        "name": "nave/widget-readme",
+        "created_at": "2026-07-15T10:00:00Z",
+        "branch": "nave/widget-readme",
+        "filter": {"terms": []},
+        "repos": [
+            {
+                "owner": owner,
+                "name": repo,
+                "default_branch": "main",
+                "clone_url": "x",
+                "synced_at": "2026-07-15T10:00:00Z",
+            }
+        ],
+        "ops": [],
+    }
+    return nave_adapter.Completed(0, json.dumps(payload), "")
+
+
+def _clean_preflight_sequence(repo_tuple):
+    return [
+        nave_adapter.Completed(0, "created\n", ""),
+        _pen_show_completed(repo_tuple),
+        nave_adapter.Completed(
+            0,
+            json.dumps([_repo_state(repo_tuple[0], repo_tuple[1])]),
+            "",
+        ),
+    ]
+
+
+# --- load_generators ---------------------------------------------------------
+
+
+def test_load_generators_returns_generator_objects(registry, generator_data):
+    generators = generator_dispatch.load_generators(
+        {"readme-from-template": generator_data}, registry
+    )
+
+    assert set(generators) == {"readme-from-template"}
+    gen = generators["readme-from-template"]
+    assert isinstance(gen, generator_dispatch.Generator)
+    assert gen.id == "readme-from-template"
+    assert gen.transformation == "regenerate-from-template"
+    assert gen.output_paths == ("README.md", "docs/**/*.md")
+    assert gen.validation.kind == "none"
+
+
+def test_load_generators_unknown_transformation_raises(registry):
+    data = {
+        "bad": {
+            "id": "bad",
+            "applies_to": ["always"],
+            "transformation": "not-a-real-transformation",
+            "source_paths": ["x"],
+            "output_paths": ["x"],
+            "validation": {"kind": "none"},
+        }
+    }
+
+    with pytest.raises(mutation_plan.MutationPlanError) as exc:
+        generator_dispatch.load_generators(data, registry)
+
+    assert "not-a-real-transformation" in str(exc.value)
+
+
+@pytest.mark.parametrize("bad_key", ["command", "command_argv"])
+def test_load_generators_rejects_shell_string_command(registry, generator_data, bad_key):
+    generator_data[bad_key] = "echo pwned" if bad_key == "command" else ["echo", "pwned"]
+
+    with pytest.raises(mutation_plan.MutationPlanError) as exc:
+        generator_dispatch.load_generators(
+            {"readme-from-template": generator_data}, registry
+        )
+
+    assert bad_key in str(exc.value)
+    assert "registry" in str(exc.value).lower()
+
+
+def test_load_generators_empty_output_paths_raises(registry):
+    data = {
+        "empty": {
+            "id": "empty",
+            "applies_to": ["always"],
+            "transformation": "regenerate-from-template",
+            "source_paths": ["x"],
+            "output_paths": [],
+            "validation": {"kind": "none"},
+        }
+    }
+
+    with pytest.raises(mutation_plan.MutationPlanError) as exc:
+        generator_dispatch.load_generators(data, registry)
+
+    assert "output_paths" in str(exc.value)
+
+
+# --- dispatch ----------------------------------------------------------------
+
+
+def test_dispatch_explicit_selection_happy_path(
+    registry, generator_data, binding, snapshot, actor
+):
+    gen = generator_dispatch.load_generators(
+        {"readme-from-template": generator_data}, registry
+    )["readme-from-template"]
+
+    proposal = generator_dispatch.dispatch(gen, binding, snapshot, actor)
+
+    assert isinstance(proposal, mutation_plan.Proposal)
+    assert proposal.id == "generate-readme-from-template-widget-readme"
+    assert proposal.selection == ("hiivmind/template-repo",)
+    assert proposal.expected_shas == {"hiivmind/template-repo": "abc1234"}
+    assert proposal.transformation == "regenerate-from-template"
+    assert proposal.mutation_policy == "propose"
+    assert proposal.actor.gh_login == "octocat"
+
+
+def test_dispatch_rejects_binding_file_outside_allowlist(
+    registry, generator_data, binding, snapshot, actor
+):
+    binding["files"].append({"path": ".github/workflows/ci.yml"})
+    gen = generator_dispatch.load_generators(
+        {"readme-from-template": generator_data}, registry
+    )["readme-from-template"]
+
+    with pytest.raises(mutation_plan.MutationPlanError) as exc:
+        generator_dispatch.dispatch(gen, binding, snapshot, actor)
+
+    assert ".github/workflows/ci.yml" in str(exc.value)
+    assert "allowlist" in str(exc.value).lower() or "output_paths" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "missing_snapshot",
+    [
+        {},
+        {"hiivmind/template-repo": {}},
+        {"hiivmind/template-repo": {"main": {"head": None}}},
+    ],
+)
+def test_dispatch_fails_closed_when_snapshot_head_missing(
+    registry, generator_data, binding, actor, missing_snapshot
+):
+    gen = generator_dispatch.load_generators(
+        {"readme-from-template": generator_data}, registry
+    )["readme-from-template"]
+
+    with pytest.raises(mutation_plan.MutationPlanError) as exc:
+        generator_dispatch.dispatch(gen, binding, missing_snapshot, actor)
+
+    assert "hiivmind/template-repo" in str(exc.value)
+
+
+# --- generator_applies -------------------------------------------------------
+
+
+def test_generator_applies_profile_mismatch_returns_false(registry, generator_data):
+    generator_data["applies_to"] = ["profile:python"]
+    gen = generator_dispatch.load_generators(
+        {"readme-from-template": generator_data}, registry
+    )["readme-from-template"]
+
+    repository = RepositoryProfile(profiles=("nodejs",), scorecard="default")
+
+    assert generator_dispatch.generator_applies(gen, repository, {}) is False
+
+
+def test_generator_applies_profile_match_returns_true(registry, generator_data):
+    generator_data["applies_to"] = ["profile:python"]
+    gen = generator_dispatch.load_generators(
+        {"readme-from-template": generator_data}, registry
+    )["readme-from-template"]
+
+    repository = RepositoryProfile(profiles=("python",), scorecard="default")
+
+    assert generator_dispatch.generator_applies(gen, repository, {}) is True
+
+
+# --- round-trip through pen_orchestrator.execute ------------------------------
+
+
+def test_dispatched_proposal_passes_pen_orchestrator_expected_sha_guard(
+    registry, generator_data, binding, snapshot, actor, monkeypatch
+):
+    gen = generator_dispatch.load_generators(
+        {"readme-from-template": generator_data}, registry
+    )["readme-from-template"]
+    proposal = generator_dispatch.dispatch(gen, binding, snapshot, actor)
+    entry = registry.get("regenerate-from-template")
+
+    plan = pen_orchestrator.PenPlan(
+        proposal=proposal,
+        entry=entry,
+        pen_name="nave/widget-readme",
+        query=nave_adapter.PenQuery(terms=["owner:hiivmind/template-repo"]),
+    )
+
+    def fake_probe(_runner):
+        return {"available": True, "version": "0.0.8", "protocol": 1}
+
+    monkeypatch.setattr(pen_orchestrator.nave_adapter, "probe", fake_probe)
+
+    repo_tuple = ("hiivmind", "template-repo")
+    runner = QueuedRunner(
+        [
+            *_clean_preflight_sequence(repo_tuple),
+            nave_adapter.Completed(0, "ran ok", ""),
+            nave_adapter.Completed(
+                0,
+                json.dumps([_repo_state(repo_tuple[0], repo_tuple[1])]),
+                "",
+            ),
+        ]
+    )
+
+    def matching_head(repo):
+        assert repo == "hiivmind/template-repo"
+        return "abc1234"
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=matching_head)
+
+    assert result.state == "proposed"
+    assert result.proposal_id == "generate-readme-from-template-widget-readme"
+    assert result.repo_outcomes == {"hiivmind/template-repo": "ok"}

--- a/lib/pulse/scripts/tests/test_impact.py
+++ b/lib/pulse/scripts/tests/test_impact.py
@@ -301,6 +301,106 @@ def test_empty_relationships_produce_empty_report():
     assert report.edges_stale == 0
 
 
+# --- audit(): contract-version composition ---
+
+def contract(**overrides):
+    c = {
+        "producer": {
+            "path": "producer.txt",
+            "parser": {"kind": "regex", "pattern": r"version:\s*(\S+)"},
+        },
+        "consumer": {
+            "path": "consumer.txt",
+            "parser": {"kind": "regex", "pattern": r"requires:\s*(\S+)"},
+        },
+        "version_scheme": "pep440",
+    }
+    c.update(overrides)
+    return c
+
+
+def fake_contract_reader(files):
+    def read(repo, path):
+        return files[(repo, path)]
+    return read
+
+
+def test_contract_state_set_when_reader_supplied():
+    rel = relationships([edge(contract=contract())])
+    snap = snapshot_for(changed_files_by_base={"base111": []})
+    files = {
+        ("upstream-repo", "producer.txt"): b"version: 1.5.0",
+        ("upstream-repo", "consumer.txt"): b"requires: >=1.0,<2.0",
+    }
+    report = audit(rel, snap, contract_reader=fake_contract_reader(files))
+
+    result = report.edges[0]
+    assert result.state == "current"
+    assert result.contract_state == "compatible"
+    assert report.findings == []
+
+
+def test_contract_state_set_to_gap_when_versions_diverge():
+    rel = relationships([edge(contract=contract())])
+    snap = snapshot_for(changed_files_by_base={"base111": []})
+    files = {
+        ("upstream-repo", "producer.txt"): b"version: 2.5.0",
+        ("upstream-repo", "consumer.txt"): b"requires: >=1.0,<2.0",
+    }
+    report = audit(rel, snap, contract_reader=fake_contract_reader(files))
+
+    assert report.edges[0].contract_state == "gap"
+
+
+def test_stale_edge_with_contract_gap_emits_one_finding():
+    rel = relationships([edge(watch_paths=["lib/foo.py"], contract=contract())])
+    snap = snapshot_for(changed_files_by_base={"base111": ["lib/foo.py"]})
+    files = {
+        ("upstream-repo", "producer.txt"): b"version: 2.5.0",
+        ("upstream-repo", "consumer.txt"): b"requires: >=1.0,<2.0",
+    }
+    report = audit(rel, snap, contract_reader=fake_contract_reader(files))
+
+    result = report.edges[0]
+    assert result.state == "stale"
+    assert result.contract_state == "gap"
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.kind == "stale_with_contract_gap"
+    assert finding.repo == "dependent-repo"
+    assert finding.severity == "high"
+    assert "path stale" in finding.detail.lower()
+    assert "contract gap" in finding.detail.lower()
+
+
+def test_contract_block_without_reader_is_unknown_and_finding():
+    rel = relationships([edge(contract=contract())])
+    snap = snapshot_for(changed_files_by_base={"base111": []})
+
+    report = audit(rel, snap)
+
+    result = report.edges[0]
+    assert result.state == "current"
+    assert result.contract_state == "unknown"
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.kind == "unevaluated_contract"
+    assert finding.repo == "dependent-repo"
+    assert finding.severity == "low"
+
+
+def test_non_contract_edges_unchanged():
+    rel = relationships([edge()])
+    snap = snapshot_for(changed_files_by_base={"base111": []})
+
+    report = audit(rel, snap)
+
+    result = report.edges[0]
+    assert result.state == "current"
+    assert result.contract_state is None
+    assert report.findings == []
+
+
 # --- mark(): expected-base guarded, idempotent, atomic marker patch ---
 
 def make_relationships_file(tmp_path, depends_on):

--- a/lib/pulse/scripts/tests/test_impact.py
+++ b/lib/pulse/scripts/tests/test_impact.py
@@ -1,9 +1,15 @@
 """Tests for impact.py — pure path-scoped integration-currency audit."""
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
 import yaml
 
 from lib.pulse.scripts.impact import audit, apply_proposals, mark, propose_marks
+
+
+SPLIT_REPO_OVERLAY = Path("templates/relationships/split-repo-tests.yaml")
 
 
 def relationships(depends_on):
@@ -658,3 +664,79 @@ def test_mark_preserves_other_edges_and_sections(tmp_path):
     edges = on_disk["repo_dependencies"]["dependent-repo"]["depends_on"]
     other = next(e for e in edges if e["repo"] == "other-upstream")
     assert other["integration_tested_sha"] == "untouched"
+
+
+# --- Split-repo binding (configuration over existing F5 machinery) ---
+
+@pytest.fixture
+def split_repo_overlay():
+    return yaml.safe_load(SPLIT_REPO_OVERLAY.read_text())
+
+
+def test_split_repo_full_tree_edge_goes_stale_on_any_change(split_repo_overlay):
+    base_sha = "0000000000000000000000000000000000000000"
+    snap = {
+        "hiivmind-pulse-gh": {
+            "develop": {
+                "head": "head999",
+                "changed_files_by_base": {
+                    base_sha: [
+                        "lib/pulse/scripts/impact.py",
+                        "docs/readme.md",
+                    ],
+                },
+                "base_missing": [],
+            }
+        }
+    }
+
+    report = audit(split_repo_overlay, snap)
+
+    assert len(report.edges) == 1
+    result = report.edges[0]
+    assert result.dependent == "hiivmind-pulse-gh-tests"
+    assert result.upstream == "hiivmind-pulse-gh"
+    assert result.watch_branch == "develop"
+    assert result.state == "stale"
+    assert result.tested_sha == base_sha
+    assert result.remote_head == "head999"
+    # Full-tree "**" watch matches arbitrary paths in any part of the tree.
+    assert "lib/pulse/scripts/impact.py" in result.changed_paths
+    assert "docs/readme.md" in result.changed_paths
+
+
+def test_split_repo_successful_workflow_advances_marker(split_repo_overlay, tmp_path):
+    base_sha = "0000000000000000000000000000000000000000"
+    new_sha = "abc1234def5678abc1234def5678abc1234def56"
+    tested_at = "2026-07-20T12:00:00Z"
+
+    proposals = propose_marks(split_repo_overlay, [
+        run_evidence(
+            workflow="ci.yml",
+            repo="hiivmind-pulse-gh",
+            outcome="success",
+            head_sha=new_sha,
+            tested_at=tested_at,
+        )
+    ])
+
+    assert len(proposals) == 1
+    proposal = proposals[0]
+    assert proposal.dependent == "hiivmind-pulse-gh-tests"
+    assert proposal.upstream == "hiivmind-pulse-gh"
+    assert proposal.expected_sha == base_sha
+    assert proposal.new_sha == new_sha
+    assert proposal.tested_at == tested_at
+
+    path = tmp_path / "relationships.yaml"
+    path.write_text(yaml.safe_dump(split_repo_overlay, sort_keys=False))
+    results = apply_proposals(path, proposals)
+
+    assert len(results) == 1
+    assert results[0].status == "updated"
+    assert results[0].new_sha == new_sha
+
+    on_disk = yaml.safe_load(path.read_text())
+    written_edge = on_disk["repo_dependencies"]["hiivmind-pulse-gh-tests"]["depends_on"][0]
+    assert written_edge["integration_tested_sha"] == new_sha
+    assert written_edge["tested_at"] == tested_at

--- a/lib/pulse/scripts/tests/test_impact.py
+++ b/lib/pulse/scripts/tests/test_impact.py
@@ -389,6 +389,22 @@ def test_contract_block_without_reader_is_unknown_and_finding():
     assert finding.severity == "low"
 
 
+def test_empty_watch_paths_and_contract_no_reader_emits_both_findings():
+    rel = relationships([edge(watch_paths=[], contract=contract())])
+    snap = snapshot_for(changed_files_by_base={"base111": []})
+
+    report = audit(rel, snap)
+
+    result = report.edges[0]
+    assert result.state == "unknown"
+    assert result.contract_state == "unknown"
+
+    kinds = [f.kind for f in report.findings]
+    assert "empty_watch_paths" in kinds
+    assert "unevaluated_contract" in kinds
+    assert len(report.findings) == 2
+
+
 def test_non_contract_edges_unchanged():
     rel = relationships([edge()])
     snap = snapshot_for(changed_files_by_base={"base111": []})

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -17,7 +17,7 @@ SCRIPT = "lib/pulse/scripts/validate_result.py"
 FIXTURES = Path("lib/pulse/scripts/tests/fixtures")
 KINDS = [
     "status", "healthcheck", "refresh", "workflow-run", "fleet-membership",
-    "impact", "repo-mutation",
+    "impact", "repo-mutation", "generated-artifact",
 ]
 
 
@@ -781,3 +781,149 @@ def test_impact_legacy_string_edge_surfaces_as_unconfigured_finding(tmp_path):
     result = run_validator(path, "impact")
 
     assert result.returncode == 0, result.stderr
+
+
+def test_generated_artifact_rejects_invalid_state(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "generated-artifact-valid.yaml").read_text())
+    doc["states"]["binding-1"] = "broken"
+    path = tmp_path / "generated-artifact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "generated-artifact")
+
+    assert result.returncode == 1
+    assert "states.binding-1 invalid: broken" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "state",
+    ["current", "template-drift", "local-customization", "conflict", "error"],
+)
+def test_generated_artifact_accepts_exact_states(tmp_path, state):
+    doc = yaml.safe_load((FIXTURES / "generated-artifact-valid.yaml").read_text())
+    doc["states"]["binding-1"] = state
+    if state == "template-drift":
+        doc["proposals"] = [
+            {"binding": "binding-1", "transformation": "t", "proposal_id": "p"}
+        ]
+    path = tmp_path / "generated-artifact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "generated-artifact")
+
+    assert result.returncode == 0, result.stderr
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "bindings_audited", "states", "findings", "proposals",
+    ],
+)
+def test_generated_artifact_requires_field(tmp_path, field):
+    doc = yaml.safe_load((FIXTURES / "generated-artifact-valid.yaml").read_text())
+    doc.pop(field)
+    path = tmp_path / "generated-artifact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "generated-artifact")
+
+    assert result.returncode == 1
+    assert f"missing required key: {field}" in result.stderr
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("bindings_audited", "not-an-int"),
+        ("states", "not-a-mapping"),
+        ("findings", "not-a-list"),
+        ("proposals", "not-a-list"),
+    ],
+)
+def test_generated_artifact_rejects_wrong_type(tmp_path, field, value):
+    doc = yaml.safe_load((FIXTURES / "generated-artifact-valid.yaml").read_text())
+    doc[field] = value
+    path = tmp_path / "generated-artifact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "generated-artifact")
+
+    assert result.returncode == 1
+
+
+@pytest.mark.parametrize(
+    ("index", "mutation"),
+    [
+        (0, {"binding": 1, "transformation": "t", "proposal_id": "p"}),
+        (0, {"binding": "b", "transformation": 1, "proposal_id": "p"}),
+        (0, {"binding": "b", "transformation": "t", "proposal_id": 1}),
+    ],
+)
+def test_generated_artifact_proposals_require_string_fields(tmp_path, index, mutation):
+    doc = yaml.safe_load((FIXTURES / "generated-artifact-valid.yaml").read_text())
+    doc["proposals"][index] = mutation
+    path = tmp_path / "generated-artifact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "generated-artifact")
+
+    assert result.returncode == 1
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        {"binding": "b", "transformation": "t"},
+        {"binding": "b", "proposal_id": "p"},
+        {"transformation": "t", "proposal_id": "p"},
+    ],
+)
+def test_generated_artifact_proposals_require_all_keys(tmp_path, mutation):
+    doc = yaml.safe_load((FIXTURES / "generated-artifact-valid.yaml").read_text())
+    doc["proposals"] = [mutation]
+    path = tmp_path / "generated-artifact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "generated-artifact")
+
+    assert result.returncode == 1
+
+
+def test_generated_artifact_rejects_negative_bindings_audited(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "generated-artifact-valid.yaml").read_text())
+    doc["bindings_audited"] = -1
+    path = tmp_path / "generated-artifact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "generated-artifact")
+
+    assert result.returncode == 1
+    assert "bindings_audited must be a non-negative integer" in result.stderr
+
+
+def test_generated_artifact_rejects_non_string_state_keys(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "generated-artifact-valid.yaml").read_text())
+    doc["states"] = {1: "current"}
+    path = tmp_path / "generated-artifact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "generated-artifact")
+
+    assert result.returncode == 1
+    assert "states keys must be strings" in result.stderr
+
+
+def test_generated_artifact_invalid_fixture_reports_every_violation(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "generated-artifact-invalid.yaml").read_text())
+    path = tmp_path / "generated-artifact.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "generated-artifact")
+
+    assert result.returncode == 1
+    assert "missing required key: actor" in result.stderr
+    assert "missing required key: bindings_audited" in result.stderr
+    assert "states.binding-2 invalid: exploded" in result.stderr
+    assert "findings[0].severity" in result.stderr
+    assert "missing required key: proposals[0].proposal_id" in result.stderr

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -817,7 +817,7 @@ def test_generated_artifact_accepts_exact_states(tmp_path, state):
 @pytest.mark.parametrize(
     "field",
     [
-        "bindings_audited", "states", "findings", "proposals",
+        "bindings_audited", "states", "findings", "proposals", "proposed_actions",
     ],
 )
 def test_generated_artifact_requires_field(tmp_path, field):
@@ -839,6 +839,7 @@ def test_generated_artifact_requires_field(tmp_path, field):
         ("states", "not-a-mapping"),
         ("findings", "not-a-list"),
         ("proposals", "not-a-list"),
+        ("proposed_actions", "not-a-list"),
     ],
 )
 def test_generated_artifact_rejects_wrong_type(tmp_path, field, value):

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -40,6 +40,13 @@ SEVERITIES = {"low", "medium", "high"}
 EDGE_STATES = {"current", "stale", "unknown"}
 REPO_MUTATION_STATES = {"proposed", "blocked", "failed"}
 REPO_OUTCOME_STATES = {"ok", "failed", "blocked"}
+GENERATED_ARTIFACT_STATES = {
+    "current",
+    "template-drift",
+    "local-customization",
+    "conflict",
+    "error",
+}
 
 
 def _err(errors, msg):
@@ -533,6 +540,25 @@ def validate(data, kind: str) -> list[str]:
         if state in {"blocked", "failed"} and data.get("reason") is None:
             _err(errors, "reason must not be null when state is blocked or failed")
 
+    elif kind == "generated-artifact":
+        _require_nonnegative_integer(data, "bindings_audited", errors)
+        states = _require(data, "states", dict, errors)
+        for binding_id, state in (states or {}).items():
+            if not isinstance(binding_id, str):
+                _err(errors, "states keys must be strings")
+            if state not in GENERATED_ARTIFACT_STATES:
+                _err(errors, f"states.{binding_id} invalid: {state}")
+        _validate_findings(data, errors)
+        proposals = _require(data, "proposals", list, errors)
+        for index, proposal in enumerate(proposals or []):
+            if not isinstance(proposal, dict):
+                _err(errors, f"proposals[{index}] is not a mapping")
+                continue
+            ctx = f"proposals[{index}]."
+            _require(proposal, "binding", str, errors, ctx=ctx)
+            _require(proposal, "transformation", str, errors, ctx=ctx)
+            _require(proposal, "proposal_id", str, errors, ctx=ctx)
+
     return errors
 
 
@@ -541,7 +567,8 @@ def main():
     parser.add_argument("file", help="Path to result YAML file")
     parser.add_argument("--kind", required=True,
                         choices=["status", "healthcheck", "refresh", "workflow-run",
-                                 "fleet-membership", "impact", "repo-mutation"])
+                                 "fleet-membership", "impact", "repo-mutation",
+                                 "generated-artifact"])
     args = parser.parse_args()
 
     path = Path(args.file)

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -558,6 +558,7 @@ def validate(data, kind: str) -> list[str]:
             _require(proposal, "binding", str, errors, ctx=ctx)
             _require(proposal, "transformation", str, errors, ctx=ctx)
             _require(proposal, "proposal_id", str, errors, ctx=ctx)
+        _require(data, "proposed_actions", list, errors)
 
     return errors
 

--- a/skills/gh-generated-artifact-headless/SKILL.md
+++ b/skills/gh-generated-artifact-headless/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: gh-generated-artifact-headless
+description: >
+  Headless generated-artifact binding audit over committed template bindings
+  (F7). Collects remote template and output-file evidence, classifies each
+  configured binding as current, template-drift, local-customization, conflict,
+  or error, and records regeneration proposals for template-drift bindings.
+  Writes a validated generated-artifact-result.yaml. Zero prompts; explicit
+  inputs only. Never applies mutations itself — F6 pen runs are propose-only.
+  Use when a scheduler audits generated files, or a release gate needs
+  template-drift evidence.
+---
+
+# Headless Generated Artifact Audit
+
+Audit whether each generated-artifact binding is still current against the
+remote source template and the recorded output blobs. Drift and customization are
+computed purely from remote evidence, never from the local working tree of the
+caller. The skill records findings and regeneration proposals; it does not write
+`generated.yaml` or dispatch actual mutations.
+
+`{PLUGIN_ROOT}` is the directory containing `plugin.json`.
+
+## Inputs and outputs
+
+- `workspace_path` (required): absolute workspace root containing `.hiivmind/github/`.
+- `repo` (optional): a repository full or short name; narrows the audit to
+  bindings whose `source` or generated output path matches that repo. Defaults to
+  every configured binding.
+- `result_path` (optional): workspace default when usable, otherwise
+  `./generated-artifact-result.yaml`.
+- `mode` (optional): `interactive` or `scheduled`; defaults to `scheduled`.
+- Result: validated `generated-artifact-result.yaml` with kind `generated-artifact`
+  (`lib/patterns/headless-contract.md` § generated-artifact-result.yaml).
+
+## Contract
+
+- Zero prompts. Explicit inputs only. Every exit writes a result file.
+- Read-only against GitHub and against the generation manifest: this skill never
+  writes `generated.yaml` markers and never applies generated files. Drift
+  bindings become `proposals` entries — typed records an orchestrator or human
+  reviews before acting.
+- F6 pen orchestration used here is always `propose-only`. The skill may route a
+  `template-drift` binding through `pen_orchestrator.execute`, but only with a
+  `mutation_policy` of `propose`; a push/commit is never requested.
+- Missing or unreachable source branches, templates, or output blobs block
+  closed: a binding that cannot be resolved is `state: error`, not `current`.
+  This mirrors `generated_artifacts.audit()`'s own fail-closed rule; the skill
+  copies the audit engine's verdict into the result unchanged.
+- Severity on any finding this skill adds is deterministic, `inferred: false`.
+  No LLM judgment pass runs here.
+
+## State
+
+Determine `RESULT_PATH` before validating the workspace: explicit `result_path`;
+otherwise the workspace default when `workspace_path` is non-empty and usable;
+otherwise `./generated-artifact-result.yaml` in the current directory. This
+fallback must be available for every early ABORT to write and validate its result.
+
+```text
+CONFIG_DIR      = {workspace_path}/.hiivmind/github
+MANIFEST        = CONFIG_DIR/generated.yaml
+RESULT_PATH     = {explicit result_path, workspace default, or current-directory fallback}
+LOGIN           = unknown
+RUN_AT          = current UTC timestamp
+MODE            = {mode, default scheduled}
+ERRORS          = []
+PROPOSALS       = []
+PROPOSED_ACTIONS = []
+```
+
+## Phase 1: VALIDATE
+
+1. Missing `workspace_path` → ABORT `"missing required input: workspace_path"`.
+2. Missing `CONFIG_DIR/config.yaml` or its top-level `workspace` → ABORT
+   `"not a workspace root: {workspace_path}"`.
+3. After config validation succeeds, replace `LOGIN` with the authoritative
+   `.workspace.login` value from `CONFIG_DIR/config.yaml`.
+4. Ensure `*-result.yaml` is present in `CONFIG_DIR/.gitignore`.
+5. Missing `MANIFEST` → ABORT `"generated.yaml not found: {MANIFEST}"` (a
+   generated-artifact audit with no manifest has nothing to audit; this is a
+   workspace setup gap, not a valid empty run).
+6. Load `MANIFEST`. When `repo` is given, resolve it against binding `source`
+   values and generated file repo paths; build `PREPARED_MANIFEST`, a temporary
+   copy whose `bindings` contains only the matching entries. An unresolvable
+   `repo` → ABORT `"unknown repo: {repo}"`. Otherwise `PREPARED_MANIFEST` is
+   `MANIFEST` unchanged.
+
+## Phase 2: SNAPSHOT
+
+Collect remote evidence for every binding in `PREPARED_MANIFEST`. For each
+binding, fetch the current source repo/branch and resolve the template tree SHA
+and every recorded output blob SHA.
+
+**See:** `lib/patterns/generation-manifest.md`,
+`lib/pulse/scripts/generated_artifacts.py`
+
+Call `generated_artifacts.collect(PREPARED_MANIFEST)` to produce the snapshot.
+A collector failure (non-zero exit, e.g. no network) → append its stderr to
+`ERRORS` and continue to Phase 3 with whatever partial snapshot it produced (or
+`{}` if it produced none). A collection gap on one binding still lets the audit
+engine mark that binding `error` per its own fail-closed rule, rather than
+aborting the whole run.
+
+## Phase 3: AUDIT
+
+Classify every binding in `PREPARED_MANIFEST` against the collected snapshot.
+This is the pure engine — no network, no git commands, no arithmetic in this
+skill:
+
+**See:** `lib/pulse/scripts/generated_artifacts.py`
+
+Call `generated_artifacts.audit(PREPARED_MANIFEST, SNAPSHOT)` and copy the
+returned report fields verbatim: `bindings`, `bindings_checked`,
+`bindings_drift`, and `findings`. The skill does not recompute these values.
+
+## Phase 4: CONFLICT/PROPOSE
+
+For each binding result from the audit engine:
+
+- `state: current` → no finding, no proposal.
+- `state: template-drift` → build a regeneration proposal. Look up the binding's
+  `generator` id in the loaded generator registry, verify the generator applies to
+  the binding's repository, then call `generator_dispatch.dispatch(...)` to
+  produce a `mutation_plan.Proposal`. Route that proposal through
+  `pen_orchestrator.execute(...)` with `mutation_policy: propose` only.
+
+  **Scheduled gating:** Under mode: scheduled, a generator whose transformation
+  has allow_scheduled: false MUST NOT be dispatched — record the drift as a
+  `proposed_action`/finding requiring human approval. Only allow_scheduled: true
+  transformations may be dispatched unattended. `generator_dispatch.dispatch`
+  does not check the registry's scheduled flag; the skill enforces it by reading
+  `allow_scheduled` from the transformation registry before dispatch.
+
+  On success, append the resulting `{binding, transformation, proposal_id}` to
+  `PROPOSALS`. On failure, append a typed finding and the error detail to `ERRORS`
+  without mutating the manifest.
+
+- `state: local-customization` → append a `local_customization` finding
+  (`severity: medium`) and no proposal. Local edits must be reviewed by a human.
+- `state: conflict` → append a `conflict` finding (`severity: high`) and no
+  proposal. The binding has both template drift and local customization.
+- `state: error` → the audit engine already produced a finding; copy it and add
+  no proposal.
+
+This phase never calls `gh` and never calls `generated_artifacts.advance()` —
+proposals are data, not actions. An orchestrator or human decides whether to
+run the proposed generator.
+
+## Phase 5: RECORD
+
+Write `RESULT_PATH`:
+
+```yaml
+contract_version: 1
+kind: generated-artifact
+workspace: {LOGIN}
+run_at: "{RUN_AT}"                # quote: an unquoted ISO-8601 value parses as a YAML datetime
+actor: { gh_login: {gh api user login or unknown}, machine: {hostname}, mode: {MODE} }
+bindings_audited: {AUDIT_REPORT.bindings_checked}
+states:
+  {binding.id}: {binding.state}  # one entry per audited binding
+findings: {AUDIT_REPORT.findings}
+proposals: {PROPOSALS}
+proposed_actions: {PROPOSED_ACTIONS}
+errors: {ERRORS}
+```
+
+Validate:
+
+```bash
+uv run "${PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py" "$RESULT_PATH" --kind generated-artifact
+```
+
+Non-zero exit is a skill bug; report validator stderr verbatim.
+
+Print a one-line log summary:
+`generated-artifact-audit: bindings={bindings_audited} drift={bindings_drift} proposals={n}`
+
+## ABORT semantics
+
+Every ABORT above appends the reason to `ERRORS` and falls through to Phase 5
+with `bindings_audited: 0`, `states: {}`, `findings: []`, `proposals: []`,
+`proposed_actions: []`, `errors: [reason]` — the result file is always written and
+validated. If `CONFIG_DIR` is unusable, write to the `result_path` input, else
+`generated-artifact-result.yaml` in the current directory, and say so.
+
+## Related
+
+- `lib/pulse/scripts/generated_artifacts.py` — collector + audit engine
+  (F7 Task 2)
+- `lib/pulse/scripts/generator_dispatch.py` — generator adapter dispatch
+  (F7 Task 3)
+- `lib/pulse/scripts/pen_orchestrator.py` — propose-only F6 pen run driver
+- `lib/pulse/scripts/validate_result.py` — result-kind validator
+- `lib/patterns/headless-contract.md` § generated-artifact-result.yaml
+- `lib/patterns/generation-manifest.md` — binding and state definitions
+- `lib/patterns/repository-mutations.md` — mutation policy and scheduled gating
+  vocabulary

--- a/templates/generated.yaml.template
+++ b/templates/generated.yaml.template
@@ -1,0 +1,86 @@
+# hiivmind-pulse-gh - Generated Artifact Bindings
+# This file declares artifact bindings: repo files that are produced from a
+# committed template and are guarded against template drift.
+#
+# Generated/Updated by gh-refresh on {{synced_at}}
+
+# Workspace identification
+workspace:
+  type: {{workspace_type}}           # organization or user
+  login: {{workspace_login}}         # Workspace login
+
+# Generated artifact bindings
+# Each entry describes one binding: a set of output files in one repository
+# generated from one template source.
+#
+# A binding is invalid when:
+#   - files[] contains duplicate path values within the same binding
+#     (a path can only be guarded once per binding);
+#   - files[] is empty (the binding has nothing to guard);
+#   - template_tree is missing (the tree SHA that produced the files is required
+#     to detect template changes);
+#   - any files[].blob is missing (the generated blob SHA is required to detect
+#     local customizations).
+# These rules are enforced by the loader/audit engine, not by this template.
+#
+# Validity is computed per binding, so one repository may have multiple
+# bindings (e.g. one per generator or template source).
+bindings:
+  - id: {{binding_id}}               # Required stable binding identifier
+    source: {{owner/repo}}           # Repository that owns the template source
+    branch: {{branch}}               # Branch in the source repo where the
+                                     # template is resolved (main, develop, ...)
+    template_path: {{template_path}} # Repo-relative path to the template file
+    template_tree: {{tree_sha}}      # Git tree SHA of the source repo at the
+                                     # point the files were generated; used to
+                                     # detect template drift
+    generator: {{generator_id}}      # Registered generator id that produced
+                                     # the files (enforced by the loader)
+    files:                           # Required, non-empty list of output files
+      - path: {{output_path}}        # Repo-relative output path in the target
+                                     # repository (not the source repository)
+        blob: {{blob_sha}}           # Blob SHA of the generated file at
+                                     # generation time; used to detect local
+                                     # customization
+    generated_at: {{timestamp}}      # ISO 8601 timestamp of last generation
+
+# Example:
+# bindings:
+#   - id: widget-readme
+#     source: hiivmind/template-repo
+#     branch: main
+#     template_path: templates/repo-readme.md
+#     template_tree: abc1234
+#     generator: readme-from-template
+#     files:
+#       - path: README.md
+#         blob: def5678
+#     generated_at: "2026-07-10T09:15:00Z"
+#   - id: widget-ci
+#     source: hiivmind/template-repo
+#     branch: main
+#     template_path: templates/ci.yml
+#     template_tree: abc1234
+#     generator: workflow-from-template
+#     files:
+#       - path: .github/workflows/ci.yml
+#         blob: aaa1111
+#       - path: .github/workflows/release.yml
+#         blob: bbb2222
+#     generated_at: "2026-07-10T09:15:00Z"
+
+# Metadata
+cache:
+  synced_at: {{synced_at}}           # ISO timestamp of last update
+  schema_version: "1.0"
+  source: "manual"                   # "manual" or "api"
+
+# Notes:
+# - The target repository is implicit from the binding id / workspace context
+#   (the loader matches bindings against repository catalog entries).
+# - template_tree is the source tree SHA, not the target tree SHA.
+# - files[].blob is the generated blob SHA at the time of generation; drift is
+#   detected by comparing the current target blob against this stored value.
+# - A template-drift finding produces a proposal entry in the generated-artifact
+#   result kind; local-customization and conflict findings are surfaced without
+#   a proposal.

--- a/templates/generators.yaml.template
+++ b/templates/generators.yaml.template
@@ -1,0 +1,80 @@
+# hiivmind-pulse-gh - Generator adapter registry
+# Loaded by lib/pulse/scripts/generator_dispatch.py (load_generators).
+# See lib/patterns/repository-mutations.md for the full mutation contract this
+# file participates in — expected-SHA guarding, policy vocabulary, and
+# scheduled-mode gating.
+#
+# A generator is an adapter that turns a drifted generated-artifact binding
+# (see templates/generated.yaml.template) into a Nave mutation Proposal. It
+# does NOT define its own command line: the exact argv is taken verbatim from
+# the registered transformation named by `transformation` (see
+# templates/transformations.yaml.template). Generators only declare where they
+# apply, which source template paths they consume, and the output-path
+# allowlist that constrains where generated files may be written.
+#
+# Fail-closed load rules (enforced by load_generators):
+#   - `transformation` must name a registered transformation id.
+#   - `output_paths` must be non-empty (a generator with no allowed outputs
+#     cannot produce anything).
+#   - `source_paths` must be non-empty (a generator must know which template
+#     source it consumes).
+#   - `command` and `command_argv` are rejected outright. The transformation
+#     registry is the ONLY source of argv; generators are not a back-door for
+#     free-form shell commands.
+#   - `applies_to` predicates use the same grammar as scorecard checks
+#     (always | profile:<id> | capability:<id> | evidence_path:<glob>).
+#
+# Glob semantics for `source_paths`/`output_paths` (via impact._glob_to_regex):
+#   - `*` matches zero or more characters within a single path segment and
+#     never crosses a `/`.
+#   - `**` matches zero or more whole path segments, so `docs/**/*.md` matches
+#     both `docs/top.md` and `docs/nested/deep.md`.
+#   - `?` matches exactly one non-separator character.
+#   - All other characters match literally.
+
+# generators:
+#
+#   {{generator_id}}:                     # Registry key; must equal `id` below.
+#     id: {{generator_id}}                # Required, must match the key exactly.
+#     applies_to:                         # Required, non-empty list of OR-matched
+#       - {{predicate}}                  # eligibility predicates:
+#                                        #   always
+#                                        #   profile:<profile id>
+#                                        #   capability:<capability id>
+#                                        #   evidence_path:<glob>
+#                                        # Same grammar as scorecard checks
+#                                        # (profile_dispatch.py).
+#     transformation: {{transformation_id}} # Required, registered transformation
+#                                        # id. The registry's command_argv is
+#                                        # the ONLY source of argv.
+#     source_paths:                       # Required, non-empty list of globs
+#       - {{glob}}                         # describing the template source path(s)
+#                                        # in the source repository.
+#     output_paths:                       # Required, non-empty allowlist. Every
+#       - {{glob}}                         # file the binding asks this generator to
+#                                        # produce must match at least one glob.
+#     validation:                         # ValidationSpec shape (same as
+#       kind: none | json_schema          # transformations). `none` takes no
+#                                        # other keys. `json_schema` requires:
+#                                        #   path: {{repo_relative_path}}
+#                                        #   schema: {{inline_json_schema}}
+
+# Example: a README generator bound to the `regenerate-from-template`
+# transformation. It applies to repos whose profile includes `nodejs`, and
+# generated files are constrained to README.md and any markdown file under docs/.
+# The actual argv (["nave", "generate", "--from-template"]) comes from the
+# transformation registry, not this generator entry.
+# readme-from-template:
+#   id: readme-from-template
+#   applies_to:
+#     - profile:nodejs
+#   transformation: regenerate-from-template
+#   source_paths:
+#     - templates/repo-readme.md
+#   output_paths:
+#     - README.md
+#     - docs/**/*.md
+#   validation:
+#     kind: none
+
+generators: {}

--- a/templates/relationships.yaml.template
+++ b/templates/relationships.yaml.template
@@ -84,10 +84,21 @@ repo_dependencies:
 #         watch_paths:
 #           - "lib/patterns/headless-contract.md"
 #           - "lib/pulse/scripts/validate_result.py"
-#         watch_branch: develop
-#         integration_tested_sha: abc1234
-#         tested_at: "2026-07-01T10:00:00Z"
-#         integration_workflow: ci.yml
+#     watch_branch: develop
+#     integration_tested_sha: abc1234
+#     tested_at: "2026-07-01T10:00:00Z"
+#     integration_workflow: ci.yml
+#     # Optional contract-version binding: the impact audit compares the
+#     # producer version extracted from the upstream repo with the consumer
+#     # requirement extracted from the upstream repo.
+#     # contract:
+#     #   producer:
+#     #     path: "pyproject.toml"
+#     #     parser: {kind: toml, key: "project.version"}
+#     #   consumer:
+#     #     path: "requirements.txt"
+#     #     parser: {kind: regex, pattern: "upstream(>=[^\\s]+)"}
+#     #   version_scheme: pep440
 #     depended_by: []
 #     relationship_type: test
 #   hiivmind-corpus:

--- a/templates/relationships/split-repo-tests.yaml
+++ b/templates/relationships/split-repo-tests.yaml
@@ -1,0 +1,30 @@
+# hiivmind-pulse-gh - Split Repository Impact Binding Overlay
+#
+# This is a concrete, copy-ready overlay fragment meant to be MERGED into the
+# workspace's `.hiivmind/github/relationships.yaml` (under `repo_dependencies:`).
+# It proves that the F5 object-edge machinery in `lib/pulse/scripts/impact.py`
+# already covers the "split test repository depends on its source repository"
+# case with NO new workflow, NO new result kind, and NO new Python — only
+# configuration.
+#
+# The dependent test repo (`hiivmind-pulse-gh-tests`) binds to its upstream
+# source repo (`hiivmind-pulse-gh`) with a full-tree `watch_paths: ["**"]`.
+# Because `**` crosses `/` (see `_glob_to_regex` in `impact.py`), ANY change in
+# the upstream tree makes this edge stale, so the test repo must re-validate.
+#
+# Marker advancement is still handled by the existing F5 machinery:
+# `propose_marks()` joins successful `integration_workflow` run evidence against
+# this edge and `apply_proposals()` writes the updated `integration_tested_sha`.
+
+repo_dependencies:
+  hiivmind-pulse-gh-tests:
+    depends_on:
+      - repo: hiivmind-pulse-gh
+        watch_paths:
+          - "**"          # full tree — ** crosses / (see impact.py _glob_to_regex)
+        watch_branch: develop
+        integration_tested_sha: "0000000000000000000000000000000000000000"
+        tested_at: "2026-07-20T00:00:00Z"
+        integration_workflow: ci.yml
+    depended_by: []
+    relationship_type: test

--- a/templates/transformations.yaml.template
+++ b/templates/transformations.yaml.template
@@ -55,6 +55,22 @@ transformations:
       kind: none
     allow_scheduled: true
 
+  # Example: a template-driven regeneration. The exact argv is fixed in the
+  # registry; a generator adapter (templates/generators.yaml.template) binds
+  # this transformation to a binding. Not allowed to run unattended because
+  # the generated files are reviewed before they are applied.
+  regenerate-from-template:
+    id: regenerate-from-template
+    command_argv:
+      - nave
+      - generate
+      - --from-template
+    applies_to:
+      - always
+    validation:
+      kind: none
+    allow_scheduled: false
+
   # Example: a dependency-lock refresh. Applies only to repos carrying a
   # capability signal (surfaced by their profile/scorecard evidence), and
   # its result is checked against a JSON Schema before it can be proposed

--- a/templates/workflows/generated-artifact-audit.yaml
+++ b/templates/workflows/generated-artifact-audit.yaml
@@ -1,0 +1,39 @@
+# hiivmind-pulse-gh - Generated Artifact Audit Workflow
+# Audit committed generated-artifact bindings for template drift, local
+# customization, conflict, or error states, and record regeneration proposals
+# for template-drift bindings. Never applies generated files itself.
+# Copy to: .hiivmind/github/workflows/generated-artifact-audit.yaml
+
+name: "generated-artifact-audit"
+description: "Audit generated-artifact bindings and propose regenerations for drifted templates"
+enabled: true
+auto: false  # Must be explicitly requested — never runs automatically
+
+# Reference headless annotation: the audit is read-only against GitHub and the
+# generation manifest; INVOKE maps to the gh-generated-artifact-headless sibling
+# when present (see workflow-execution.md).
+headless:
+  enabled: true
+  on_ask: record
+  on_mutation: propose   # regenerated files are proposed, never applied unattended
+
+trigger:
+  type: on_demand
+  condition: user_requested
+
+params:
+  repo:
+    description: "Optional repo (full or short name) to scope the audit to; empty audits every configured binding"
+    type: string
+    default: ""
+
+state: {}
+
+workflow: |
+  EXECUTE:
+    INVOKE skill hiivmind-pulse-gh:gh-generated-artifact-headless
+      WITH workspace_path=workspace_root,
+           repo=params.repo,
+           mode=scheduled
+
+cooldown_minutes: 1440  # 24 hours


### PR DESCRIPTION
## F7: Generated Artifact & Contract Binding Specializations

Adds generic **generated-artifact drift** and **contract-version propagation** as adapter-driven specializations of the shared binding + Nave mutation infrastructure (F5/F6). Neutral core — Claude/corpus overlays are deferred to F9.

Plan: `docs/superpowers/plans/2026-07-13-f7-binding-specializations.md`. Stacked off the F6 merge (develop @ b6755f8).

### What shipped (6 tasks, TDD)
- **T1** — `generated-artifact` result kind (`validate_result.py`), `generated.yaml.template` manifest, `generation-manifest.md` pattern doc, `headless-contract.md` registration.
- **T2** — `generated_artifacts.py`: `backfill`/`audit`/`advance`/`collect`. Pure audit with 6-way fail-closed drift classification (current / template-drift / local-customization / conflict / error); CAS-guarded marker advancement; partial-clone snapshot collector.
- **T3** — `generator_dispatch.py`: `load_generators`/`dispatch`/`generator_applies`. Output-path allowlist via shared `impact._glob_to_regex`; argv sourced **only** from the F6 transformation registry; `regenerate-from-template` example transformation.
- **T4** — `contract_versions.py` (regex/toml/json/yaml parsers, PEP 440 via `packaging`, fail-to-`None`) composed into `impact.audit` (new `contract_state` on edge rows; stale+gap dedupe; `unevaluated_contract` fail-closed finding).
- **T5** — `gh-generated-artifact-headless` skill + `generated-artifact-audit.yaml` workflow (lints clean) + neutrality test. Enforces `allow_scheduled` gating for unattended runs.
- **T6** — `templates/relationships/split-repo-tests.yaml` overlay + tests proving F5 already covers the split test-repo case (configuration, not new code).

### Verification
- **679 tests pass** (`uv run pytest lib/pulse/scripts/tests` from repo root).
- Workflow lint exit 0; neutrality asserted (no `claude`/`corpus`/`plugin manifest`/`SKILL.md` in the neutral core).
- All 6 plan Global Constraints verified (tree-hash drift, blob bases, argv-in-registry-only, no-LLM-inference, explicit contract parsers, all writes via F6 propose-only).

### Review-driven fixes (found by controller review, each with a regression test)
- Fail-closed on unresolved template tree (was a spurious drift proposal to `new_tree=ABSENT`).
- Bound `mutation_plan` module for `generator_dispatch` annotations (broke `get_type_hints`).
- Surface **both** watch-path and contract findings on one edge (a compound-misconfig finding was dropped).
- Require `proposed_actions` on the `generated-artifact` kind, matching sibling headless kinds and the skill's own output.

### Deferred (follow-ups, non-blocking)
- **Manifest validity not enforced**: Task 1 documents `generated.yaml` rules (no duplicate `files[].path`, no empty `files[]`) but no loader/audit path rejects a malformed manifest. Deferred per maintainer decision (additive; no real manifests exist pre-adoption).
- `proposals[].binding ∈ template-drift` cross-check not enforced (plan scoped the validator without it).
- No finding for a standalone contract `gap` on a path-current edge (plan design; `contract_state` still carries it).
- `contract_versions`: RFC 6901 `~0`/`~1` escapes unhandled; PEP 440 `SpecifierSet` excludes prereleases by default. v1 limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
