### PR TITLE
F8: Generic Plan Synchronization (propose-only)

### DIFF
--- a/lib/patterns/headless-contract.md
+++ b/lib/patterns/headless-contract.md
@@ -390,9 +390,9 @@ proposal.
 
 ### plan-sync-result.yaml (written by the plan synchronization audit, F8)
 
-Reports one generic plan synchronization run. It records only counts and
-typed findings; reconciliation mutations are accounted for as document or
-GitHub patches rather than embedded in this result file.
+Reports one generic plan synchronization run. It records counts, typed findings,
+and the deferred proposals/actions needed to perform reconciliation; the audit
+itself remains propose-only.
 
 ```yaml
 contract_version: 1
@@ -413,6 +413,11 @@ findings:                             # list, required (may be empty)
     detail: <str>                     # optional
     ref: { type: <str>, id: <any>, url: <str> }   # optional locator
     inferred: <bool>                  # optional
+proposals:                            # list, required (may be empty)
+  - binding: <binding id>             # str, required
+    transformation: plan-sync-doc-patch # str, required
+    proposal_id: <str>                # str, required
+proposed_actions: [<str>, ...]        # list, required (may be empty)
 errors: []
 ```
 

--- a/lib/patterns/headless-contract.md
+++ b/lib/patterns/headless-contract.md
@@ -16,6 +16,7 @@ retained for human-readable logs only — orchestrators MUST read the file.
 | impact | impact-result.yaml | `{workspace_root}/.hiivmind/github/impact-result.yaml` |
 | repo-mutation | repo-mutation-result.yaml | `{workspace_root}/.hiivmind/github/repo-mutation-result.yaml` |
 | generated-artifact | generated-artifact-result.yaml | `{workspace_root}/.hiivmind/github/generated-artifact-result.yaml` |
+| plan-sync | plan-sync-result.yaml | `{workspace_root}/.hiivmind/github/plan-sync-result.yaml` |
 
 Result files are per-machine transient run artifacts (never authority — see
 `workspace-detection.md` § Multi-machine topology). The workspace repo's
@@ -35,7 +36,7 @@ not kinds they were not asked to validate.
 
 ```yaml
 contract_version: 1                   # int, required
-kind: status | healthcheck | fleet-membership | refresh | workflow-run | impact | repo-mutation | generated-artifact
+kind: status | healthcheck | fleet-membership | refresh | workflow-run | impact | repo-mutation | generated-artifact | plan-sync
 workspace: <login>                    # str, required — org/user login
 run_at: <ISO 8601 timestamp>          # str, required
 actor:                                # required on ALL kinds (I4)
@@ -59,6 +60,7 @@ profiles, and machines: identity-sensitive logic resolves against the
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py impact-result.yaml --kind impact
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py repo-mutation-result.yaml --kind repo-mutation
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py generated-artifact-result.yaml --kind generated-artifact
+    uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py plan-sync-result.yaml --kind plan-sync
 
 Orchestrators validate before consuming and treat exit 1/2 as a failed run
 (report, do not commit). Exit codes: 0 valid, 1 invalid (errors on stderr),
@@ -385,6 +387,34 @@ states. `proposals` are emitted only for `template-drift` bindings, because only
 template drift can be resolved by re-running a registered generator. Findings
 for `local-customization`, `conflict`, and `error` states are surfaced without a
 proposal.
+
+### plan-sync-result.yaml (written by the plan synchronization audit, F8)
+
+Reports one generic plan synchronization run. It records only counts and
+typed findings; reconciliation mutations are accounted for as document or
+GitHub patches rather than embedded in this result file.
+
+```yaml
+contract_version: 1
+kind: plan-sync
+workspace: <login>
+run_at: <ISO 8601>
+actor: { gh_login: <str>, machine: <str>, mode: <enum> }
+docs_scanned: <int>                   # required, non-negative
+in_sync: <int>                        # required, non-negative
+doc_patches: <int>                    # required, non-negative
+github_patches: <int>                 # required, non-negative
+conflicts: <int>                      # required, non-negative
+excluded: <int>                       # required, non-negative
+findings:                             # list, required (may be empty)
+  - kind: dirty_doc | local_ahead | rename_detected | base_conflict | <str>
+    repo: <owner/name>                # str, required
+    severity: low | medium | high     # required enum
+    detail: <str>                     # optional
+    ref: { type: <str>, id: <any>, url: <str> }   # optional locator
+    inferred: <bool>                  # optional
+errors: []
+```
 
 ## Related patterns
 

--- a/lib/patterns/plan-sync-binding.md
+++ b/lib/patterns/plan-sync-binding.md
@@ -1,0 +1,44 @@
+# Pattern: Plan Synchronization Binding
+
+A plan document can opt into GitHub issue reconciliation with a `sync:` block
+in its YAML frontmatter. Frontmatter fields outside `sync:` are preserved by
+the parser and are not part of this binding contract.
+
+```yaml
+sync:
+  issue: {repo: owner/name, number: 42}
+  policy:
+    title: conflict
+    state: conflict
+    assignees: conflict
+    milestone: conflict
+    body: conflict
+  base:
+    blob: <git blob SHA of the doc at last reconciliation>
+    title: "..."
+    state: open
+    assignees: [a, b]
+    milestone: "v2.0"
+```
+
+`base.blob` is required and must be a non-empty string. It identifies the
+document version used for the last reconciliation. `policy` values are one of
+`conflict` (the default), `prefer-doc`, or `prefer-github`. Unknown keys under
+`sync:` are invalid.
+
+## V1 synchronized fields
+
+V1 reconciles only these issue fields:
+
+- `title`
+- `state`
+- `assignees`
+- `milestone`
+- `body`
+
+`assignees` are recorded as a sorted, deduplicated list. `milestone` is a
+milestone title or `null`.
+
+## V1 exclusions
+
+V1 does not synchronize GitHub Projects custom fields, labels, or comments.

--- a/lib/patterns/plan-sync-binding.md
+++ b/lib/patterns/plan-sync-binding.md
@@ -42,3 +42,29 @@ milestone title or `null`.
 ## V1 exclusions
 
 V1 does not synchronize GitHub Projects custom fields, labels, or comments.
+
+## V1 limitation: propose-only, apply-mode deferred
+
+F8 is **propose-only** end to end (see the plan's Global Constraints): the doc
+path is proposed as an F6 `plan-sync-doc-patch` repo mutation and the GitHub
+path as a Pulse proposed action, and **neither is ever applied**. Two aspects of
+the doc transformation are therefore defined but not yet execution-safe, and
+must be closed before any apply-mode consumer runs `plan-sync-doc-patch`:
+
+- **Executor path.** The registered argv runs `apply_doc_patch.py` by a
+  plugin-repo-relative path, which does not resolve inside a doc-repo pen
+  checkout (unlike F7's `regenerate-from-template`, which calls the installed
+  `nave` CLI). Apply mode needs the patch applier reachable on `PATH` in the
+  checkout (an installed console entry point or a `nave` subcommand).
+- **Bound-path enforcement.** The transformation's output allowlist is the
+  *per-binding dynamic* document path, but the F6 registry allowlist and
+  `validation` are static — the entry carries `validation: {kind: none}`, and
+  the bound path is currently self-attested by the (caller-authored) patch
+  descriptor. Apply mode needs the bound path carried as immutable proposal
+  metadata that the F6 orchestrator enforces, plus a "this exact path changed"
+  validation kind. `apply_doc_patch.py` already verifies the base-blob match and
+  rejects path escapes, but that is script-level, not orchestrator-level.
+
+These are backlogged as an F6/apply-mode enhancement; they do not affect
+propose-mode correctness (the argv is recorded, never executed; no validation
+runs).

--- a/lib/pulse/scripts/apply_doc_patch.py
+++ b/lib/pulse/scripts/apply_doc_patch.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["ruamel.yaml>=0.18.0"]
+# ///
+"""Apply one guarded plan-document patch from a pen checkout.
+
+The variable patch content lives in a well-known file rather than command
+arguments.  This script only writes after the target's Git blob hash matches
+the patch's recorded base, so a stale checkout cannot overwrite newer work.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import sys
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+# The script is invoked by an absolute plugin path while its working directory
+# is a pen checkout.  Keep the plugin root importable without depending on the
+# checkout containing the Pulse package itself.
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from lib.pulse.scripts.plan_sync import patch_document  # noqa: E402
+
+
+def _blob_sha(content: bytes) -> str:
+    return hashlib.sha1(f"blob {len(content)}\0".encode() + content).hexdigest()
+
+
+def _relative_path(value: Any, label: str) -> Path:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty relative path")
+    path = Path(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{label} must be a safe relative path")
+    return path
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a mapping")
+    return value
+
+
+def apply_patch_file(patch_file: Path, checkout: Path) -> None:
+    yaml = YAML(typ="safe")
+    try:
+        patch = _mapping(yaml.load(patch_file.read_text()), "patch")
+    except FileNotFoundError as exc:
+        raise ValueError(f"patch file not found: {patch_file}") from exc
+
+    path = _relative_path(patch.get("path"), "patch.path")
+    output_paths = patch.get("output_paths")
+    if not isinstance(output_paths, list) or not output_paths:
+        raise ValueError("patch.output_paths must be a non-empty list")
+    allowed_paths = {
+        str(_relative_path(output_path, "patch.output_paths entry"))
+        for output_path in output_paths
+    }
+    if str(path) not in allowed_paths:
+        raise ValueError(f"document is outside the output allowlist: {path}")
+    target = (checkout / path).resolve()
+    try:
+        target.relative_to(checkout.resolve())
+    except ValueError as exc:
+        raise ValueError("patch.path escapes the checkout") from exc
+    if not target.is_file():
+        raise ValueError(f"document not found: {path}")
+
+    base_blob = patch.get("base_blob")
+    if not isinstance(base_blob, str) or not base_blob:
+        raise ValueError("patch.base_blob must be a non-empty string")
+    original_bytes = target.read_bytes()
+    if _blob_sha(original_bytes) != base_blob:
+        raise ValueError(f"base blob mismatch for document: {path}")
+
+    try:
+        original = original_bytes.decode()
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"document is not UTF-8: {path}") from exc
+    doc_patch = _mapping(patch.get("doc_patch"), "patch.doc_patch")
+    sync_patch = _mapping(patch.get("sync_patch"), "patch.sync_patch")
+    target.write_text(patch_document(original, doc_patch, sync_patch))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--patch", default=".hiivmind/plan-sync-patch.yaml")
+    args = parser.parse_args(argv)
+    checkout = Path.cwd().resolve()
+    try:
+        apply_patch_file(checkout / _relative_path(args.patch, "--patch"), checkout)
+    except (OSError, UnicodeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/pulse/scripts/plan_sync.py
+++ b/lib/pulse/scripts/plan_sync.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["ruamel.yaml>=0.18.0"]
+# ///
+"""Lossless parsing and patching for GitHub-bound Markdown plans."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from io import StringIO
+import re
+from typing import Any
+
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap
+
+
+_YAML = YAML(typ="rt")
+_YAML.preserve_quotes = True
+_FRONTMATTER = re.compile(
+    r"\A(?P<opening>---(?P<line_ending>\r?\n))"
+    r"(?P<content>.*?)"
+    r"(?P<closing>^---(?:\r?\n|\Z))",
+    re.DOTALL | re.MULTILINE,
+)
+_H1 = re.compile(r"^# (?P<title>[^\r\n]*)(?=\r?$)", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class BoundDocument:
+    """A Markdown document and its optional ``sync:`` frontmatter block."""
+
+    frontmatter: Any | None
+    body: str
+    title: str | None
+    binding: Any | None
+
+
+def _split_frontmatter(text: str) -> tuple[re.Match[str] | None, str]:
+    match = _FRONTMATTER.match(text)
+    return match, text[match.end():] if match else text
+
+
+def _title_from(body: str) -> str | None:
+    match = _H1.search(body)
+    return match.group("title") if match else None
+
+
+def parse_document(text: str) -> BoundDocument:
+    """Parse frontmatter without normalizing the Markdown body."""
+    match, body = _split_frontmatter(text)
+    if match is None:
+        return BoundDocument(None, body, _title_from(body), None)
+
+    frontmatter = _YAML.load(match.group("content"))
+    binding = frontmatter.get("sync") if isinstance(frontmatter, dict) else None
+    return BoundDocument(frontmatter, body, _title_from(body), binding)
+
+
+def _replace_title(body: str, title: str) -> str:
+    match = _H1.search(body)
+    if match is None:
+        raise ValueError("document has no H1 title to patch")
+    start, end = match.span("title")
+    return body[:start] + title + body[end:]
+
+
+def _dump_frontmatter(frontmatter: Any, line_ending: str) -> str:
+    output = StringIO()
+    yaml = YAML(typ="rt")
+    yaml.preserve_quotes = True
+    yaml.line_break = line_ending
+    yaml.dump(frontmatter, output)
+    # ruamel's comment attachment can otherwise yield ``\r\r\n`` for an
+    # inline-commented mapping when serializing a CRLF source document.
+    return output.getvalue().replace("\r\r\n", "\r\n")
+
+
+def _apply_base_patch(binding: Any, sync_patch: dict) -> None:
+    if not isinstance(binding, dict):
+        raise ValueError("document has no sync binding to patch")
+
+    base_patch = sync_patch.get("base", sync_patch)
+    if not isinstance(base_patch, dict):
+        raise TypeError("sync patch must be a mapping of base fields")
+
+    base = binding.get("base")
+    if base is None:
+        base = CommentedMap()
+        binding["base"] = base
+    if not isinstance(base, dict):
+        raise TypeError("sync.base must be a mapping")
+    base.update(base_patch)
+
+
+def patch_document(text: str, doc_patch: dict, sync_patch: dict) -> str:
+    """Apply document and ``sync.base`` updates while preserving untouched text."""
+    if not doc_patch and not sync_patch:
+        return text
+
+    match, original_body = _split_frontmatter(text)
+    document = parse_document(text)
+    body = doc_patch.get("body", original_body)
+    if "title" in doc_patch:
+        body = _replace_title(body, doc_patch["title"])
+
+    if not sync_patch:
+        return text[:match.end()] + body if match else body
+
+    if match is None:
+        raise ValueError("document has no frontmatter to patch")
+    _apply_base_patch(document.binding, sync_patch)
+    frontmatter = _dump_frontmatter(document.frontmatter, match.group("line_ending"))
+    return match.group("opening") + frontmatter + match.group("closing") + body

--- a/lib/pulse/scripts/plan_sync.py
+++ b/lib/pulse/scripts/plan_sync.py
@@ -6,7 +6,7 @@
 """Lossless parsing and patching for GitHub-bound Markdown plans."""
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from io import StringIO
 import json
 import re
@@ -55,6 +55,8 @@ class ReconciliationPlan:
     github_patch: dict[str, Any]
     base_patch: dict[str, Any]
     conflicts: tuple[str, ...]
+    doc_base_patch: dict[str, Any] = field(default_factory=dict)
+    requires_final_blob: bool = False
 
     @property
     def conflicted(self) -> bool:
@@ -95,6 +97,7 @@ class FinalizeDecision:
 
 
 _SYNC_FIELDS = ("title", "state", "assignees", "milestone", "body")
+_GITHUB_ONLY_FIELDS = {"state", "assignees", "milestone"}
 
 
 def _normalise(field: str, value: Any) -> Any:
@@ -149,6 +152,7 @@ def compute(
     github: Mapping[str, Any],
     binding: Mapping[str, Any],
     base_body: Any,
+    document_blob: str | None = None,
 ) -> ReconciliationPlan:
     """Reconcile V1 plan fields into independent document, GitHub, and base patches."""
     base = binding.get("base", {})
@@ -156,30 +160,66 @@ def compute(
     doc_patch: dict[str, Any] = {}
     github_patch: dict[str, Any] = {}
     base_patch: dict[str, Any] = {}
+    doc_base_patch: dict[str, Any] = {}
     conflicts: list[str] = []
+    requires_final_blob = False
 
     for field in _SYNC_FIELDS:
         base_value = base_body if field == "body" else base.get(field)
         policy = policies.get(field) if isinstance(policies, Mapping) else None
+        # V1 has no document representation for these GitHub-only scalars.
+        # Their document-side value is therefore the recorded base; a GitHub
+        # delta advances sync.base rather than inventing a body/frontmatter key.
+        doc_value = (
+            base_value
+            if isinstance(doc, BoundDocument) and field in _GITHUB_ONLY_FIELDS
+            else _field_value(doc, field)
+        )
         outcome = merge_field(
             field,
             base_value,
-            _field_value(doc, field),
+            doc_value,
             github.get(field),
             policy,
         )
         if outcome.decision == "conflict":
             conflicts.append(field)
         elif outcome.decision == "apply_to_doc":
-            doc_patch[field] = outcome.value
-            base_patch[field] = outcome.value
+            if field in _GITHUB_ONLY_FIELDS:
+                base_patch[field] = outcome.value
+                doc_base_patch[field] = outcome.value
+            else:
+                doc_patch[field] = outcome.value
+                if field == "body":
+                    requires_final_blob = True
+                else:
+                    base_patch[field] = outcome.value
+                    doc_base_patch[field] = outcome.value
         elif outcome.decision == "apply_to_github":
             github_patch[field] = outcome.value
-            base_patch[field] = outcome.value
+            if field == "body":
+                if document_blob:
+                    base_patch["blob"] = document_blob
+            else:
+                base_patch[field] = outcome.value
         elif outcome.decision == "agree":
-            base_patch[field] = outcome.value
+            if field == "body":
+                if document_blob:
+                    base_patch["blob"] = document_blob
+                    doc_base_patch["blob"] = document_blob
+            else:
+                base_patch[field] = outcome.value
+                if isinstance(doc, BoundDocument):
+                    doc_base_patch[field] = outcome.value
 
-    return ReconciliationPlan(doc_patch, github_patch, base_patch, tuple(conflicts))
+    return ReconciliationPlan(
+        doc_patch,
+        github_patch,
+        base_patch,
+        tuple(conflicts),
+        doc_base_patch,
+        requires_final_blob,
+    )
 
 
 def _snapshot_value(snapshot: Any, name: str) -> Any:
@@ -221,7 +261,7 @@ def build_apply_plans(
 
     repo_mutation: Proposal | None = None
     doc_patch: dict[str, Any] | None = None
-    if reconciliation.doc_patch:
+    if reconciliation.doc_patch or reconciliation.doc_base_patch:
         head = _required_string(_snapshot_value(snapshot, "head"), "snapshot.head")
         blob = _required_string(_snapshot_value(snapshot, "blob"), "snapshot.blob")
         repo_mutation = build_proposal(
@@ -236,9 +276,11 @@ def build_apply_plans(
             "path": path,
             "base_blob": blob,
             "doc_patch": dict(reconciliation.doc_patch),
-            # Base advancement belongs to finalize, after confirmation from
-            # both paths.  Never advance it speculatively in the doc pen.
-            "sync_patch": {},
+            "sync_patch": (
+                {"base": dict(reconciliation.doc_base_patch)}
+                if reconciliation.doc_base_patch
+                else {}
+            ),
             "output_paths": [path],
         }
 
@@ -270,21 +312,31 @@ def finalize(
     reconciliation: ReconciliationPlan,
     doc_applied: bool,
     github_applied: bool,
+    confirmed_document_blob: str | None = None,
 ) -> FinalizeDecision:
     """Advance bases only where the corresponding two-way value is confirmed."""
     base_patch: dict[str, Any] = {}
     for field, value in reconciliation.base_patch.items():
-        if field in reconciliation.doc_patch and not doc_applied:
+        if (
+            field in reconciliation.doc_patch
+            or field in reconciliation.doc_base_patch
+        ) and not doc_applied:
+            continue
+        if field == "blob" and "body" in reconciliation.github_patch and not github_applied:
             continue
         if field in reconciliation.github_patch and not github_applied:
             continue
         base_patch[field] = value
+    if reconciliation.requires_final_blob and doc_applied and confirmed_document_blob:
+        base_patch["blob"] = confirmed_document_blob
 
     findings: tuple[FinalizeFinding, ...] = ()
     # Only a genuine partial application is notable: both sides had a patch to
     # apply and exactly one succeeded. A one-sided reconciliation (only the doc
     # or only GitHub changed) is a complete application, not a partial one.
-    both_had_work = bool(reconciliation.doc_patch) and bool(reconciliation.github_patch)
+    both_had_work = bool(
+        reconciliation.doc_patch or reconciliation.doc_base_patch
+    ) and bool(reconciliation.github_patch)
     if both_had_work and doc_applied != github_applied:
         findings = (
             FinalizeFinding(
@@ -294,6 +346,110 @@ def finalize(
             ),
         )
     return FinalizeDecision(base_patch, findings)
+
+
+def _finding_dict(finding: Any, *, repo: str | None = None) -> dict[str, Any]:
+    result = {
+        "kind": getattr(finding, "kind"),
+        "repo": getattr(finding, "repo", None) or repo or "",
+        "severity": getattr(finding, "severity"),
+    }
+    for key in ("detail", "path", "new_path"):
+        value = getattr(finding, key, None)
+        if value is not None:
+            result[key] = value
+    result["inferred"] = False
+    return result
+
+
+def build_result(
+    snapshot: Any,
+    *,
+    workspace: str,
+    run_at: str,
+    actor: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the production plan-sync result from collected evidence.
+
+    The builder composes the public merge and proposal paths used by the
+    headless workflow.  It is deliberately propose-only and performs no I/O.
+    """
+    result: dict[str, Any] = {
+        "contract_version": 1,
+        "kind": "plan-sync",
+        "workspace": workspace,
+        "run_at": run_at,
+        "actor": dict(actor),
+        "docs_scanned": 0,
+        "in_sync": 0,
+        "doc_patches": 0,
+        "github_patches": 0,
+        "conflicts": 0,
+        "excluded": 0,
+        "findings": [_finding_dict(f) for f in getattr(snapshot, "findings", ())],
+        "proposals": [],
+        "proposed_actions": [],
+        "errors": [],
+    }
+
+    for document in getattr(snapshot, "documents", ()):
+        result["docs_scanned"] += 1
+        if document.state in {"excluded", "error"}:
+            result["excluded"] += 1
+            continue
+        if document.state == "in_sync":
+            result["in_sync"] += 1
+            continue
+        if not document.document or not document.github or document.base_body is None:
+            result["excluded"] += 1
+            continue
+
+        reconciliation = compute(
+            document.document,
+            document.github,
+            document.document.binding,
+            document.base_body,
+            document_blob=document.blob,
+        )
+        if reconciliation.conflicted:
+            result["conflicts"] += 1
+            for conflict in reconciliation.conflicts:
+                result["findings"].append({
+                    "kind": "base_conflict",
+                    "repo": document.repo,
+                    "severity": "high",
+                    "detail": f"{conflict} changed differently in the document and GitHub",
+                    "inferred": False,
+                })
+            continue
+
+        plans = build_apply_plans(reconciliation, document.binding, document, actor)
+        if plans.repo_mutation is not None:
+            result["doc_patches"] += 1
+            result["proposals"].append({
+                "binding": document.binding["id"],
+                "transformation": plans.repo_mutation.transformation,
+                "proposal_id": plans.repo_mutation.id,
+            })
+            result["proposed_actions"].append(
+                f"propose document patch {plans.repo_mutation.id} for "
+                f"{document.path} at {document.head}"
+            )
+        if plans.github_mutation is not None:
+            result["github_patches"] += 1
+            result["proposed_actions"].extend(
+                plans.github_mutation.get("proposed_actions", [])
+            )
+        if plans.repo_mutation is None and plans.github_mutation is None:
+            result["in_sync"] += 1
+
+        # Propose-only: neither path is confirmed, so no base is persisted.
+        final = finalize(reconciliation, doc_applied=False, github_applied=False)
+        result["findings"].extend(
+            _finding_dict(finding, repo=document.repo) for finding in final.findings
+        )
+
+    return result
 
 
 def _split_frontmatter(text: str) -> tuple[re.Match[str] | None, str]:

--- a/lib/pulse/scripts/plan_sync.py
+++ b/lib/pulse/scripts/plan_sync.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from io import StringIO
 import re
-from typing import Any
+from typing import Any, Mapping
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
@@ -34,6 +34,117 @@ class BoundDocument:
     body: str
     title: str | None
     binding: Any | None
+
+
+@dataclass(frozen=True)
+class FieldDecision:
+    """The selected outcome for reconciling one synchronized field."""
+
+    decision: str
+    value: Any | None
+
+
+@dataclass(frozen=True)
+class ReconciliationPlan:
+    """Pure patches and conflicts resulting from a three-way reconciliation."""
+
+    doc_patch: dict[str, Any]
+    github_patch: dict[str, Any]
+    base_patch: dict[str, Any]
+    conflicts: tuple[str, ...]
+
+    @property
+    def conflicted(self) -> bool:
+        """Whether any field requires manual reconciliation."""
+        return bool(self.conflicts)
+
+
+_SYNC_FIELDS = ("title", "state", "assignees", "milestone", "body")
+
+
+def _normalise(field: str, value: Any) -> Any:
+    if field == "assignees":
+        return sorted(set(value or ()))
+    return value
+
+
+def merge_field(
+    field: str,
+    base: Any,
+    doc: Any,
+    github: Any,
+    policy: str | None = None,
+) -> FieldDecision:
+    """Determine a pure three-way merge outcome for a single plan field."""
+    base_value = _normalise(field, base)
+    doc_value = _normalise(field, doc)
+    github_value = _normalise(field, github)
+    doc_changed = doc_value != base_value
+    github_changed = github_value != base_value
+
+    if not doc_changed and not github_changed:
+        return FieldDecision("noop", None)
+    if doc_changed and not github_changed:
+        return FieldDecision("apply_to_github", doc_value)
+    if github_changed and not doc_changed:
+        return FieldDecision("apply_to_doc", github_value)
+    if doc_value == github_value:
+        return FieldDecision("agree", doc_value)
+    if policy == "prefer-doc":
+        return FieldDecision("apply_to_github", doc_value)
+    if policy == "prefer-github":
+        return FieldDecision("apply_to_doc", github_value)
+    return FieldDecision("conflict", None)
+
+
+def _field_value(source: Mapping[str, Any] | BoundDocument, field: str) -> Any:
+    if isinstance(source, BoundDocument):
+        if field == "title":
+            return source.title
+        if field == "body":
+            return source.body
+        if isinstance(source.frontmatter, Mapping):
+            return source.frontmatter.get(field)
+        return None
+    return source.get(field)
+
+
+def compute(
+    doc: Mapping[str, Any] | BoundDocument,
+    github: Mapping[str, Any],
+    binding: Mapping[str, Any],
+    base_body: Any,
+) -> ReconciliationPlan:
+    """Reconcile V1 plan fields into independent document, GitHub, and base patches."""
+    base = binding.get("base", {})
+    policies = binding.get("policy", {})
+    doc_patch: dict[str, Any] = {}
+    github_patch: dict[str, Any] = {}
+    base_patch: dict[str, Any] = {}
+    conflicts: list[str] = []
+
+    for field in _SYNC_FIELDS:
+        base_value = base_body if field == "body" else base.get(field)
+        policy = policies.get(field) if isinstance(policies, Mapping) else None
+        outcome = merge_field(
+            field,
+            base_value,
+            _field_value(doc, field),
+            github.get(field),
+            policy,
+        )
+        if outcome.decision == "conflict":
+            conflicts.append(field)
+        elif outcome.decision == "apply_to_doc":
+            doc_patch[field] = outcome.value
+            base_patch[field] = outcome.value
+        elif outcome.decision == "apply_to_github":
+            github_patch[field] = outcome.value
+            base_patch[field] = outcome.value
+        elif outcome.decision == "agree":
+            base_patch[field] = outcome.value
+
+    return ReconciliationPlan(doc_patch, github_patch, base_patch, tuple(conflicts))
 
 
 def _split_frontmatter(text: str) -> tuple[re.Match[str] | None, str]:

--- a/lib/pulse/scripts/plan_sync.py
+++ b/lib/pulse/scripts/plan_sync.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from io import StringIO
+import json
 import re
 from typing import Any, Mapping
 
 from ruamel.yaml import YAML
 from ruamel.yaml.comments import CommentedMap
+
+from lib.pulse.scripts.mutation_plan import Proposal, build_proposal
 
 
 _YAML = YAML(typ="rt")
@@ -57,6 +60,38 @@ class ReconciliationPlan:
     def conflicted(self) -> bool:
         """Whether any field requires manual reconciliation."""
         return bool(self.conflicts)
+
+
+@dataclass(frozen=True)
+class ApplyPlans:
+    """Independent, propose-only plans for one reconciliation.
+
+    ``repo_mutation`` is an F6 proposal for the document checkout.  Its
+    companion ``doc_patch`` is the caller-owned content for the well-known
+    pen-checkout patch file; it is deliberately data, never command argv.
+    ``github_mutation`` is a Pulse proposed action, not an API invocation.
+    """
+
+    repo_mutation: Proposal | None
+    github_mutation: dict[str, Any] | None
+    doc_patch: dict[str, Any] | None
+
+
+@dataclass(frozen=True)
+class FinalizeFinding:
+    """A typed finalization finding suitable for a plan-sync result."""
+
+    kind: str
+    severity: str
+    detail: str
+
+
+@dataclass(frozen=True)
+class FinalizeDecision:
+    """The bases safe to persist after the two independent apply paths."""
+
+    base_patch: dict[str, Any]
+    findings: tuple[FinalizeFinding, ...]
 
 
 _SYNC_FIELDS = ("title", "state", "assignees", "milestone", "body")
@@ -145,6 +180,120 @@ def compute(
             base_patch[field] = outcome.value
 
     return ReconciliationPlan(doc_patch, github_patch, base_patch, tuple(conflicts))
+
+
+def _snapshot_value(snapshot: Any, name: str) -> Any:
+    if isinstance(snapshot, Mapping):
+        return snapshot.get(name)
+    return getattr(snapshot, name, None)
+
+
+def _sync_binding(binding: Mapping[str, Any]) -> Mapping[str, Any]:
+    sync = binding.get("sync")
+    return sync if isinstance(sync, Mapping) else binding
+
+
+def _required_string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
+def build_apply_plans(
+    reconciliation: ReconciliationPlan,
+    binding: Mapping[str, Any],
+    snapshot: Any,
+    actor: Mapping[str, Any] | Any,
+) -> ApplyPlans:
+    """Build separate propose-only document and GitHub patch proposals.
+
+    This function has no side effects.  The caller writes ``doc_patch`` to
+    ``.hiivmind/plan-sync-patch.yaml`` in the pen checkout only when it is
+    ready to execute the already-proposed F6 document path.  GitHub receives
+    a parallel proposed action and is never folded into that proposal.
+    """
+    repo = _required_string(binding.get("repo"), "binding.repo")
+    path = _required_string(binding.get("path"), "binding.path")
+    binding_id = _required_string(binding.get("id"), "binding.id")
+    snapshot_repo = _snapshot_value(snapshot, "repo")
+    if snapshot_repo is not None and snapshot_repo != repo:
+        raise ValueError("snapshot.repo must match binding.repo")
+
+    repo_mutation: Proposal | None = None
+    doc_patch: dict[str, Any] | None = None
+    if reconciliation.doc_patch:
+        head = _required_string(_snapshot_value(snapshot, "head"), "snapshot.head")
+        blob = _required_string(_snapshot_value(snapshot, "blob"), "snapshot.blob")
+        repo_mutation = build_proposal(
+            id=f"plan-sync-doc-{binding_id}",
+            selection=[repo],
+            transformation="plan-sync-doc-patch",
+            expected_shas={repo: head},
+            actor=actor,
+            mutation_policy="propose",
+        )
+        doc_patch = {
+            "path": path,
+            "base_blob": blob,
+            "doc_patch": dict(reconciliation.doc_patch),
+            # Base advancement belongs to finalize, after confirmation from
+            # both paths.  Never advance it speculatively in the doc pen.
+            "sync_patch": {},
+            "output_paths": [path],
+        }
+
+    github_mutation: dict[str, Any] | None = None
+    if reconciliation.github_patch:
+        issue = _sync_binding(binding).get("issue")
+        if not isinstance(issue, Mapping):
+            raise ValueError("binding.sync.issue must be a mapping")
+        issue_repo = _required_string(issue.get("repo"), "binding.sync.issue.repo")
+        issue_number = issue.get("number")
+        if isinstance(issue_number, bool) or not isinstance(issue_number, int) or issue_number <= 0:
+            raise ValueError("binding.sync.issue.number must be a positive integer")
+        patch = dict(reconciliation.github_patch)
+        github_mutation = {
+            "repo": issue_repo,
+            "number": issue_number,
+            "patch": patch,
+            "mutation_policy": "propose",
+            "proposed_actions": [
+                f"propose GitHub issue patch for {issue_repo}#{issue_number}: "
+                f"{json.dumps(patch, sort_keys=True)}"
+            ],
+        }
+
+    return ApplyPlans(repo_mutation, github_mutation, doc_patch)
+
+
+def finalize(
+    reconciliation: ReconciliationPlan,
+    doc_applied: bool,
+    github_applied: bool,
+) -> FinalizeDecision:
+    """Advance bases only where the corresponding two-way value is confirmed."""
+    base_patch: dict[str, Any] = {}
+    for field, value in reconciliation.base_patch.items():
+        if field in reconciliation.doc_patch and not doc_applied:
+            continue
+        if field in reconciliation.github_patch and not github_applied:
+            continue
+        base_patch[field] = value
+
+    findings: tuple[FinalizeFinding, ...] = ()
+    # Only a genuine partial application is notable: both sides had a patch to
+    # apply and exactly one succeeded. A one-sided reconciliation (only the doc
+    # or only GitHub changed) is a complete application, not a partial one.
+    both_had_work = bool(reconciliation.doc_patch) and bool(reconciliation.github_patch)
+    if both_had_work and doc_applied != github_applied:
+        findings = (
+            FinalizeFinding(
+                "partial_application",
+                "medium",
+                "document and GitHub proposals must be finalized independently",
+            ),
+        )
+    return FinalizeDecision(base_patch, findings)
 
 
 def _split_frontmatter(text: str) -> tuple[re.Match[str] | None, str]:

--- a/lib/pulse/scripts/plan_sync_snapshot.py
+++ b/lib/pulse/scripts/plan_sync_snapshot.py
@@ -239,9 +239,16 @@ def collect(bindings, workdir=None, runner=default_runner, gh_api=None) -> SyncS
     pending: list[dict[str, Any]] = []
     for binding in raw_bindings:
         repo, branch, path, _ = _binding_values(binding)
-        if not (_valid_repo(repo) and _valid_branch(branch) and _valid_path(path)):
+        locator_id = binding.get("id")
+        if not (
+            isinstance(locator_id, str)
+            and bool(locator_id)
+            and _valid_repo(repo)
+            and _valid_branch(branch)
+            and _valid_path(path)
+        ):
             doc, finding = _error(binding, str(repo or ""), str(branch or ""), str(path or ""), None,
-                                  "invalid document repository, branch, or path")
+                                  "invalid document id, repository, branch, or path")
             documents.append(doc)
             findings.append(finding)
         elif local_dir is not None and _local_dirty(run, local_dir, path):

--- a/lib/pulse/scripts/plan_sync_snapshot.py
+++ b/lib/pulse/scripts/plan_sync_snapshot.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Collect pushed plan-document and GitHub issue evidence for F8 sync.
+
+All git operations pass through ``runner`` and all GitHub reads pass through
+``gh_api``.  A local checkout is only inspected for dirty/ahead *metadata*;
+its document content is never an input to reconciliation.
+"""
+from __future__ import annotations
+
+import contextlib
+import re
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from lib.pulse.scripts.impact_snapshot import (
+    _slug,
+    _valid_branch,
+    _valid_sha,
+    default_runner,
+)
+from lib.pulse.scripts.plan_sync import BoundDocument, parse_document
+
+
+Runner = Callable[..., object]
+GhApi = Callable[[str], Any]
+
+_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+
+@dataclass(frozen=True)
+class SnapshotFinding:
+    kind: str
+    repo: str
+    severity: str
+    detail: str | None = None
+    path: str | None = None
+    new_path: str | None = None
+
+
+@dataclass(frozen=True)
+class DocumentSnapshot:
+    binding: dict[str, Any]
+    repo: str
+    branch: str
+    path: str
+    head: str | None
+    blob: str | None
+    state: str  # in_sync | changed | excluded | error
+    document: BoundDocument | None = None
+    base_body: str | None = None
+    github: dict[str, Any] | None = None
+    milestones: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SyncSnapshot:
+    documents: tuple[DocumentSnapshot, ...]
+    findings: tuple[SnapshotFinding, ...]
+
+
+def _failed(result: object) -> bool:
+    return getattr(result, "returncode", 1) != 0
+
+
+def _stdout(result: object) -> str:
+    return (getattr(result, "stdout", "") or "").strip()
+
+
+def _valid_repo(value: Any) -> bool:
+    return isinstance(value, str) and bool(_REPO_RE.fullmatch(value))
+
+
+def _valid_path(value: Any) -> bool:
+    """Accept ordinary repository-relative paths only.
+
+    The revision passed to ``git rev-parse`` is formed as ``FETCH_HEAD:path``;
+    it cannot use ``--`` without changing git's meaning, so reject values that
+    could change revision parsing instead.
+    """
+    return (
+        isinstance(value, str)
+        and bool(value)
+        and not value.startswith("-")
+        and not value.startswith("/")
+        and "\x00" not in value
+        and ":" not in value
+        and all(part not in {"", ".", ".."} for part in value.split("/"))
+    )
+
+
+def _repo_url(repo: str) -> str:
+    return f"https://github.com/{repo}.git"
+
+
+def _sync(binding: dict[str, Any]) -> dict[str, Any]:
+    nested = binding.get("sync")
+    return nested if isinstance(nested, dict) else binding
+
+
+def _binding_values(binding: dict[str, Any]) -> tuple[str | None, str | None, str | None, dict[str, Any]]:
+    return binding.get("repo"), binding.get("branch"), binding.get("path"), _sync(binding)
+
+
+def _is_local_checkout(run: Runner, workdir: str | Path | None) -> bool:
+    if workdir is None:
+        return False
+    result = run(["git", "rev-parse", "--is-inside-work-tree"], Path(workdir))
+    return not _failed(result) and _stdout(result).lower() == "true"
+
+
+@contextlib.contextmanager
+def _bare_workdir(workdir: str | Path | None, local_checkout: bool) -> Iterator[Path]:
+    """Use a supplied non-repository directory, or an isolated temp bare repo.
+
+    A local checkout is never repurposed as the fetch destination.
+    """
+    if workdir is not None and not local_checkout:
+        yield Path(workdir)
+        return
+    with tempfile.TemporaryDirectory(prefix="pulse-plan-sync-") as temp:
+        yield Path(temp)
+
+
+def _resolve_head(run: Runner, repo_dir: Path) -> str | None:
+    result = run(["git", "rev-parse", "FETCH_HEAD"], repo_dir)
+    head = _stdout(result)
+    return head if not _failed(result) and _valid_sha(head) else None
+
+
+def _resolve_blob(run: Runner, repo_dir: Path, path: str) -> str | None:
+    result = run(["git", "rev-parse", f"FETCH_HEAD:{path}"], repo_dir)
+    blob = _stdout(result)
+    return blob if not _failed(result) and _valid_sha(blob) else None
+
+
+def _read_blob(run: Runner, repo_dir: Path, blob: str) -> str | None:
+    if not _valid_sha(blob):
+        return None
+    result = run(["git", "cat-file", "blob", blob], repo_dir)
+    # Blob bytes are merge inputs: unlike ref output, a trailing newline is
+    # significant and must not be normalized away.
+    return (getattr(result, "stdout", "") or "") if not _failed(result) else None
+
+
+def _rename_target(run: Runner, repo_dir: Path, path: str) -> str | None:
+    result = run(
+        ["git", "log", "--follow", "--format=%H", "--name-only", "--", path], repo_dir
+    )
+    if _failed(result):
+        return None
+    for line in _stdout(result).splitlines():
+        candidate = line.strip()
+        if candidate != path and not _valid_sha(candidate) and _valid_path(candidate):
+            return candidate
+    return None
+
+
+def _local_dirty(run: Runner, workdir: Path, path: str) -> bool:
+    result = run(["git", "status", "--porcelain", "--", path], workdir)
+    return not _failed(result) and bool(_stdout(result))
+
+
+def _local_ahead(run: Runner, workdir: Path, head: str) -> bool:
+    if not _valid_sha(head):
+        return False
+    result = run(["git", "rev-list", "--count", f"{head}..HEAD"], workdir)
+    try:
+        return not _failed(result) and int(_stdout(result) or "0") > 0
+    except ValueError:
+        return False
+
+
+def _github_snapshot(sync: dict[str, Any], gh_api: GhApi | None) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+    """Read and normalize the V1 issue state exclusively through ``gh_api``."""
+    if gh_api is None:
+        return None, ()
+    issue_ref = sync.get("issue") or {}
+    issue_repo = issue_ref.get("repo") if isinstance(issue_ref, dict) else None
+    number = issue_ref.get("number") if isinstance(issue_ref, dict) else None
+    if not _valid_repo(issue_repo) or isinstance(number, bool) or not isinstance(number, int) or number <= 0:
+        return None, ()
+    issue = gh_api(f"/repos/{issue_repo}/issues/{number}") or {}
+    catalog = gh_api(f"/repos/{issue_repo}/milestones?state=all&per_page=100") or []
+    if not isinstance(issue, dict):
+        return None, ()
+    assignees = sorted({a.get("login") for a in issue.get("assignees") or [] if isinstance(a, dict) and a.get("login")})
+    milestone = issue.get("milestone") or {}
+    github = {
+        "title": issue.get("title"),
+        "body": issue.get("body"),
+        "state": issue.get("state"),
+        "assignees": assignees,
+        "milestone": milestone.get("title") if isinstance(milestone, dict) else None,
+    }
+    milestones = tuple(sorted({m.get("title") for m in catalog if isinstance(m, dict) and m.get("title")})) if isinstance(catalog, list) else ()
+    return github, milestones
+
+
+def _error(binding: dict[str, Any], repo: str, branch: str, path: str, head: str | None,
+           detail: str) -> tuple[DocumentSnapshot, SnapshotFinding]:
+    return (
+        DocumentSnapshot(binding, repo, branch, path, head, None, "error"),
+        SnapshotFinding("snapshot_error", repo, "high", detail=detail, path=path),
+    )
+
+
+def collect(bindings, workdir=None, runner=default_runner, gh_api=None) -> SyncSnapshot:
+    """Collect only pushed document blobs and injected GitHub API evidence.
+
+    ``bindings`` are mappings with ``repo``, ``branch``, ``path``, and either
+    a nested ``sync`` mapping or the sync fields at top level.  Failed blob
+    resolution remains explicit error evidence; it is never treated as a
+    no-op.  Local dirty/ahead documents are excluded before reconciliation.
+    """
+    raw_bindings = [item for item in (bindings or []) if isinstance(item, dict)]
+    run: Runner = runner
+    local_checkout = _is_local_checkout(run, workdir)
+    local_dir = Path(workdir) if local_checkout and workdir is not None else None
+    documents: list[DocumentSnapshot] = []
+    findings: list[SnapshotFinding] = []
+
+    pending: list[dict[str, Any]] = []
+    for binding in raw_bindings:
+        repo, branch, path, _ = _binding_values(binding)
+        if not (_valid_repo(repo) and _valid_branch(branch) and _valid_path(path)):
+            doc, finding = _error(binding, str(repo or ""), str(branch or ""), str(path or ""), None,
+                                  "invalid document repository, branch, or path")
+            documents.append(doc)
+            findings.append(finding)
+        elif local_dir is not None and _local_dirty(run, local_dir, path):
+            documents.append(DocumentSnapshot(binding, repo, branch, path, None, None, "excluded"))
+            findings.append(SnapshotFinding("dirty_doc", repo, "medium", path=path,
+                                            detail="local document changes must be pushed before sync"))
+        else:
+            pending.append(binding)
+
+    with _bare_workdir(workdir, local_checkout) as base_dir:
+        for binding in pending:
+            repo, branch, path, sync = _binding_values(binding)
+            assert isinstance(repo, str) and isinstance(branch, str) and isinstance(path, str)
+            repo_dir = base_dir / _slug(repo, branch)
+            if _failed(run(["git", "init", "--bare", "-q", "--", str(repo_dir)], None)):
+                doc, finding = _error(binding, repo, branch, path, None, "could not initialize bare repository")
+                documents.append(doc)
+                findings.append(finding)
+                continue
+            if _failed(run(["git", "fetch", "--filter=blob:none", "-q", "--", _repo_url(repo), branch], repo_dir)):
+                doc, finding = _error(binding, repo, branch, path, None, "could not fetch pushed branch")
+                documents.append(doc)
+                findings.append(finding)
+                continue
+            head = _resolve_head(run, repo_dir)
+            if head is None:
+                doc, finding = _error(binding, repo, branch, path, None, "could not resolve fetched head")
+                documents.append(doc)
+                findings.append(finding)
+                continue
+            if local_dir is not None and _local_ahead(run, local_dir, head):
+                documents.append(DocumentSnapshot(binding, repo, branch, path, head, None, "excluded"))
+                findings.append(SnapshotFinding("local_ahead", repo, "medium", path=path,
+                                                detail="local commits must be pushed before sync"))
+                continue
+            blob = _resolve_blob(run, repo_dir, path)
+            if blob is None:
+                new_path = _rename_target(run, repo_dir, path)
+                documents.append(DocumentSnapshot(binding, repo, branch, path, head, None, "excluded"))
+                findings.append(SnapshotFinding(
+                    "rename_detected" if new_path else "snapshot_error", repo,
+                    "medium" if new_path else "high", path=path, new_path=new_path,
+                    detail=(f"document was renamed to {new_path}; update its binding" if new_path
+                            else "document path is absent from pushed head"),
+                ))
+                continue
+            base = sync.get("base") if isinstance(sync, dict) else None
+            base_blob = base.get("blob") if isinstance(base, dict) else None
+            if blob == base_blob:
+                documents.append(DocumentSnapshot(binding, repo, branch, path, head, blob, "in_sync"))
+                continue
+            document_text = _read_blob(run, repo_dir, blob)
+            base_text = _read_blob(run, repo_dir, base_blob) if isinstance(base_blob, str) else None
+            if document_text is None or base_text is None:
+                doc, finding = _error(binding, repo, branch, path, head, "document or body-base blob is unavailable")
+                documents.append(doc)
+                findings.append(finding)
+                continue
+            # The base body base is the body of the reconciled base document, not
+            # its raw blob — compute() compares it against the current doc's body
+            # (frontmatter-stripped), so the base must be stripped identically.
+            base_body = parse_document(base_text).body
+            github, milestones = _github_snapshot(sync, gh_api)
+            documents.append(DocumentSnapshot(
+                binding, repo, branch, path, head, blob, "changed", parse_document(document_text),
+                base_body, github, milestones,
+            ))
+
+    return SyncSnapshot(tuple(documents), tuple(findings))

--- a/lib/pulse/scripts/plan_sync_snapshot.py
+++ b/lib/pulse/scripts/plan_sync_snapshot.py
@@ -14,19 +14,16 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
-from lib.pulse.scripts.impact_snapshot import (
-    _slug,
-    _valid_branch,
-    _valid_sha,
-    default_runner,
-)
-from lib.pulse.scripts.plan_sync import BoundDocument, parse_document
+from lib.pulse.scripts.impact_snapshot import _slug, _valid_sha, default_runner
+from lib.pulse.scripts.plan_sync import BoundDocument, compute, parse_document
+from lib.pulse.scripts.validate_result import validate_sync_binding
 
 
 Runner = Callable[..., object]
 GhApi = Callable[[str], Any]
 
 _REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_INVALID_REF_CHARS = re.compile(r"[\x00-\x20\x7f ~^:?*\[\\]")
 
 
 @dataclass(frozen=True)
@@ -90,6 +87,17 @@ def _valid_path(value: Any) -> bool:
     )
 
 
+def _valid_branch(value: Any) -> bool:
+    """Validate a branch name as one refs/heads component, never a refspec."""
+    if not isinstance(value, str) or not value or value == "@":
+        return False
+    if value.startswith(("-", ".", "/")) or value.endswith((".", "/")):
+        return False
+    if ".." in value or "@{" in value or "//" in value or _INVALID_REF_CHARS.search(value):
+        return False
+    return all(part and not part.startswith(".") and not part.endswith(".lock") for part in value.split("/"))
+
+
 def _repo_url(repo: str) -> str:
     return f"https://github.com/{repo}.git"
 
@@ -112,13 +120,7 @@ def _is_local_checkout(run: Runner, workdir: str | Path | None) -> bool:
 
 @contextlib.contextmanager
 def _bare_workdir(workdir: str | Path | None, local_checkout: bool) -> Iterator[Path]:
-    """Use a supplied non-repository directory, or an isolated temp bare repo.
-
-    A local checkout is never repurposed as the fetch destination.
-    """
-    if workdir is not None and not local_checkout:
-        yield Path(workdir)
-        return
+    """Always use an isolated, automatically removed bare-fetch directory."""
     with tempfile.TemporaryDirectory(prefix="pulse-plan-sync-") as temp:
         yield Path(temp)
 
@@ -146,14 +148,20 @@ def _read_blob(run: Runner, repo_dir: Path, blob: str) -> str | None:
 
 def _rename_target(run: Runner, repo_dir: Path, path: str) -> str | None:
     result = run(
-        ["git", "log", "--follow", "--format=%H", "--name-only", "--", path], repo_dir
+        [
+            "git", "log", "FETCH_HEAD", "--format=%H", "--name-status",
+            "--find-renames", "--diff-filter=R",
+        ],
+        repo_dir,
     )
     if _failed(result):
         return None
     for line in _stdout(result).splitlines():
-        candidate = line.strip()
-        if candidate != path and not _valid_sha(candidate) and _valid_path(candidate):
-            return candidate
+        fields = line.strip().split("\t")
+        if len(fields) == 3 and fields[0].startswith("R") and fields[1] == path:
+            candidate = fields[2]
+            if _valid_path(candidate):
+                return candidate
     return None
 
 
@@ -172,19 +180,26 @@ def _local_ahead(run: Runner, workdir: Path, head: str) -> bool:
         return False
 
 
-def _github_snapshot(sync: dict[str, Any], gh_api: GhApi | None) -> tuple[dict[str, Any] | None, tuple[str, ...]]:
+def _github_snapshot(
+    sync: dict[str, Any], gh_api: GhApi | None
+) -> tuple[dict[str, Any] | None, tuple[str, ...], str | None]:
     """Read and normalize the V1 issue state exclusively through ``gh_api``."""
     if gh_api is None:
-        return None, ()
+        return None, (), "GitHub API reader is unavailable"
     issue_ref = sync.get("issue") or {}
     issue_repo = issue_ref.get("repo") if isinstance(issue_ref, dict) else None
     number = issue_ref.get("number") if isinstance(issue_ref, dict) else None
     if not _valid_repo(issue_repo) or isinstance(number, bool) or not isinstance(number, int) or number <= 0:
-        return None, ()
-    issue = gh_api(f"/repos/{issue_repo}/issues/{number}") or {}
-    catalog = gh_api(f"/repos/{issue_repo}/milestones?state=all&per_page=100") or []
+        return None, (), "pushed sync.issue reference is invalid"
+    try:
+        issue = gh_api(f"/repos/{issue_repo}/issues/{number}")
+        catalog = gh_api(f"/repos/{issue_repo}/milestones?state=all&per_page=100")
+    except Exception as exc:
+        return None, (), f"GitHub evidence read failed: {exc}"
     if not isinstance(issue, dict):
-        return None, ()
+        return None, (), "GitHub issue evidence is missing or invalid"
+    if not isinstance(catalog, list):
+        return None, (), "GitHub milestone evidence is missing or invalid"
     assignees = sorted({a.get("login") for a in issue.get("assignees") or [] if isinstance(a, dict) and a.get("login")})
     milestone = issue.get("milestone") or {}
     github = {
@@ -194,8 +209,8 @@ def _github_snapshot(sync: dict[str, Any], gh_api: GhApi | None) -> tuple[dict[s
         "assignees": assignees,
         "milestone": milestone.get("title") if isinstance(milestone, dict) else None,
     }
-    milestones = tuple(sorted({m.get("title") for m in catalog if isinstance(m, dict) and m.get("title")})) if isinstance(catalog, list) else ()
-    return github, milestones
+    milestones = tuple(sorted({m.get("title") for m in catalog if isinstance(m, dict) and m.get("title")}))
+    return github, milestones, None
 
 
 def _error(binding: dict[str, Any], repo: str, branch: str, path: str, head: str | None,
@@ -246,7 +261,8 @@ def collect(bindings, workdir=None, runner=default_runner, gh_api=None) -> SyncS
                 documents.append(doc)
                 findings.append(finding)
                 continue
-            if _failed(run(["git", "fetch", "--filter=blob:none", "-q", "--", _repo_url(repo), branch], repo_dir)):
+            branch_ref = f"refs/heads/{branch}"
+            if _failed(run(["git", "fetch", "--filter=blob:none", "-q", "--", _repo_url(repo), branch_ref], repo_dir)):
                 doc, finding = _error(binding, repo, branch, path, None, "could not fetch pushed branch")
                 documents.append(doc)
                 findings.append(finding)
@@ -273,15 +289,31 @@ def collect(bindings, workdir=None, runner=default_runner, gh_api=None) -> SyncS
                             else "document path is absent from pushed head"),
                 ))
                 continue
-            base = sync.get("base") if isinstance(sync, dict) else None
-            base_blob = base.get("blob") if isinstance(base, dict) else None
-            if blob == base_blob:
-                documents.append(DocumentSnapshot(binding, repo, branch, path, head, blob, "in_sync"))
-                continue
             document_text = _read_blob(run, repo_dir, blob)
-            base_text = _read_blob(run, repo_dir, base_blob) if isinstance(base_blob, str) else None
-            if document_text is None or base_text is None:
-                doc, finding = _error(binding, repo, branch, path, head, "document or body-base blob is unavailable")
+            if document_text is None:
+                doc, finding = _error(binding, repo, branch, path, head, "pushed document blob is unavailable")
+                documents.append(doc)
+                findings.append(finding)
+                continue
+            document = parse_document(document_text)
+            binding_errors = validate_sync_binding(document.binding)
+            if binding_errors:
+                doc, finding = _error(
+                    binding, repo, branch, path, head,
+                    "invalid pushed sync binding: " + "; ".join(binding_errors),
+                )
+                documents.append(doc)
+                findings.append(finding)
+                continue
+            authoritative = {
+                key: binding[key] for key in ("id", "repo", "branch", "path") if key in binding
+            }
+            authoritative["sync"] = document.binding
+            base = document.binding.get("base")
+            base_blob = base.get("blob") if isinstance(base, dict) else None
+            base_text = document_text if base_blob == blob else _read_blob(run, repo_dir, base_blob)
+            if base_text is None:
+                doc, finding = _error(authoritative, repo, branch, path, head, "body-base blob is unavailable")
                 documents.append(doc)
                 findings.append(finding)
                 continue
@@ -289,9 +321,25 @@ def collect(bindings, workdir=None, runner=default_runner, gh_api=None) -> SyncS
             # its raw blob — compute() compares it against the current doc's body
             # (frontmatter-stripped), so the base must be stripped identically.
             base_body = parse_document(base_text).body
-            github, milestones = _github_snapshot(sync, gh_api)
+            github, milestones, github_error = _github_snapshot(document.binding, gh_api)
+            if github_error is not None:
+                doc, finding = _error(authoritative, repo, branch, path, head, github_error)
+                documents.append(doc)
+                findings.append(finding)
+                continue
+            reconciliation = compute(
+                document, github, document.binding, base_body, document_blob=blob
+            )
+            state = "in_sync" if not (
+                reconciliation.conflicted
+                or reconciliation.doc_patch
+                or reconciliation.github_patch
+                or reconciliation.base_patch
+                or reconciliation.doc_base_patch
+                or reconciliation.requires_final_blob
+            ) else "changed"
             documents.append(DocumentSnapshot(
-                binding, repo, branch, path, head, blob, "changed", parse_document(document_text),
+                authoritative, repo, branch, path, head, blob, state, document,
                 base_body, github, milestones,
             ))
 

--- a/lib/pulse/scripts/poll.py
+++ b/lib/pulse/scripts/poll.py
@@ -243,6 +243,45 @@ def check_branch_heads(config_dir: Path, state: dict) -> bool:
     return changed
 
 
+def _doc_watches(config_dir: Path) -> list[tuple[str, str]]:
+    """Unique pushed repo/branch pairs for locally configured bound docs."""
+    config = load_yaml(config_dir / "plan-sync.yaml")
+    pairs: set[tuple[str, str]] = set()
+    for doc in (config.get("docs") or []):
+        if not isinstance(doc, dict):
+            continue
+        repo = doc.get("repo")
+        branch = doc.get("branch")
+        if repo and branch:
+            pairs.add((repo, branch))
+    return sorted(pairs)
+
+
+def check_docs(config_dir: Path, state: dict) -> bool:
+    """Trigger-only pushed-head watch for configured plan documents.
+
+    This deliberately mirrors ``check_branch_heads``: first observations
+    baseline, later pushed-head movement triggers, and document content is
+    never fetched or diffed by the poller.
+    """
+    watches = _doc_watches(config_dir)
+    if not watches:
+        return False
+    slot = state.setdefault("docs", {})
+    changed = False
+    for repo, branch in watches:
+        resp = gh_api(f"/repos/{repo}/git/ref/heads/{branch}") or {}
+        sha = ((resp.get("object") or {}).get("sha"))
+        if not sha:
+            continue
+        repo_slot = slot.setdefault(repo, {})
+        previous = repo_slot.get(branch)
+        repo_slot[branch] = sha
+        if previous is not None and previous != sha:
+            changed = True
+    return changed
+
+
 REPO_CHECKS = {
     "pull_requests": check_pull_requests,
     "issues": check_issues,
@@ -270,6 +309,8 @@ def evaluate_source(source: str, repo: str, config: dict, config_dir: Path,
         changed = check_org_repos(config, state)
     elif source == "branch_heads":
         changed = check_branch_heads(config_dir, state)
+    elif source == "docs":
+        changed = check_docs(config_dir, state)
     cache[source] = changed
     return changed
 

--- a/lib/pulse/scripts/tests/fixtures/plan-sync-binding-invalid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/plan-sync-binding-invalid.yaml
@@ -1,0 +1,9 @@
+sync:
+  issue:
+    repo: testorg/widget
+    number: 42
+  policy:
+    title: merge
+  base:
+    title: "Synchronize widget planning"
+  labels: [bug]

--- a/lib/pulse/scripts/tests/fixtures/plan-sync-binding-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/plan-sync-binding-valid.yaml
@@ -1,0 +1,17 @@
+title: Synchronize widget planning
+sync:
+  issue:
+    repo: testorg/widget
+    number: 42
+  policy:
+    title: conflict
+    state: conflict
+    assignees: prefer-doc
+    milestone: prefer-github
+    body: conflict
+  base:
+    blob: 0123456789abcdef0123456789abcdef01234567
+    title: "Synchronize widget planning"
+    state: open
+    assignees: [octocat]
+    milestone: "v2.0"

--- a/lib/pulse/scripts/tests/fixtures/plan-sync-invalid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/plan-sync-invalid.yaml
@@ -1,0 +1,13 @@
+contract_version: 1
+kind: plan-sync
+workspace: testorg
+run_at: "2026-07-21T09:15:00Z"
+in_sync: 2
+doc_patches: 1
+github_patches: 1
+conflicts: 1
+excluded: 1
+findings:
+  - kind: base_conflict
+    repo: testorg/widget
+errors: []

--- a/lib/pulse/scripts/tests/fixtures/plan-sync-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/plan-sync-valid.yaml
@@ -1,0 +1,20 @@
+contract_version: 1
+kind: plan-sync
+workspace: testorg
+run_at: "2026-07-21T09:15:00Z"
+actor:
+  gh_login: octocat
+  machine: mba-m4
+  mode: scheduled
+docs_scanned: 6
+in_sync: 2
+doc_patches: 1
+github_patches: 1
+conflicts: 1
+excluded: 1
+findings:
+  - kind: base_conflict
+    repo: testorg/widget
+    severity: high
+    detail: "The title changed in both the document and GitHub."
+errors: []

--- a/lib/pulse/scripts/tests/fixtures/plan-sync-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/plan-sync-valid.yaml
@@ -17,4 +17,10 @@ findings:
     repo: testorg/widget
     severity: high
     detail: "The title changed in both the document and GitHub."
+proposals:
+  - binding: release-plan
+    transformation: plan-sync-doc-patch
+    proposal_id: plan-sync-doc-release-plan
+proposed_actions:
+  - propose document patch for release-plan
 errors: []

--- a/lib/pulse/scripts/tests/test_apply_doc_patch.py
+++ b/lib/pulse/scripts/tests/test_apply_doc_patch.py
@@ -1,0 +1,120 @@
+"""Black-box tests for the guarded plan-document patch script."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import subprocess
+import sys
+
+import yaml
+
+
+SCRIPT = Path("lib/pulse/scripts/apply_doc_patch.py").resolve()
+
+
+def _blob(text: str) -> str:
+    data = text.encode()
+    return hashlib.sha1(f"blob {len(data)}\0".encode() + data).hexdigest()
+
+
+def _write_patch(repo: Path, patch: dict) -> None:
+    patch_path = repo / ".hiivmind" / "plan-sync-patch.yaml"
+    patch_path.parent.mkdir()
+    patch_path.write_text(yaml.safe_dump(patch, sort_keys=False))
+
+
+def _run(repo: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--patch", ".hiivmind/plan-sync-patch.yaml"],
+        cwd=repo,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_apply_doc_patch_exits_zero_and_updates_the_bound_document(tmp_path):
+    document = "---\nsync:\n  base:\n    blob: old\n---\n# Old title\n"
+    target = tmp_path / "plans" / "widget.md"
+    target.parent.mkdir()
+    target.write_text(document)
+    _write_patch(
+        tmp_path,
+        {
+            "path": "plans/widget.md",
+            "base_blob": _blob(document),
+            "doc_patch": {"title": "New title"},
+            "sync_patch": {"blob": "new"},
+            "output_paths": ["plans/widget.md"],
+        },
+    )
+
+    result = _run(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert target.read_text() == document.replace("blob: old", "blob: new").replace(
+        "# Old title", "# New title"
+    )
+
+
+def test_apply_doc_patch_exits_nonzero_when_the_bound_document_is_missing(tmp_path):
+    _write_patch(
+        tmp_path,
+        {
+            "path": "plans/missing.md",
+            "base_blob": "deadbeef",
+            "doc_patch": {},
+            "sync_patch": {},
+            "output_paths": ["plans/missing.md"],
+        },
+    )
+
+    result = _run(tmp_path)
+
+    assert result.returncode != 0
+    assert "not found" in result.stderr
+
+
+def test_apply_doc_patch_exits_nonzero_when_the_document_blob_no_longer_matches(tmp_path):
+    target = tmp_path / "plans" / "widget.md"
+    target.parent.mkdir()
+    target.write_text("# Current title\n")
+    _write_patch(
+        tmp_path,
+        {
+            "path": "plans/widget.md",
+            "base_blob": _blob("# Previous title\n"),
+            "doc_patch": {"title": "New title"},
+            "sync_patch": {},
+            "output_paths": ["plans/widget.md"],
+        },
+    )
+
+    result = _run(tmp_path)
+
+    assert result.returncode != 0
+    assert "base blob mismatch" in result.stderr
+
+
+def test_apply_doc_patch_rejects_a_document_outside_its_bound_output_allowlist(tmp_path):
+    document = "# Old title\n"
+    target = tmp_path / "plans" / "widget.md"
+    target.parent.mkdir()
+    target.write_text(document)
+    _write_patch(
+        tmp_path,
+        {
+            "path": "plans/widget.md",
+            "base_blob": _blob(document),
+            "doc_patch": {"title": "New title"},
+            "sync_patch": {},
+            "output_paths": ["plans/other.md"],
+        },
+    )
+
+    result = _run(tmp_path)
+
+    assert result.returncode != 0
+    assert "outside the output allowlist" in result.stderr
+    assert target.read_text() == document

--- a/lib/pulse/scripts/tests/test_plan_sync.py
+++ b/lib/pulse/scripts/tests/test_plan_sync.py
@@ -1,8 +1,11 @@
 """Round-trip and reconciliation tests for plan-document synchronization."""
 
+import json
+from pathlib import Path
+
 import pytest
 
-from lib.pulse.scripts import plan_sync
+from lib.pulse.scripts import mutation_plan, nave_adapter, pen_orchestrator, plan_sync
 from lib.pulse.scripts.plan_sync import parse_document, patch_document
 
 
@@ -178,3 +181,188 @@ def test_compute_keeps_non_conflicting_field_applies_when_another_field_conflict
     assert plan.base_patch == {"assignees": ["ada", "zoe"]}
     assert plan.conflicts == ("title",)
     assert plan.conflicted is True
+
+
+def _pen_show(repo):
+    owner, name = repo.split("/", 1)
+    return nave_adapter.Completed(
+        0,
+        json.dumps(
+            {
+                "name": "nave/plan-sync",
+                "created_at": "2026-07-21T00:00:00Z",
+                "branch": "nave/plan-sync",
+                "filter": {"terms": []},
+                "repos": [
+                    {
+                        "owner": owner,
+                        "name": name,
+                        "default_branch": "main",
+                        "clone_url": "x",
+                        "synced_at": "2026-07-21T00:00:00Z",
+                    }
+                ],
+                "ops": [],
+            }
+        ),
+        "",
+    )
+
+
+def _clean_pen_status(repo):
+    owner, name = repo.split("/", 1)
+    return nave_adapter.Completed(
+        0,
+        json.dumps(
+            [
+                {
+                    "owner": owner,
+                    "repo": name,
+                    "working_tree": "clean",
+                    "freshness": "fresh",
+                    "run_state": "not-run",
+                    "divergence": "up-to-date",
+                    "ahead": 0,
+                    "behind": 0,
+                }
+            ]
+        ),
+        "",
+    )
+
+
+class _QueuedRunner:
+    def __init__(self, results):
+        self.calls = []
+        self.results = list(results)
+
+    def run(self, args):
+        self.calls.append(args)
+        return self.results.pop(0)
+
+
+def _binding():
+    return {
+        "id": "widget-plan",
+        "repo": "acme/docs",
+        "branch": "main",
+        "path": "plans/widget.md",
+        "sync": {"issue": {"repo": "acme/widgets", "number": 42}},
+    }
+
+
+def _snapshot():
+    return {"repo": "acme/docs", "head": "head-at-snapshot", "blob": "blob-at-snapshot"}
+
+
+def _actor():
+    return {"gh_login": "octocat", "machine": "test-mac", "mode": "interactive"}
+
+
+def test_build_apply_plans_keeps_document_and_github_proposals_separate_and_propose_only():
+    reconciliation = plan_sync.ReconciliationPlan(
+        {"state": "closed"},
+        {"title": "Document title"},
+        {"state": "closed", "title": "Document title"},
+        (),
+    )
+
+    plans = plan_sync.build_apply_plans(reconciliation, _binding(), _snapshot(), _actor())
+
+    assert isinstance(plans.repo_mutation, mutation_plan.Proposal)
+    assert plans.repo_mutation.selection == ("acme/docs",)
+    assert plans.repo_mutation.expected_shas == {"acme/docs": "head-at-snapshot"}
+    assert plans.repo_mutation.transformation == "plan-sync-doc-patch"
+    assert plans.repo_mutation.mutation_policy == "propose"
+    assert plans.doc_patch == {
+        "path": "plans/widget.md",
+        "base_blob": "blob-at-snapshot",
+        "doc_patch": {"state": "closed"},
+        "sync_patch": {},
+        "output_paths": ["plans/widget.md"],
+    }
+    assert plans.github_mutation == {
+        "repo": "acme/widgets",
+        "number": 42,
+        "patch": {"title": "Document title"},
+        "mutation_policy": "propose",
+        "proposed_actions": [
+            "propose GitHub issue patch for acme/widgets#42: {\"title\": \"Document title\"}"
+        ],
+    }
+
+
+def test_expected_blob_mismatch_blocks_the_separate_document_proposal_before_exec(monkeypatch):
+    reconciliation = plan_sync.ReconciliationPlan(
+        {"title": "Current GitHub title"}, {}, {"title": "Current GitHub title"}, ()
+    )
+    plans = plan_sync.build_apply_plans(reconciliation, _binding(), _snapshot(), _actor())
+    registry = mutation_plan.load_registry(Path("templates/transformations.yaml.template"))
+    entry = registry.get(plans.repo_mutation.transformation)
+    pen_plan = pen_orchestrator.PenPlan(
+        proposal=plans.repo_mutation,
+        entry=entry,
+        pen_name="nave/plan-sync",
+        query=nave_adapter.PenQuery(terms=["repo:acme/docs"]),
+    )
+    runner = _QueuedRunner(
+        [
+            nave_adapter.Completed(0, "created\n", ""),
+            _pen_show("acme/docs"),
+            _clean_pen_status("acme/docs"),
+        ]
+    )
+    monkeypatch.setattr(
+        pen_orchestrator.nave_adapter,
+        "probe",
+        lambda _runner: {"available": True, "version": "0.0.9", "protocol": 1},
+    )
+
+    result = pen_orchestrator.execute(
+        pen_plan, runner, read_repo_head=lambda _repo: "different-current-blob"
+    )
+
+    assert result.state == "blocked"
+    assert result.repo_outcomes == {"acme/docs": "blocked"}
+    assert result.reason is not None
+    assert "acme/docs" in result.reason
+    assert not any("exec" in call for call in runner.calls)
+
+
+@pytest.mark.parametrize(
+    ("doc_applied", "github_applied", "expected_base"),
+    [
+        (True, False, {"state": "closed"}),
+        (False, True, {"title": "Document title"}),
+    ],
+)
+def test_finalize_advances_only_the_confirmed_side_and_reports_partial_application(
+    doc_applied, github_applied, expected_base
+):
+    reconciliation = plan_sync.ReconciliationPlan(
+        {"state": "closed"},
+        {"title": "Document title"},
+        {"state": "closed", "title": "Document title"},
+        (),
+    )
+
+    decision = plan_sync.finalize(reconciliation, doc_applied, github_applied)
+
+    assert decision.base_patch == expected_base
+    assert [finding.kind for finding in decision.findings] == ["partial_application"]
+
+
+def test_finalize_one_sided_reconciliation_is_not_a_partial_application():
+    # Only the document changed; there is no GitHub patch. Applying the single
+    # side is a COMPLETE reconciliation, not a partial one — no finding.
+    reconciliation = plan_sync.ReconciliationPlan(
+        {"state": "closed"},
+        {},
+        {"state": "closed"},
+        (),
+    )
+
+    decision = plan_sync.finalize(reconciliation, doc_applied=True, github_applied=False)
+
+    assert decision.base_patch == {"state": "closed"}
+    assert decision.findings == ()

--- a/lib/pulse/scripts/tests/test_plan_sync.py
+++ b/lib/pulse/scripts/tests/test_plan_sync.py
@@ -183,6 +183,106 @@ def test_compute_keeps_non_conflicting_field_applies_when_another_field_conflict
     assert plan.conflicted is True
 
 
+def test_body_base_advances_as_blob_and_validates_as_sync_binding():
+    current_blob = "c" * 40
+    base = {field: values[0] for field, values in FIELD_VALUES.items() if field != "body"}
+    binding = {"issue": {"repo": "acme/widgets", "number": 42}, "base": base | {"blob": "b" * 40}}
+
+    plan = plan_sync.compute(
+        {**base, "body": "Document body\n"},
+        {**base, "body": FIELD_VALUES["body"][0]},
+        binding,
+        FIELD_VALUES["body"][0],
+        document_blob=current_blob,
+    )
+    finalized = plan_sync.finalize(plan, doc_applied=False, github_applied=True)
+
+    assert plan.base_patch == {"blob": current_blob}
+    assert "body" not in plan.base_patch
+    merged_binding = {**binding, "base": binding["base"] | finalized.base_patch}
+    from lib.pulse.scripts.validate_result import validate_sync_binding
+    assert validate_sync_binding(merged_binding) == []
+
+
+def test_body_blob_base_waits_for_the_github_patch_confirmation():
+    current_blob = "c" * 40
+    base = {field: values[0] for field, values in FIELD_VALUES.items() if field != "body"}
+    binding = {"issue": {"repo": "acme/widgets", "number": 42}, "base": base | {"blob": "b" * 40}}
+    plan = plan_sync.compute(
+        {**base, "body": "Document body\n"},
+        {**base, "body": FIELD_VALUES["body"][0]},
+        binding,
+        FIELD_VALUES["body"][0],
+        document_blob=current_blob,
+    )
+
+    assert plan_sync.finalize(plan, doc_applied=False, github_applied=False).base_patch == {}
+    assert plan_sync.finalize(plan, doc_applied=False, github_applied=True).base_patch == {
+        "blob": current_blob
+    }
+
+
+def test_github_body_change_uses_confirmed_applied_document_blob_as_base():
+    base = {field: values[0] for field, values in FIELD_VALUES.items() if field != "body"}
+    binding = {"issue": {"repo": "acme/widgets", "number": 42}, "base": base | {"blob": "b" * 40}}
+    plan = plan_sync.compute(
+        {**base, "body": FIELD_VALUES["body"][0]},
+        {**base, "body": "GitHub body\n"},
+        binding,
+        FIELD_VALUES["body"][0],
+        document_blob="c" * 40,
+    )
+
+    assert "body" not in plan.base_patch
+    assert plan_sync.finalize(
+        plan,
+        doc_applied=True,
+        github_applied=False,
+        confirmed_document_blob="d" * 40,
+    ).base_patch == {"blob": "d" * 40}
+
+
+@pytest.mark.parametrize(
+    ("field", "base_value", "github_value"),
+    [
+        ("state", "open", "closed"),
+        ("assignees", ["ada"], ["ada", "zoe"]),
+        ("milestone", None, "M2"),
+    ],
+)
+def test_github_only_scalar_change_is_a_frontmatter_base_patch_not_a_body_edit(
+    field, base_value, github_value
+):
+    base = {
+        "blob": "b" * 40,
+        "title": "Release plan",
+        "state": "open",
+        "assignees": ["ada"],
+        "milestone": None,
+    }
+    binding = {"issue": {"repo": "acme/widgets", "number": 42}, "base": base}
+    source = (
+        "---\nsync:\n"
+        "  issue: {repo: acme/widgets, number: 42}\n"
+        f"  base: {{blob: {'b' * 40}, title: Release plan, state: open, assignees: [ada], milestone: null}}\n"
+        "---\n# Release plan\n"
+    )
+    github = {"title": "Release plan", "body": "# Release plan\n", **{k: base[k] for k in ("state", "assignees", "milestone")}}
+    github[field] = github_value
+
+    reconciliation = plan_sync.compute(parse_document(source), github, binding, "# Release plan\n")
+    plans = plan_sync.build_apply_plans(reconciliation, _binding(), _snapshot(), _actor())
+    patched = patch_document(source, plans.doc_patch["doc_patch"], plans.doc_patch["sync_patch"])
+
+    assert reconciliation.doc_patch == {}
+    assert reconciliation.base_patch == {field: sorted(set(github_value)) if field == "assignees" else github_value}
+    assert plans.repo_mutation is not None
+    assert plans.doc_patch["doc_patch"] == {}
+    assert plans.doc_patch["sync_patch"] == {"base": reconciliation.base_patch}
+    assert parse_document(patched).binding["base"][field] == reconciliation.base_patch[field]
+    assert parse_document(patched).body == "# Release plan\n"
+
+
 def _pen_show(repo):
     owner, name = repo.split("/", 1)
     return nave_adapter.Completed(

--- a/lib/pulse/scripts/tests/test_plan_sync.py
+++ b/lib/pulse/scripts/tests/test_plan_sync.py
@@ -1,5 +1,8 @@
-"""Round-trip tests for lossless plan-document synchronization."""
+"""Round-trip and reconciliation tests for plan-document synchronization."""
 
+import pytest
+
+from lib.pulse.scripts import plan_sync
 from lib.pulse.scripts.plan_sync import parse_document, patch_document
 
 
@@ -60,3 +63,118 @@ def test_body_patch_uses_the_replacement_verbatim():
     patched = patch_document(DOCUMENT, {"body": replacement}, {})
 
     assert patched == DOCUMENT[:DOCUMENT.index("# Original title")] + replacement
+
+
+FIELD_VALUES = {
+    "title": ("Base title", "Document title", "GitHub title"),
+    "state": ("open", "closed", "in progress"),
+    "assignees": (["ada"], ["zoe", "ada", "zoe"], ["bea"]),
+    "milestone": ("M1", "M2", "M3"),
+    "body": ("Base body\n", "Document body\n", "GitHub body\n"),
+}
+
+
+@pytest.mark.parametrize("field", FIELD_VALUES)
+@pytest.mark.parametrize(
+    ("scenario", "doc_source", "github_source", "policy", "expected"),
+    [
+        ("neither", "base", "base", None, ("noop", None)),
+        (
+            "document only",
+            "doc",
+            "base",
+            None,
+            ("apply_to_github", "doc"),
+        ),
+        (
+            "github only",
+            "base",
+            "github",
+            None,
+            ("apply_to_doc", "github"),
+        ),
+        ("both agree", "doc", "doc", None, ("agree", "doc")),
+        ("conflict", "doc", "github", None, ("conflict", None)),
+        (
+            "prefer document",
+            "doc",
+            "github",
+            "prefer-doc",
+            ("apply_to_github", "doc"),
+        ),
+        (
+            "prefer github",
+            "doc",
+            "github",
+            "prefer-github",
+            ("apply_to_doc", "github"),
+        ),
+    ],
+)
+def test_merge_field_full_three_way_matrix(
+    field, scenario, doc_source, github_source, policy, expected
+):
+    base, document_change, github_change = FIELD_VALUES[field]
+    values = {"base": base, "doc": document_change, "github": github_change}
+    expected_decision, expected_value_source = expected
+    expected_value = values[expected_value_source] if expected_value_source else None
+    if field == "assignees" and expected_value is not None:
+        expected_value = sorted(set(expected_value))
+
+    assert callable(getattr(plan_sync, "merge_field", None))
+
+    decision = plan_sync.merge_field(
+        field, base, values[doc_source], values[github_source], policy=policy
+    )
+
+    assert decision == plan_sync.FieldDecision(expected_decision, expected_value)
+
+
+def test_merge_field_normalizes_assignee_order_and_duplicates_before_comparison():
+    assert callable(getattr(plan_sync, "merge_field", None))
+
+    decision = plan_sync.merge_field(
+        "assignees",
+        ["ada"],
+        ["zoe", "ada", "zoe"],
+        ["ada"],
+    )
+
+    assert decision == plan_sync.FieldDecision("apply_to_github", ["ada", "zoe"])
+
+
+def test_compute_treats_missing_and_null_milestones_as_the_same_value():
+    assert callable(getattr(plan_sync, "compute", None))
+
+    plan = plan_sync.compute(
+        {field: base for field, (base, _, _) in FIELD_VALUES.items() if field != "milestone"},
+        {
+            field: base
+            for field, (base, _, _) in FIELD_VALUES.items()
+            if field != "milestone"
+        }
+        | {"milestone": None},
+        {"base": {field: base for field, (base, _, _) in FIELD_VALUES.items()}},
+        FIELD_VALUES["body"][0],
+    )
+
+    assert plan == plan_sync.ReconciliationPlan({}, {}, {"milestone": None}, ())
+    assert plan.conflicted is False
+
+
+def test_compute_keeps_non_conflicting_field_applies_when_another_field_conflicts():
+    base = {field: values[0] for field, values in FIELD_VALUES.items()}
+    assert callable(getattr(plan_sync, "compute", None))
+
+    plan = plan_sync.compute(
+        base | {"title": "Document title", "assignees": ["zoe", "ada", "zoe"]},
+        base | {"title": "GitHub title"},
+        {"base": base},
+        base["body"],
+    )
+
+    assert plan.doc_patch == {}
+    assert plan.github_patch == {"assignees": ["ada", "zoe"]}
+    assert plan.base_patch == {"assignees": ["ada", "zoe"]}
+    assert plan.conflicts == ("title",)
+    assert plan.conflicted is True

--- a/lib/pulse/scripts/tests/test_plan_sync.py
+++ b/lib/pulse/scripts/tests/test_plan_sync.py
@@ -1,0 +1,62 @@
+"""Round-trip tests for lossless plan-document synchronization."""
+
+from lib.pulse.scripts.plan_sync import parse_document, patch_document
+
+
+DOCUMENT = """---\n# Keep this frontmatter comment.\nowner: docs-team\ncustom: # Unknown keys must survive sync patches.\n  review: required\nsync:\n  issue: {repo: acme/widgets, number: 42}\n  base:\n    blob: deadbeef\n    title: Original title\n---\n# Original title\n\nThis body must remain exactly as written.  \n"""
+
+
+def test_parse_document_preserves_frontmatter_comments_unknown_keys_and_body_bytes():
+    document = parse_document(DOCUMENT)
+
+    assert document.frontmatter["owner"] == "docs-team"
+    assert document.frontmatter["custom"]["review"] == "required"
+    assert document.binding is document.frontmatter["sync"]
+    assert document.title == "Original title"
+    assert document.body == "# Original title\n\nThis body must remain exactly as written.  \n"
+
+
+def test_parse_document_allows_unbound_documents():
+    source = "---\nowner: docs-team\n---\n# Standalone plan\n\nNo sync block.\n"
+
+    document = parse_document(source)
+
+    assert document.frontmatter["owner"] == "docs-team"
+    assert document.binding is None
+    assert document.title == "Standalone plan"
+    assert document.body == "# Standalone plan\n\nNo sync block.\n"
+
+
+def test_noop_patch_returns_byte_identical_document():
+    assert patch_document(DOCUMENT, {}, {}) == DOCUMENT
+
+
+def test_sync_base_patch_preserves_frontmatter_comments_unknown_keys_and_body_bytes():
+    patched = patch_document(DOCUMENT, {}, {"blob": "cafebabe"})
+
+    assert patched == DOCUMENT.replace("blob: deadbeef", "blob: cafebabe")
+
+
+def test_patch_preserves_crlf_line_endings_and_untouched_body_bytes():
+    document = DOCUMENT.replace("\n", "\r\n")
+
+    patched = patch_document(document, {}, {"blob": "cafebabe"})
+
+    assert patched == document.replace("blob: deadbeef", "blob: cafebabe")
+    assert "\n" not in patched.replace("\r\n", "")
+
+
+def test_retitle_changes_only_the_first_h1_line():
+    document = "# Old title\n\n# Later H1 stays\n"
+
+    patched = patch_document(document, {"title": "New title"}, {})
+
+    assert patched == "# New title\n\n# Later H1 stays\n"
+
+
+def test_body_patch_uses_the_replacement_verbatim():
+    replacement = "# Replacement\r\n\r\nBody with CRLF.\r\n"
+
+    patched = patch_document(DOCUMENT, {"body": replacement}, {})
+
+    assert patched == DOCUMENT[:DOCUMENT.index("# Original title")] + replacement

--- a/lib/pulse/scripts/tests/test_plan_sync_acceptance.py
+++ b/lib/pulse/scripts/tests/test_plan_sync_acceptance.py
@@ -1,0 +1,246 @@
+"""Offline acceptance coverage for the F8 plan synchronization contract."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from lib.pulse.scripts import (
+    mutation_plan,
+    nave_adapter,
+    pen_orchestrator,
+    plan_sync,
+    plan_sync_snapshot,
+    validate_result,
+)
+
+
+SKILL = Path("skills/gh-plan-sync-headless/SKILL.md")
+WORKFLOW = Path("templates/workflows/plan-sync.yaml")
+HEAD = "a" * 40
+BASE_BLOB = "b" * 40
+CURRENT_BLOB = "c" * 40
+REPO = "acme/docs"
+ISSUE_REPO = "acme/widgets"
+PATH = "plans/release.md"
+ACTOR = {"gh_login": "octocat", "machine": "acceptance-mba", "mode": "scheduled"}
+BASE = {
+    "title": "Release plan",
+    "state": "open",
+    "assignees": ["ada"],
+    "milestone": None,
+    "body": "# Release plan\n\nBase body.\n",
+}
+
+
+@dataclass
+class Completed:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+class SnapshotRunner:
+    """Hermetic remote-document fixture; no subprocesses or network."""
+
+    def __init__(self, document: str, *, blob: str = CURRENT_BLOB, rename: str | None = None):
+        self.document = document
+        self.blob = blob
+        self.rename = rename
+        self.calls = []
+
+    def __call__(self, argv, cwd=None):
+        self.calls.append(tuple(argv))
+        if tuple(argv) == ("git", "rev-parse", "--is-inside-work-tree"):
+            return Completed(1)
+        if argv[:3] == ["git", "init", "--bare"] or argv[:2] == ["git", "fetch"]:
+            return Completed()
+        if tuple(argv) == ("git", "rev-parse", "FETCH_HEAD"):
+            return Completed(0, f"{HEAD}\n")
+        if tuple(argv) == ("git", "rev-parse", f"FETCH_HEAD:{PATH}"):
+            return Completed(0, f"{self.blob}\n") if self.rename is None else Completed(128, "", "missing")
+        if tuple(argv[:3]) == ("git", "cat-file", "blob"):
+            return Completed(0, self.document if argv[-1] == CURRENT_BLOB else BASE["body"])
+        if tuple(argv[:3]) == ("git", "log", "--follow") and self.rename:
+            return Completed(0, f"{HEAD}\n{self.rename}\n{BASE_BLOB}\n{PATH}\n")
+        return Completed(1, "", f"unexpected: {argv}")
+
+
+def _binding(base_blob: str = BASE_BLOB):
+    return {
+        "id": "release-plan",
+        "repo": REPO,
+        "branch": "main",
+        "path": PATH,
+        "sync": {
+            "issue": {"repo": ISSUE_REPO, "number": 42},
+            "base": {key: value for key, value in BASE.items() if key != "body"} | {"blob": base_blob},
+        },
+    }
+
+
+def _document(values: dict) -> str:
+    return (
+        "---\n"
+        f"state: {values['state']}\n"
+        f"assignees: [{', '.join(values['assignees'])}]\n"
+        f"milestone: {values['milestone'] if values['milestone'] is not None else ''}\n"
+        "sync:\n"
+        "  issue: {repo: acme/widgets, number: 42}\n"
+        f"  base: {{blob: {BASE_BLOB}, title: Release plan, state: open, assignees: [ada], milestone: null}}\n"
+        "---\n"
+        f"# {values['title']}\n\n"
+        f"{values['body'].split('\n\n', 1)[1]}"
+    )
+
+
+def _github(values: dict):
+    def api(endpoint):
+        if endpoint == "/repos/acme/widgets/issues/42":
+            return {
+                "title": values["title"], "body": values["body"], "state": values["state"],
+                "assignees": [{"login": name} for name in values["assignees"]],
+                "milestone": None if values["milestone"] is None else {"title": values["milestone"]},
+            }
+        if endpoint == "/repos/acme/widgets/milestones?state=all&per_page=100":
+            return []
+        raise AssertionError(endpoint)
+    return api
+
+
+def _collect(values: dict, tmp_path, *, blob: str = CURRENT_BLOB, github_values: dict | None = None):
+    snapshot = plan_sync_snapshot.collect(
+        [_binding()], workdir=tmp_path, runner=SnapshotRunner(_document(values), blob=blob),
+        gh_api=_github(github_values or values),
+    )
+    return snapshot.documents[0]
+
+
+def _counts(document, reconciliation):
+    """The result buckets used by the headless orchestration document."""
+    result = {"docs_scanned": 1, "in_sync": 0, "doc_patches": 0,
+              "github_patches": 0, "conflicts": 0, "excluded": 0}
+    if document.state == "in_sync":
+        result["in_sync"] = 1
+    elif document.state == "excluded":
+        result["excluded"] = 1
+    elif reconciliation.conflicted:
+        result["conflicts"] = 1
+    elif reconciliation.doc_patch or reconciliation.github_patch:
+        result["doc_patches"] = int(bool(reconciliation.doc_patch))
+        result["github_patches"] = int(bool(reconciliation.github_patch))
+    else:
+        result["in_sync"] = 1
+    return result
+
+
+@pytest.mark.parametrize(
+    ("doc_values", "github_values", "expected"),
+    [
+        (BASE, BASE, {"in_sync": 1}),
+        (BASE | {"state": "closed"}, BASE, {"github_patches": 1}),
+        (BASE, BASE | {"state": "closed"}, {"doc_patches": 1}),
+        (BASE | {"state": "closed"}, BASE | {"state": "in progress"}, {"conflicts": 1}),
+        (BASE | {"state": "closed"}, BASE | {"state": "closed"}, {"in_sync": 1}),
+    ],
+    ids=("noop", "document-to-github", "github-to-document", "conflict", "agree"),
+)
+def test_merge_outcomes_land_in_their_result_buckets(tmp_path, doc_values, github_values, expected):
+    document = _collect(doc_values, tmp_path, github_values=github_values)
+    reconciliation = plan_sync.compute(document.document, document.github, document.binding["sync"], document.base_body)
+    plans = plan_sync.build_apply_plans(reconciliation, document.binding, document, ACTOR)
+    plan_sync.finalize(reconciliation, doc_applied=False, github_applied=False)
+
+    counts = _counts(document, reconciliation)
+
+    assert {key: counts[key] for key in expected} == expected
+    assert (plans.doc_patch is not None) == bool(reconciliation.doc_patch)
+    assert (plans.github_mutation is not None) == bool(reconciliation.github_patch)
+
+
+def test_rename_and_local_ahead_are_excluded_from_reconciliation(tmp_path):
+    renamed = plan_sync_snapshot.collect(
+        [_binding()], workdir=tmp_path,
+        runner=SnapshotRunner(_document(BASE), rename="plans/renamed-release.md"), gh_api=_github(BASE),
+    ).documents[0]
+    assert renamed.state == "excluded"
+    assert _counts(renamed, plan_sync.ReconciliationPlan({}, {}, {}, ()))["excluded"] == 1
+
+    class LocalAheadRunner(SnapshotRunner):
+        def __call__(self, argv, cwd=None):
+            if tuple(argv) == ("git", "rev-parse", "--is-inside-work-tree"):
+                return Completed(0, "true\n")
+            if tuple(argv) == ("git", "status", "--porcelain", "--", PATH):
+                return Completed()
+            if tuple(argv) == ("git", "rev-list", "--count", f"{HEAD}..HEAD"):
+                return Completed(0, "1\n")
+            return super().__call__(argv, cwd)
+
+    ahead = plan_sync_snapshot.collect(
+        [_binding()], workdir=tmp_path, runner=LocalAheadRunner(_document(BASE)), gh_api=_github(BASE)
+    ).documents[0]
+    assert ahead.state == "excluded"
+    assert _counts(ahead, plan_sync.ReconciliationPlan({}, {}, {}, ()))["excluded"] == 1
+
+
+def _pen_show():
+    return nave_adapter.Completed(0, json.dumps({
+        "name": "nave/plan-sync", "created_at": "2026-07-21T00:00:00Z", "branch": "nave/plan-sync",
+        "filter": {"terms": []}, "repos": [{"owner": "acme", "name": "docs", "default_branch": "main", "clone_url": "x", "synced_at": "2026-07-21T00:00:00Z"}], "ops": [],
+    }), "")
+
+
+def test_remote_base_advance_blocks_document_proposal_before_pen_execution(tmp_path, monkeypatch):
+    document = _collect(BASE, tmp_path)
+    changed = plan_sync.ReconciliationPlan({"title": "GitHub title"}, {}, {"title": "GitHub title"}, ())
+    proposal = plan_sync.build_apply_plans(changed, document.binding, document, ACTOR).repo_mutation
+    registry = mutation_plan.load_registry(Path("templates/transformations.yaml.template"))
+    pen_plan = pen_orchestrator.PenPlan(proposal, registry.get(proposal.transformation), "nave/plan-sync", nave_adapter.PenQuery(terms=["repo:acme/docs"]))
+
+    class QueuedRunner:
+        def __init__(self):
+            self.calls, self.results = [], [nave_adapter.Completed(0, "created\n", ""), _pen_show(), nave_adapter.Completed(0, json.dumps([{"owner": "acme", "repo": "docs", "working_tree": "clean", "freshness": "fresh", "run_state": "not-run", "divergence": "up-to-date", "ahead": 0, "behind": 0}]), "")]
+        def run(self, args):
+            self.calls.append(args)
+            return self.results.pop(0)
+
+    monkeypatch.setattr(pen_orchestrator.nave_adapter, "probe", lambda _runner: {"available": True, "version": "0.0.9", "protocol": 1})
+    runner = QueuedRunner()
+    result = pen_orchestrator.execute(pen_plan, runner, read_repo_head=lambda _repo: "remote-advanced")
+
+    assert result.state == "blocked"
+    assert result.repo_outcomes == {REPO: "blocked"}
+    assert not any("exec" in call for call in runner.calls)
+
+
+def test_repeat_after_full_sync_is_a_noop_with_identical_counts(tmp_path):
+    first = _collect(BASE | {"state": "closed"}, tmp_path)
+    reconciliation = plan_sync.compute(first.document, first.github, first.binding["sync"], first.base_body)
+    finalized = plan_sync.finalize(reconciliation, doc_applied=True, github_applied=True)
+    assert finalized.base_patch == {"state": "closed"}
+
+    synced_base = BASE | finalized.base_patch
+    document = _collect(synced_base, tmp_path, blob=BASE_BLOB)
+    repeated = _collect(synced_base, tmp_path, blob=BASE_BLOB)
+    noop = plan_sync.ReconciliationPlan({}, {}, {}, ())
+
+    assert _counts(document, noop) == _counts(repeated, noop) == {
+        "docs_scanned": 1, "in_sync": 1, "doc_patches": 0, "github_patches": 0, "conflicts": 0, "excluded": 0,
+    }
+
+
+def test_headless_skill_is_neutral_and_declares_ordered_propose_only_phases():
+    for path in (plan_sync.__file__, plan_sync_snapshot.__file__, validate_result.__file__, SKILL, WORKFLOW):
+        content = Path(path).read_text().lower()
+        for forbidden in ("claude", "corpus", "plugin manifest", "skill.md"):
+            assert forbidden not in content, f"{forbidden!r} found in {path}"
+
+    skill = SKILL.read_text()
+    normalized = " ".join(skill.split())
+    phases = ("Phase 1: DISCOVER", "Phase 2: SNAPSHOT", "Phase 3: COMPUTE", "Phase 4: APPLY_GITHUB", "Phase 5: APPLY_DOC", "Phase 6: FINALIZE", "Phase 7: RECORD")
+    assert [normalized.index(phase) for phase in phases] == sorted(normalized.index(phase) for phase in phases)
+    assert "mutation_policy: propose" in skill
+    assert "--kind plan-sync" in skill

--- a/lib/pulse/scripts/tests/test_plan_sync_acceptance.py
+++ b/lib/pulse/scripts/tests/test_plan_sync_acceptance.py
@@ -5,8 +5,11 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
+import subprocess
+import sys
 
 import pytest
+import yaml
 
 from lib.pulse.scripts import (
     mutation_plan,
@@ -46,9 +49,17 @@ class Completed:
 class SnapshotRunner:
     """Hermetic remote-document fixture; no subprocesses or network."""
 
-    def __init__(self, document: str, *, blob: str = CURRENT_BLOB, rename: str | None = None):
+    def __init__(
+        self,
+        document: str,
+        *,
+        blob: str = CURRENT_BLOB,
+        base_document: str = BASE["body"],
+        rename: str | None = None,
+    ):
         self.document = document
         self.blob = blob
+        self.base_document = base_document
         self.rename = rename
         self.calls = []
 
@@ -63,9 +74,9 @@ class SnapshotRunner:
         if tuple(argv) == ("git", "rev-parse", f"FETCH_HEAD:{PATH}"):
             return Completed(0, f"{self.blob}\n") if self.rename is None else Completed(128, "", "missing")
         if tuple(argv[:3]) == ("git", "cat-file", "blob"):
-            return Completed(0, self.document if argv[-1] == CURRENT_BLOB else BASE["body"])
-        if tuple(argv[:3]) == ("git", "log", "--follow") and self.rename:
-            return Completed(0, f"{HEAD}\n{self.rename}\n{BASE_BLOB}\n{PATH}\n")
+            return Completed(0, self.document if argv[-1] == self.blob else self.base_document)
+        if tuple(argv[:3]) == ("git", "log", "FETCH_HEAD") and self.rename:
+            return Completed(0, f"{HEAD}\nR100\t{PATH}\t{self.rename}\n")
         return Completed(1, "", f"unexpected: {argv}")
 
 
@@ -82,7 +93,7 @@ def _binding(base_blob: str = BASE_BLOB):
     }
 
 
-def _document(values: dict) -> str:
+def _document(values: dict, *, sync_base: dict = BASE, sync_blob: str = BASE_BLOB) -> str:
     return (
         "---\n"
         f"state: {values['state']}\n"
@@ -90,7 +101,9 @@ def _document(values: dict) -> str:
         f"milestone: {values['milestone'] if values['milestone'] is not None else ''}\n"
         "sync:\n"
         "  issue: {repo: acme/widgets, number: 42}\n"
-        f"  base: {{blob: {BASE_BLOB}, title: Release plan, state: open, assignees: [ada], milestone: null}}\n"
+        f"  base: {{blob: {sync_blob}, title: {sync_base['title']}, state: {sync_base['state']}, "
+        f"assignees: [{', '.join(sync_base['assignees'])}], "
+        f"milestone: {sync_base['milestone'] if sync_base['milestone'] is not None else 'null'}}}\n"
         "---\n"
         f"# {values['title']}\n\n"
         f"{values['body'].split('\n\n', 1)[1]}"
@@ -111,63 +124,67 @@ def _github(values: dict):
     return api
 
 
-def _collect(values: dict, tmp_path, *, blob: str = CURRENT_BLOB, github_values: dict | None = None):
-    snapshot = plan_sync_snapshot.collect(
-        [_binding()], workdir=tmp_path, runner=SnapshotRunner(_document(values), blob=blob),
+def _snapshot(
+    values: dict,
+    tmp_path,
+    *,
+    blob: str = CURRENT_BLOB,
+    github_values: dict | None = None,
+    sync_base: dict = BASE,
+    sync_blob: str = BASE_BLOB,
+    base_document: str = BASE["body"],
+):
+    return plan_sync_snapshot.collect(
+        [_binding()],
+        workdir=tmp_path,
+        runner=SnapshotRunner(
+            _document(values, sync_base=sync_base, sync_blob=sync_blob),
+            blob=blob,
+            base_document=base_document,
+        ),
         gh_api=_github(github_values or values),
     )
-    return snapshot.documents[0]
 
 
-def _counts(document, reconciliation):
-    """The result buckets used by the headless orchestration document."""
-    result = {"docs_scanned": 1, "in_sync": 0, "doc_patches": 0,
-              "github_patches": 0, "conflicts": 0, "excluded": 0}
-    if document.state == "in_sync":
-        result["in_sync"] = 1
-    elif document.state == "excluded":
-        result["excluded"] = 1
-    elif reconciliation.conflicted:
-        result["conflicts"] = 1
-    elif reconciliation.doc_patch or reconciliation.github_patch:
-        result["doc_patches"] = int(bool(reconciliation.doc_patch))
-        result["github_patches"] = int(bool(reconciliation.github_patch))
-    else:
-        result["in_sync"] = 1
-    return result
+def _collect(values: dict, tmp_path, *, blob: str = CURRENT_BLOB, github_values: dict | None = None):
+    return _snapshot(values, tmp_path, blob=blob, github_values=github_values).documents[0]
+
+
+def _result(snapshot):
+    return plan_sync.build_result(
+        snapshot,
+        workspace="acme",
+        run_at="2026-07-21T00:00:00Z",
+        actor=ACTOR,
+    )
 
 
 @pytest.mark.parametrize(
     ("doc_values", "github_values", "expected"),
     [
         (BASE, BASE, {"in_sync": 1}),
-        (BASE | {"state": "closed"}, BASE, {"github_patches": 1}),
+        (BASE | {"title": "Document title"}, BASE, {"github_patches": 1}),
         (BASE, BASE | {"state": "closed"}, {"doc_patches": 1}),
-        (BASE | {"state": "closed"}, BASE | {"state": "in progress"}, {"conflicts": 1}),
-        (BASE | {"state": "closed"}, BASE | {"state": "closed"}, {"in_sync": 1}),
+        (BASE | {"title": "Document title"}, BASE | {"title": "GitHub title"}, {"conflicts": 1}),
+        (BASE | {"title": "Shared title"}, BASE | {"title": "Shared title"}, {"doc_patches": 1}),
     ],
     ids=("noop", "document-to-github", "github-to-document", "conflict", "agree"),
 )
 def test_merge_outcomes_land_in_their_result_buckets(tmp_path, doc_values, github_values, expected):
-    document = _collect(doc_values, tmp_path, github_values=github_values)
-    reconciliation = plan_sync.compute(document.document, document.github, document.binding["sync"], document.base_body)
-    plans = plan_sync.build_apply_plans(reconciliation, document.binding, document, ACTOR)
-    plan_sync.finalize(reconciliation, doc_applied=False, github_applied=False)
+    result = _result(_snapshot(doc_values, tmp_path, github_values=github_values))
 
-    counts = _counts(document, reconciliation)
-
-    assert {key: counts[key] for key in expected} == expected
-    assert (plans.doc_patch is not None) == bool(reconciliation.doc_patch)
-    assert (plans.github_mutation is not None) == bool(reconciliation.github_patch)
+    assert {key: result[key] for key in expected} == expected
+    assert "proposals" in result
+    assert "proposed_actions" in result
 
 
 def test_rename_and_local_ahead_are_excluded_from_reconciliation(tmp_path):
     renamed = plan_sync_snapshot.collect(
         [_binding()], workdir=tmp_path,
         runner=SnapshotRunner(_document(BASE), rename="plans/renamed-release.md"), gh_api=_github(BASE),
-    ).documents[0]
-    assert renamed.state == "excluded"
-    assert _counts(renamed, plan_sync.ReconciliationPlan({}, {}, {}, ()))["excluded"] == 1
+    )
+    assert renamed.documents[0].state == "excluded"
+    assert _result(renamed)["excluded"] == 1
 
     class LocalAheadRunner(SnapshotRunner):
         def __call__(self, argv, cwd=None):
@@ -181,9 +198,9 @@ def test_rename_and_local_ahead_are_excluded_from_reconciliation(tmp_path):
 
     ahead = plan_sync_snapshot.collect(
         [_binding()], workdir=tmp_path, runner=LocalAheadRunner(_document(BASE)), gh_api=_github(BASE)
-    ).documents[0]
-    assert ahead.state == "excluded"
-    assert _counts(ahead, plan_sync.ReconciliationPlan({}, {}, {}, ()))["excluded"] == 1
+    )
+    assert ahead.documents[0].state == "excluded"
+    assert _result(ahead)["excluded"] == 1
 
 
 def _pen_show():
@@ -217,19 +234,68 @@ def test_remote_base_advance_blocks_document_proposal_before_pen_execution(tmp_p
 
 
 def test_repeat_after_full_sync_is_a_noop_with_identical_counts(tmp_path):
-    first = _collect(BASE | {"state": "closed"}, tmp_path)
-    reconciliation = plan_sync.compute(first.document, first.github, first.binding["sync"], first.base_body)
+    first = _collect(BASE | {"title": "Updated title"}, tmp_path)
+    reconciliation = plan_sync.compute(
+        first.document, first.github, first.binding["sync"], first.base_body,
+        document_blob=first.blob,
+    )
     finalized = plan_sync.finalize(reconciliation, doc_applied=True, github_applied=True)
-    assert finalized.base_patch == {"state": "closed"}
+    assert finalized.base_patch == {"title": "Updated title", "blob": CURRENT_BLOB}
 
-    synced_base = BASE | finalized.base_patch
-    document = _collect(synced_base, tmp_path, blob=BASE_BLOB)
-    repeated = _collect(synced_base, tmp_path, blob=BASE_BLOB)
-    noop = plan_sync.ReconciliationPlan({}, {}, {}, ())
-
-    assert _counts(document, noop) == _counts(repeated, noop) == {
-        "docs_scanned": 1, "in_sync": 1, "doc_patches": 0, "github_patches": 0, "conflicts": 0, "excluded": 0,
+    synced_values = BASE | {
+        "title": "Updated title",
+        "body": "# Updated title\n\nBase body.\n",
     }
+    new_blob = "d" * 40
+    kwargs = {
+        "blob": new_blob,
+        "sync_base": synced_values,
+        "sync_blob": CURRENT_BLOB,
+        "base_document": synced_values["body"],
+    }
+    document = _snapshot(synced_values, tmp_path, **kwargs)
+    repeated = _snapshot(synced_values, tmp_path, **kwargs)
+
+    expected = {"docs_scanned": 1, "in_sync": 1, "doc_patches": 0,
+                "github_patches": 0, "conflicts": 0, "excluded": 0}
+    assert {key: _result(document)[key] for key in expected} == expected
+    assert {key: _result(repeated)[key] for key in expected} == expected
+
+
+def test_real_result_builder_round_trips_through_plan_sync_validator(tmp_path):
+    result = _result(_snapshot(BASE, tmp_path, github_values=BASE | {"state": "closed"}))
+    result_path = tmp_path / "plan-sync-result.yaml"
+    result_path.write_text(yaml.safe_dump(result, sort_keys=False))
+
+    validated = subprocess.run(
+        [sys.executable, str(Path(validate_result.__file__)), str(result_path), "--kind", "plan-sync"],
+        capture_output=True,
+        text=True,
+    )
+
+    assert validated.returncode == 0, validated.stderr
+    assert result["proposals"] == [{
+        "binding": "release-plan",
+        "transformation": "plan-sync-doc-patch",
+        "proposal_id": "plan-sync-doc-release-plan",
+    }]
+    assert result["proposed_actions"]
+
+
+def test_github_evidence_error_is_counted_as_excluded(tmp_path):
+    snapshot = plan_sync_snapshot.collect(
+        [_binding()],
+        workdir=tmp_path,
+        runner=SnapshotRunner(_document(BASE)),
+        gh_api=lambda _endpoint: None,
+    )
+
+    result = _result(snapshot)
+
+    assert result["docs_scanned"] == 1
+    assert result["excluded"] == 1
+    assert result["in_sync"] == 0
+    assert [finding["kind"] for finding in result["findings"]] == ["snapshot_error"]
 
 
 def test_headless_skill_is_neutral_and_declares_ordered_propose_only_phases():

--- a/lib/pulse/scripts/tests/test_plan_sync_snapshot.py
+++ b/lib/pulse/scripts/tests/test_plan_sync_snapshot.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+import subprocess
 
 from lib.pulse.scripts import plan_sync_snapshot as snap
 
@@ -22,7 +24,13 @@ class RecordingRunner:
 
     def __call__(self, argv, cwd=None):
         self.calls.append((tuple(argv), str(cwd) if cwd is not None else None))
-        return self.responses.get(tuple(argv), Completed(1, "", f"unexpected: {argv}"))
+        response = self.responses.get(tuple(argv))
+        if response is None and argv[:5] == ["git", "init", "--bare", "-q", "--"]:
+            response = next(
+                (value for key, value in self.responses.items() if key[:5] == tuple(argv[:5])),
+                None,
+            )
+        return response or Completed(1, "", f"unexpected: {argv}")
 
 
 REPO = "acme/docs"
@@ -57,30 +65,49 @@ def binding(**overrides):
 def base_git_responses(repo_dir, blob=CHANGED_BLOB):
     return {
         ("git", "init", "--bare", "-q", "--", str(repo_dir)): Completed(),
-        ("git", "fetch", "--filter=blob:none", "-q", "--", URL, BRANCH): Completed(),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", URL, f"refs/heads/{BRANCH}"): Completed(),
         ("git", "rev-parse", "FETCH_HEAD"): Completed(0, f"{HEAD}\n"),
         ("git", "rev-parse", f"FETCH_HEAD:{PATH}"): Completed(0, f"{blob}\n"),
     }
 
 
-def test_same_blob_on_unrelated_commit_short_circuits_as_in_sync(tmp_path):
+def test_same_blob_on_unrelated_commit_is_in_sync_only_after_github_snapshot(tmp_path):
     repo_dir = tmp_path / "acme_docs_main"
-    runner = RecordingRunner(base_git_responses(repo_dir, BASE_BLOB))
+    responses = base_git_responses(repo_dir, BASE_BLOB)
+    responses[("git", "cat-file", "blob", BASE_BLOB)] = Completed(
+        0,
+        "---\nsync:\n"
+        "  issue: {repo: acme/widgets, number: 42}\n"
+        f"  base: {{blob: {BASE_BLOB}, title: Release plan, state: open, assignees: [ada], milestone: null}}\n"
+        "---\n# Release plan\n\nBase body.\n",
+    )
+    runner = RecordingRunner(responses)
     gh_calls = []
+
+    def gh_api(path):
+        gh_calls.append(path)
+        if path.endswith("/issues/42"):
+            return {
+                "title": "Release plan", "body": "# Release plan\n\nBase body.\n",
+                "state": "open", "assignees": [{"login": "ada"}], "milestone": None,
+            }
+        return []
 
     snapshot = snap.collect(
         [binding()], workdir=tmp_path, runner=runner,
-        gh_api=lambda path: gh_calls.append(path),
+        gh_api=gh_api,
     )
 
     document = snapshot.documents[0]
     assert document.state == "in_sync"
     assert document.head == HEAD
     assert document.blob == BASE_BLOB
-    assert document.github is None
+    assert document.github is not None
     assert snapshot.findings == ()
-    assert gh_calls == []
-    assert not any(call[0][1:3] == ("cat-file", "blob") for call in runner.calls)
+    assert gh_calls == [
+        "/repos/acme/widgets/issues/42",
+        "/repos/acme/widgets/milestones?state=all&per_page=100",
+    ]
 
 
 def test_changed_blob_loads_pushed_document_and_body_base(tmp_path):
@@ -88,12 +115,22 @@ def test_changed_blob_loads_pushed_document_and_body_base(tmp_path):
     responses = base_git_responses(repo_dir)
     responses.update({
         ("git", "cat-file", "blob", CHANGED_BLOB): Completed(
-            0, "---\nsync:\n  base:\n    blob: base\n---\n# Updated release\n\nChanged body.\n"
+            0,
+            "---\nsync:\n"
+            "  issue: {repo: acme/widgets, number: 42}\n"
+            f"  base: {{blob: {BASE_BLOB}, title: Release plan, state: open, assignees: [ada], milestone: null}}\n"
+            "---\n# Updated release\n\nChanged body.\n",
         ),
         ("git", "cat-file", "blob", BASE_BLOB): Completed(0, "# Release plan\n\nBase body.\n"),
     })
 
-    snapshot = snap.collect([binding()], workdir=tmp_path, runner=RecordingRunner(responses))
+    snapshot = snap.collect(
+        [binding()], workdir=tmp_path, runner=RecordingRunner(responses),
+        gh_api=lambda path: ({
+            "title": "Release plan", "body": "# Release plan\n\nBase body.\n",
+            "state": "open", "assignees": [{"login": "ada"}], "milestone": None,
+        } if "/issues/" in path else []),
+    )
 
     document = snapshot.documents[0]
     assert document.state == "changed"
@@ -110,7 +147,11 @@ def test_base_body_strips_frontmatter_from_the_base_blob(tmp_path):
     responses = base_git_responses(repo_dir)
     responses.update({
         ("git", "cat-file", "blob", CHANGED_BLOB): Completed(
-            0, "---\nsync:\n  base:\n    blob: base\n---\n# Release plan\n\nShared body.\n"
+            0,
+            "---\nsync:\n"
+            "  issue: {repo: acme/widgets, number: 42}\n"
+            f"  base: {{blob: {BASE_BLOB}, title: Release plan, state: open, assignees: [ada], milestone: null}}\n"
+            "---\n# Release plan\n\nShared body.\n",
         ),
         ("git", "cat-file", "blob", BASE_BLOB): Completed(
             0,
@@ -119,7 +160,13 @@ def test_base_body_strips_frontmatter_from_the_base_blob(tmp_path):
         ),
     })
 
-    snapshot = snap.collect([binding()], workdir=tmp_path, runner=RecordingRunner(responses))
+    snapshot = snap.collect(
+        [binding()], workdir=tmp_path, runner=RecordingRunner(responses),
+        gh_api=lambda path: ({
+            "title": "Release plan", "body": "# Release plan\n\nShared body.\n",
+            "state": "open", "assignees": [{"login": "ada"}], "milestone": None,
+        } if "/issues/" in path else []),
+    )
 
     document = snapshot.documents[0]
     assert document.base_body == "# Release plan\n\nShared body.\n"
@@ -134,15 +181,17 @@ def test_git_init_uses_option_separator_for_the_repo_dir(tmp_path):
                  gh_api=lambda path: None)
 
     init_calls = [call[0] for call in runner.calls if call[0][:2] == ("git", "init")]
-    assert init_calls == [("git", "init", "--bare", "-q", "--", str(repo_dir))]
+    assert len(init_calls) == 1
+    assert init_calls[0][:5] == ("git", "init", "--bare", "-q", "--")
+    assert tmp_path not in Path(init_calls[0][-1]).parents
 
 
 def test_missing_head_path_reports_rename_without_silently_following_it(tmp_path):
     repo_dir = tmp_path / "acme_docs_main"
     responses = base_git_responses(repo_dir)
     responses[("git", "rev-parse", f"FETCH_HEAD:{PATH}")] = Completed(128, "", "missing")
-    responses[("git", "log", "--follow", "--format=%H", "--name-only", "--", PATH)] = Completed(
-        0, f"{HEAD}\nplans/renamed-release.md\n{BASE_BLOB}\n{PATH}\n"
+    responses[("git", "log", "FETCH_HEAD", "--format=%H", "--name-status", "--find-renames", "--diff-filter=R")] = Completed(
+        0, f"{HEAD}\nR100\t{PATH}\tplans/renamed-release.md\n"
     )
 
     snapshot = snap.collect([binding()], workdir=tmp_path, runner=RecordingRunner(responses))
@@ -199,7 +248,13 @@ def test_github_snapshot_normalizes_assignees_and_missing_milestone(tmp_path):
     repo_dir = tmp_path / "acme_docs_main"
     responses = base_git_responses(repo_dir)
     responses.update({
-        ("git", "cat-file", "blob", CHANGED_BLOB): Completed(0, "# Updated release\n"),
+        ("git", "cat-file", "blob", CHANGED_BLOB): Completed(
+            0,
+            "---\nsync:\n"
+            "  issue: {repo: acme/widgets, number: 42}\n"
+            f"  base: {{blob: {BASE_BLOB}, title: Release plan, state: open, assignees: [ada], milestone: null}}\n"
+            "---\n# Updated release\n",
+        ),
         ("git", "cat-file", "blob", BASE_BLOB): Completed(0, "# Release plan\n"),
     })
     calls = []
@@ -227,3 +282,165 @@ def test_github_snapshot_normalizes_assignees_and_missing_milestone(tmp_path):
         "/repos/acme/widgets/issues/42",
         "/repos/acme/widgets/milestones?state=all&per_page=100",
     ]
+
+
+def test_pushed_frontmatter_overrides_stale_config_sync_binding(tmp_path):
+    repo_dir = tmp_path / "acme_docs_main"
+    pushed_base = "d" * 40
+    responses = base_git_responses(repo_dir)
+    responses.update({
+        ("git", "cat-file", "blob", CHANGED_BLOB): Completed(
+            0,
+            "---\n"
+            "sync:\n"
+            "  issue: {repo: acme/widgets, number: 99}\n"
+            "  policy: {title: prefer-github}\n"
+            f"  base: {{blob: {pushed_base}, title: Pushed base, state: open, assignees: [], milestone: null}}\n"
+            "---\n# Pushed title\n",
+        ),
+        ("git", "cat-file", "blob", pushed_base): Completed(0, "# Pushed base\n"),
+    })
+    calls = []
+
+    def gh_api(path):
+        calls.append(path)
+        if path == "/repos/acme/widgets/issues/99":
+            return {"title": "Issue 99", "body": "# Pushed base\n", "state": "open"}
+        if path == "/repos/acme/widgets/milestones?state=all&per_page=100":
+            return []
+        raise AssertionError(path)
+
+    snapshot = snap.collect(
+        [binding()], workdir=tmp_path, runner=RecordingRunner(responses), gh_api=gh_api
+    )
+
+    document = snapshot.documents[0]
+    assert document.binding["sync"]["issue"]["number"] == 99
+    assert document.binding["sync"]["policy"] == {"title": "prefer-github"}
+    assert document.binding["sync"]["base"]["blob"] == pushed_base
+    assert document.base_body == "# Pushed base\n"
+    assert calls[0] == "/repos/acme/widgets/issues/99"
+
+
+def test_unchanged_document_still_detects_github_only_state_change(tmp_path):
+    repo_dir = tmp_path / "acme_docs_main"
+    document_text = (
+        "---\nsync:\n"
+        "  issue: {repo: acme/widgets, number: 42}\n"
+        f"  base: {{blob: {BASE_BLOB}, title: Release plan, state: open, assignees: [ada], milestone: null}}\n"
+        "---\n# Release plan\n\nBase body.\n"
+    )
+    responses = base_git_responses(repo_dir, BASE_BLOB)
+    responses[("git", "cat-file", "blob", BASE_BLOB)] = Completed(0, document_text)
+
+    def gh_api(path):
+        if path.endswith("/issues/42"):
+            return {
+                "title": "Release plan", "body": "# Release plan\n\nBase body.\n",
+                "state": "closed", "assignees": [{"login": "ada"}], "milestone": None,
+            }
+        return []
+
+    snapshot = snap.collect(
+        [binding()], workdir=tmp_path, runner=RecordingRunner(responses), gh_api=gh_api
+    )
+
+    document = snapshot.documents[0]
+    assert document.state == "changed"
+    assert document.github["state"] == "closed"
+
+
+def test_missing_github_evidence_is_an_explicit_error_and_finding(tmp_path):
+    repo_dir = tmp_path / "acme_docs_main"
+    responses = base_git_responses(repo_dir)
+    responses.update({
+        ("git", "cat-file", "blob", CHANGED_BLOB): Completed(
+            0,
+            "---\nsync:\n"
+            "  issue: {repo: acme/widgets, number: 42}\n"
+            f"  base: {{blob: {BASE_BLOB}, title: Release plan, state: open, assignees: [], milestone: null}}\n"
+            "---\n# Release plan\n",
+        ),
+        ("git", "cat-file", "blob", BASE_BLOB): Completed(0, "# Release plan\n"),
+    })
+
+    snapshot = snap.collect(
+        [binding()], workdir=tmp_path, runner=RecordingRunner(responses), gh_api=lambda _path: None
+    )
+
+    assert snapshot.documents[0].state == "error"
+    assert snapshot.findings[0].kind == "snapshot_error"
+    assert "GitHub" in snapshot.findings[0].detail
+
+
+def test_non_repo_workspace_is_never_used_as_a_persistent_bare_fetch_directory(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    class TempRunner(RecordingRunner):
+        def __call__(self, argv, cwd=None):
+            self.calls.append((tuple(argv), str(cwd) if cwd is not None else None))
+            if argv[1] in {"init", "fetch"}:
+                return Completed()
+            if tuple(argv) == ("git", "rev-parse", "FETCH_HEAD"):
+                return Completed(0, f"{HEAD}\n")
+            if tuple(argv) == ("git", "rev-parse", f"FETCH_HEAD:{PATH}"):
+                return Completed(128, "", "missing")
+            if argv[1] == "log":
+                return Completed(1)
+            return Completed(1)
+
+    runner = TempRunner()
+    snap.collect([binding()], workdir=workspace, runner=runner)
+
+    init_target = Path(next(call[0][-1] for call in runner.calls if call[0][1] == "init"))
+    assert workspace not in init_target.parents
+    assert list(workspace.iterdir()) == []
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True, text=True)
+
+
+def test_rename_detection_uses_fetch_head_in_a_real_bare_repository(tmp_path):
+    source = tmp_path / "source"
+    source.mkdir()
+    _git(source, "init", "-q", "-b", "main")
+    _git(source, "config", "user.email", "test@example.com")
+    _git(source, "config", "user.name", "Test User")
+    (source / "plans").mkdir()
+    (source / "plans" / "old.md").write_text("old\n")
+    _git(source, "add", "plans/old.md")
+    _git(source, "commit", "-q", "-m", "add plan")
+    _git(source, "mv", "plans/old.md", "plans/new.md")
+    _git(source, "commit", "-q", "-m", "rename plan")
+
+    bare = tmp_path / "snapshot.git"
+    _git(tmp_path, "init", "--bare", "-q", str(bare))
+    _git(bare, "fetch", "-q", str(source), "refs/heads/main")
+
+    assert snap._rename_target(snap.default_runner, bare, "plans/old.md") == "plans/new.md"
+
+
+def test_branch_refspec_destination_is_rejected_and_valid_fetch_is_explicit(tmp_path):
+    bad = binding(branch="main:refs/heads/injected")
+    bad_runner = RecordingRunner()
+
+    snapshot = snap.collect([bad], workdir=tmp_path, runner=bad_runner)
+
+    assert snapshot.documents[0].state == "error"
+    assert not any(call[0][1] == "fetch" for call in bad_runner.calls)
+
+    class FetchRunner(RecordingRunner):
+        def __call__(self, argv, cwd=None):
+            self.calls.append((tuple(argv), str(cwd) if cwd is not None else None))
+            if argv[1] in {"init", "fetch"}:
+                return Completed()
+            if tuple(argv) == ("git", "rev-parse", "FETCH_HEAD"):
+                return Completed(1)
+            return Completed(1)
+
+    good_runner = FetchRunner()
+    snap.collect([binding()], workdir=tmp_path, runner=good_runner)
+    fetch = next(call[0] for call in good_runner.calls if call[0][1] == "fetch")
+    assert fetch[-1] == "refs/heads/main"

--- a/lib/pulse/scripts/tests/test_plan_sync_snapshot.py
+++ b/lib/pulse/scripts/tests/test_plan_sync_snapshot.py
@@ -1,0 +1,229 @@
+"""Tests for pushed-document and GitHub snapshot collection (F8 Task 4)."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from lib.pulse.scripts import plan_sync_snapshot as snap
+
+
+@dataclass
+class Completed:
+    returncode: int = 0
+    stdout: str = ""
+    stderr: str = ""
+
+
+class RecordingRunner:
+    """Hermetic git seam keyed by exact argv, including argv guard checks."""
+
+    def __init__(self, responses=None):
+        self.responses = responses or {}
+        self.calls = []
+
+    def __call__(self, argv, cwd=None):
+        self.calls.append((tuple(argv), str(cwd) if cwd is not None else None))
+        return self.responses.get(tuple(argv), Completed(1, "", f"unexpected: {argv}"))
+
+
+REPO = "acme/docs"
+BRANCH = "main"
+PATH = "plans/release.md"
+URL = "https://github.com/acme/docs.git"
+HEAD = "a" * 40
+BASE_BLOB = "b" * 40
+CHANGED_BLOB = "c" * 40
+
+
+def binding(**overrides):
+    value = {
+        "repo": REPO,
+        "branch": BRANCH,
+        "path": PATH,
+        "sync": {
+            "issue": {"repo": "acme/widgets", "number": 42},
+            "base": {
+                "blob": BASE_BLOB,
+                "title": "Release plan",
+                "state": "open",
+                "assignees": ["ada"],
+                "milestone": None,
+            },
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+def base_git_responses(repo_dir, blob=CHANGED_BLOB):
+    return {
+        ("git", "init", "--bare", "-q", "--", str(repo_dir)): Completed(),
+        ("git", "fetch", "--filter=blob:none", "-q", "--", URL, BRANCH): Completed(),
+        ("git", "rev-parse", "FETCH_HEAD"): Completed(0, f"{HEAD}\n"),
+        ("git", "rev-parse", f"FETCH_HEAD:{PATH}"): Completed(0, f"{blob}\n"),
+    }
+
+
+def test_same_blob_on_unrelated_commit_short_circuits_as_in_sync(tmp_path):
+    repo_dir = tmp_path / "acme_docs_main"
+    runner = RecordingRunner(base_git_responses(repo_dir, BASE_BLOB))
+    gh_calls = []
+
+    snapshot = snap.collect(
+        [binding()], workdir=tmp_path, runner=runner,
+        gh_api=lambda path: gh_calls.append(path),
+    )
+
+    document = snapshot.documents[0]
+    assert document.state == "in_sync"
+    assert document.head == HEAD
+    assert document.blob == BASE_BLOB
+    assert document.github is None
+    assert snapshot.findings == ()
+    assert gh_calls == []
+    assert not any(call[0][1:3] == ("cat-file", "blob") for call in runner.calls)
+
+
+def test_changed_blob_loads_pushed_document_and_body_base(tmp_path):
+    repo_dir = tmp_path / "acme_docs_main"
+    responses = base_git_responses(repo_dir)
+    responses.update({
+        ("git", "cat-file", "blob", CHANGED_BLOB): Completed(
+            0, "---\nsync:\n  base:\n    blob: base\n---\n# Updated release\n\nChanged body.\n"
+        ),
+        ("git", "cat-file", "blob", BASE_BLOB): Completed(0, "# Release plan\n\nBase body.\n"),
+    })
+
+    snapshot = snap.collect([binding()], workdir=tmp_path, runner=RecordingRunner(responses))
+
+    document = snapshot.documents[0]
+    assert document.state == "changed"
+    assert document.document.title == "Updated release"
+    assert document.base_body == "# Release plan\n\nBase body.\n"
+
+
+def test_base_body_strips_frontmatter_from_the_base_blob(tmp_path):
+    # The base blob is a full bound document (frontmatter + body). base_body must
+    # be the BODY only, so it compares like-for-like against the current doc's
+    # frontmatter-stripped body in compute(); otherwise every bound doc's body
+    # reads as changed.
+    repo_dir = tmp_path / "acme_docs_main"
+    responses = base_git_responses(repo_dir)
+    responses.update({
+        ("git", "cat-file", "blob", CHANGED_BLOB): Completed(
+            0, "---\nsync:\n  base:\n    blob: base\n---\n# Release plan\n\nShared body.\n"
+        ),
+        ("git", "cat-file", "blob", BASE_BLOB): Completed(
+            0,
+            "---\nsync:\n  issue: {repo: acme/widgets, number: 42}\n---\n"
+            "# Release plan\n\nShared body.\n",
+        ),
+    })
+
+    snapshot = snap.collect([binding()], workdir=tmp_path, runner=RecordingRunner(responses))
+
+    document = snapshot.documents[0]
+    assert document.base_body == "# Release plan\n\nShared body.\n"
+    assert "sync:" not in document.base_body
+
+
+def test_git_init_uses_option_separator_for_the_repo_dir(tmp_path):
+    repo_dir = tmp_path / "acme_docs_main"
+    runner = RecordingRunner(base_git_responses(repo_dir, BASE_BLOB))
+
+    snap.collect([binding()], workdir=tmp_path, runner=runner,
+                 gh_api=lambda path: None)
+
+    init_calls = [call[0] for call in runner.calls if call[0][:2] == ("git", "init")]
+    assert init_calls == [("git", "init", "--bare", "-q", "--", str(repo_dir))]
+
+
+def test_missing_head_path_reports_rename_without_silently_following_it(tmp_path):
+    repo_dir = tmp_path / "acme_docs_main"
+    responses = base_git_responses(repo_dir)
+    responses[("git", "rev-parse", f"FETCH_HEAD:{PATH}")] = Completed(128, "", "missing")
+    responses[("git", "log", "--follow", "--format=%H", "--name-only", "--", PATH)] = Completed(
+        0, f"{HEAD}\nplans/renamed-release.md\n{BASE_BLOB}\n{PATH}\n"
+    )
+
+    snapshot = snap.collect([binding()], workdir=tmp_path, runner=RecordingRunner(responses))
+
+    document = snapshot.documents[0]
+    assert document.state == "excluded"
+    assert document.blob is None
+    assert snapshot.findings[0].kind == "rename_detected"
+    assert snapshot.findings[0].new_path == "plans/renamed-release.md"
+
+
+def test_dirty_or_local_ahead_checkout_is_excluded_and_nudged(tmp_path):
+    repo_dir = tmp_path / "acme_docs_main"
+    checkout = tmp_path / "checkout"
+    responses = base_git_responses(repo_dir)
+    responses.update({
+        ("git", "rev-parse", "--is-inside-work-tree"): Completed(0, "true\n"),
+        ("git", "status", "--porcelain", "--", PATH): Completed(0, " M plans/release.md\n"),
+    })
+    runner = RecordingRunner(responses)
+
+    snapshot = snap.collect([binding()], workdir=checkout, runner=runner)
+
+    assert snapshot.documents[0].state == "excluded"
+    assert snapshot.findings[0].kind == "dirty_doc"
+    assert not any(call[0][1] == "fetch" for call in runner.calls)
+
+
+def test_local_ahead_checkout_is_excluded_and_nudged_without_reading_it(tmp_path):
+    checkout = tmp_path / "checkout"
+    class LocalAheadRunner(RecordingRunner):
+        def __call__(self, argv, cwd=None):
+            self.calls.append((tuple(argv), str(cwd) if cwd is not None else None))
+            if argv[1] in {"init", "fetch"}:
+                return Completed()
+            if tuple(argv) == ("git", "rev-parse", "FETCH_HEAD"):
+                return Completed(0, f"{HEAD}\n")
+            return self.responses.get(tuple(argv), Completed(1, "", f"unexpected: {argv}"))
+
+    runner = LocalAheadRunner({
+        ("git", "rev-parse", "--is-inside-work-tree"): Completed(0, "true\n"),
+        ("git", "status", "--porcelain", "--", PATH): Completed(),
+        ("git", "rev-list", "--count", f"{HEAD}..HEAD"): Completed(0, "2\n"),
+    })
+
+    snapshot = snap.collect([binding()], workdir=checkout, runner=runner)
+
+    assert snapshot.documents[0].state == "excluded"
+    assert snapshot.findings[0].kind == "local_ahead"
+    assert not any(call[0][1] == "cat-file" for call in runner.calls)
+
+
+def test_github_snapshot_normalizes_assignees_and_missing_milestone(tmp_path):
+    repo_dir = tmp_path / "acme_docs_main"
+    responses = base_git_responses(repo_dir)
+    responses.update({
+        ("git", "cat-file", "blob", CHANGED_BLOB): Completed(0, "# Updated release\n"),
+        ("git", "cat-file", "blob", BASE_BLOB): Completed(0, "# Release plan\n"),
+    })
+    calls = []
+
+    def gh_api(path):
+        calls.append(path)
+        if path == "/repos/acme/widgets/issues/42":
+            return {
+                "title": "GitHub title", "body": "GitHub body\n", "state": "open",
+                "assignees": [{"login": "zoe"}, {"login": "ada"}, {"login": "zoe"}],
+                "milestone": None,
+            }
+        if path == "/repos/acme/widgets/milestones?state=all&per_page=100":
+            return [{"title": "M2"}, {"title": "M1"}]
+        raise AssertionError(path)
+
+    snapshot = snap.collect([binding()], workdir=tmp_path, runner=RecordingRunner(responses), gh_api=gh_api)
+
+    assert snapshot.documents[0].github == {
+        "title": "GitHub title", "body": "GitHub body\n", "state": "open",
+        "assignees": ["ada", "zoe"], "milestone": None,
+    }
+    assert snapshot.documents[0].milestones == ("M1", "M2")
+    assert calls == [
+        "/repos/acme/widgets/issues/42",
+        "/repos/acme/widgets/milestones?state=all&per_page=100",
+    ]

--- a/lib/pulse/scripts/tests/test_plan_sync_snapshot.py
+++ b/lib/pulse/scripts/tests/test_plan_sync_snapshot.py
@@ -44,6 +44,7 @@ CHANGED_BLOB = "c" * 40
 
 def binding(**overrides):
     value = {
+        "id": "release-plan",
         "repo": REPO,
         "branch": BRANCH,
         "path": PATH,
@@ -444,3 +445,21 @@ def test_branch_refspec_destination_is_rejected_and_valid_fetch_is_explicit(tmp_
     snap.collect([binding()], workdir=tmp_path, runner=good_runner)
     fetch = next(call[0] for call in good_runner.calls if call[0][1] == "fetch")
     assert fetch[-1] == "refs/heads/main"
+
+
+def test_missing_locator_id_is_a_fail_closed_error_not_a_crash(tmp_path):
+    """An id-less binding must bucket as error, never reach fetch or crash RECORD.
+
+    build_apply_plans/build_result hard-require binding.id; without in-collect
+    enforcement an id-less binding would raise deep in RECORD and leave no
+    result file. collect must reject it as a clean error-state document.
+    """
+    bad = binding()
+    del bad["id"]
+    runner = RecordingRunner()
+
+    snapshot = snap.collect([bad], workdir=tmp_path, runner=runner)
+
+    assert snapshot.documents[0].state == "error"
+    assert snapshot.findings[0].kind == "snapshot_error"
+    assert not any(call[0][1] == "fetch" for call in runner.calls)

--- a/lib/pulse/scripts/tests/test_poll.py
+++ b/lib/pulse/scripts/tests/test_poll.py
@@ -251,3 +251,33 @@ def test_branch_heads_no_relationships_file_does_not_trigger_or_crash(tmp_path):
     out = json.loads(r.stdout)
     assert r.returncode == 0, r.stderr
     assert out["triggered_workflows"] == []
+
+
+def test_docs_first_sight_baselines_then_pushed_head_move_triggers(tmp_path):
+    ws, cfg = make_workspace(tmp_path, with_workflow=False)
+    (cfg / "workflows" / "plan-watch.yaml").write_text(
+        "name: plan-watch\nenabled: true\nauto: false\ncooldown_minutes: 0\n"
+        "trigger:\n  type: session_poll\n  source: docs\n"
+    )
+    (cfg / "plan-sync.yaml").write_text(
+        "docs:\n  - repo: testorg/docs\n    branch: main\n    path: plans/release.md\n"
+    )
+    fixtures = tmp_path / "fixtures"
+    fixtures.mkdir()
+    (fixtures / "_rate_limit.json").write_text('{"rate":{"remaining":5000}}')
+    ref_fixture = fixtures / f"{_ref_fixture_slug('testorg/docs', 'main')}.json"
+    ref_fixture.write_text(json.dumps({"object": {"sha": "sha-one"}}))
+
+    run_poll(ws, fixtures=fixtures)
+    first_observation = json.loads(run_poll(ws, fixtures=fixtures).stdout)
+
+    assert first_observation["triggered_workflows"] == []
+    state = yaml.safe_load((cfg / "poll-state.yaml").read_text())
+    assert state["state"]["docs"]["testorg/docs"]["main"] == "sha-one"
+
+    ref_fixture.write_text(json.dumps({"object": {"sha": "sha-two"}}))
+    changed = json.loads(run_poll(ws, fixtures=fixtures).stdout)
+
+    assert changed["triggered_workflows"] == ["plan-watch"]
+    state = yaml.safe_load((cfg / "poll-state.yaml").read_text())
+    assert state["state"]["docs"]["testorg/docs"]["main"] == "sha-two"

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -12,12 +12,13 @@ from lib.pulse.scripts.evaluate_checks import (
     fleet_coverage,
     score_checks,
 )
+from lib.pulse.scripts import validate_result
 
 SCRIPT = "lib/pulse/scripts/validate_result.py"
 FIXTURES = Path("lib/pulse/scripts/tests/fixtures")
 KINDS = [
     "status", "healthcheck", "refresh", "workflow-run", "fleet-membership",
-    "impact", "repo-mutation", "generated-artifact",
+    "impact", "repo-mutation", "generated-artifact", "plan-sync",
 ]
 
 
@@ -928,3 +929,121 @@ def test_generated_artifact_invalid_fixture_reports_every_violation(tmp_path):
     assert "states.binding-2 invalid: exploded" in result.stderr
     assert "findings[0].severity" in result.stderr
     assert "missing required key: proposals[0].proposal_id" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "docs_scanned", "in_sync", "doc_patches", "github_patches", "conflicts",
+        "excluded",
+    ],
+)
+def test_plan_sync_requires_count(tmp_path, field):
+    doc = yaml.safe_load((FIXTURES / "plan-sync-valid.yaml").read_text())
+    doc.pop(field)
+    path = tmp_path / "plan-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "plan-sync")
+
+    assert result.returncode == 1
+    assert f"missing required key: {field}" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "docs_scanned", "in_sync", "doc_patches", "github_patches", "conflicts",
+        "excluded",
+    ],
+)
+def test_plan_sync_rejects_mistyped_count(tmp_path, field):
+    doc = yaml.safe_load((FIXTURES / "plan-sync-valid.yaml").read_text())
+    doc[field] = "not-an-int"
+    path = tmp_path / "plan-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "plan-sync")
+
+    assert result.returncode == 1
+    assert f"wrong type for {field}" in result.stderr
+
+
+def test_plan_sync_rejects_negative_count(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "plan-sync-valid.yaml").read_text())
+    doc["conflicts"] = -1
+    path = tmp_path / "plan-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "plan-sync")
+
+    assert result.returncode == 1
+    assert "conflicts must be a non-negative integer" in result.stderr
+
+
+def test_plan_sync_invalid_fixture_reports_every_violation(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "plan-sync-invalid.yaml").read_text())
+    path = tmp_path / "plan-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "plan-sync")
+
+    assert result.returncode == 1
+    assert "missing required key: actor" in result.stderr
+    assert "missing required key: docs_scanned" in result.stderr
+    assert "findings[0].severity" in result.stderr
+
+
+def test_validate_sync_binding_accepts_valid_fixture():
+    doc = yaml.safe_load((FIXTURES / "plan-sync-binding-valid.yaml").read_text())
+
+    errors = validate_result.validate_sync_binding(doc["sync"])
+
+    assert errors == []
+
+
+def test_validate_sync_binding_rejects_bad_policy_enum():
+    doc = yaml.safe_load((FIXTURES / "plan-sync-binding-invalid.yaml").read_text())
+
+    errors = validate_result.validate_sync_binding(doc["sync"])
+
+    assert "policy.title invalid: merge" in errors
+
+
+def test_validate_sync_binding_rejects_missing_base_blob():
+    doc = yaml.safe_load((FIXTURES / "plan-sync-binding-invalid.yaml").read_text())
+
+    errors = validate_result.validate_sync_binding(doc["sync"])
+
+    assert "missing required key: base.blob" in errors
+
+
+def test_validate_sync_binding_rejects_unknown_sync_key():
+    doc = yaml.safe_load((FIXTURES / "plan-sync-binding-invalid.yaml").read_text())
+
+    errors = validate_result.validate_sync_binding(doc["sync"])
+
+    assert "unknown sync key: labels" in errors
+
+
+def test_validate_sync_binding_rejects_unknown_policy_field():
+    block = {
+        "issue": {"repo": "testorg/widget", "number": 42},
+        "policy": {"labels": "conflict"},
+        "base": {"blob": "abc123"},
+    }
+
+    errors = validate_result.validate_sync_binding(block)
+
+    assert "unknown policy field: labels" in errors
+
+
+def test_validate_sync_binding_rejects_unknown_base_key():
+    block = {
+        "issue": {"repo": "testorg/widget", "number": 42},
+        "base": {"blob": "abc123", "labels": ["bug"]},
+    }
+
+    errors = validate_result.validate_sync_binding(block)
+
+    assert "unknown base key: labels" in errors

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -994,6 +994,19 @@ def test_plan_sync_invalid_fixture_reports_every_violation(tmp_path):
     assert "findings[0].severity" in result.stderr
 
 
+@pytest.mark.parametrize("field", ["proposals", "proposed_actions"])
+def test_plan_sync_requires_actionable_proposal_fields(tmp_path, field):
+    doc = yaml.safe_load((FIXTURES / "plan-sync-valid.yaml").read_text())
+    doc.pop(field, None)
+    path = tmp_path / "plan-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "plan-sync")
+
+    assert result.returncode == 1
+    assert f"missing required key: {field}" in result.stderr
+
+
 def test_validate_sync_binding_accepts_valid_fixture():
     doc = yaml.safe_load((FIXTURES / "plan-sync-binding-valid.yaml").read_text())
 
@@ -1047,3 +1060,19 @@ def test_validate_sync_binding_rejects_unknown_base_key():
     errors = validate_result.validate_sync_binding(block)
 
     assert "unknown base key: labels" in errors
+
+
+@pytest.mark.parametrize(
+    ("issue", "expected"),
+    [
+        (None, "missing required key: sync.issue"),
+        ({"repo": "testorg/widget"}, "missing required key: issue.number"),
+        ({"repo": "testorg/widget", "number": 0}, "issue.number must be a positive integer"),
+    ],
+)
+def test_validate_sync_binding_rejects_invalid_issue_reference(issue, expected):
+    block = {"base": {"blob": "abc123"}}
+    if issue is not None:
+        block["issue"] = issue
+
+    assert expected in validate_result.validate_sync_binding(block)

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -47,6 +47,13 @@ GENERATED_ARTIFACT_STATES = {
     "conflict",
     "error",
 }
+SYNC_POLICIES = {"conflict", "prefer-doc", "prefer-github"}
+SYNC_KEYS = {"issue", "policy", "base"}
+# Policy may target any of the 5 V1 fields (including body). The base carries
+# the scalar bases blob + title + state + assignees + milestone — body's base is
+# the reconciled blob SHA, so "body" is not a valid base key.
+SYNC_POLICY_FIELDS = {"title", "state", "assignees", "milestone", "body"}
+SYNC_BASE_KEYS = {"blob", "title", "state", "assignees", "milestone"}
 
 
 def _err(errors, msg):
@@ -157,6 +164,38 @@ def _validate_findings(data, errors):
         if "ref" in finding and not isinstance(finding["ref"], dict):
             _err(errors, f"wrong type for {ctx}ref: expected mapping")
     return findings
+
+
+def validate_sync_binding(block: dict) -> list[str]:
+    """Validate the ``sync:`` frontmatter binding for a plan document."""
+    errors = []
+    if not isinstance(block, dict):
+        _err(errors, "sync must be a mapping")
+        return errors
+
+    for key in block:
+        if key not in SYNC_KEYS:
+            _err(errors, f"unknown sync key: {key}")
+
+    base = _require(block, "base", dict, errors, ctx="sync.")
+    if base is not None:
+        blob = _require(base, "blob", str, errors, ctx="base.")
+        if blob is not None and not blob:
+            _err(errors, "base.blob must be a non-empty string")
+        for key in base:
+            if key not in SYNC_BASE_KEYS:
+                _err(errors, f"unknown base key: {key}")
+
+    policy = None
+    if "policy" in block:
+        policy = _require(block, "policy", dict, errors)
+    for key in (policy or {}):
+        if key not in SYNC_POLICY_FIELDS:
+            _err(errors, f"unknown policy field: {key}")
+        else:
+            _require_enum(policy, key, SYNC_POLICIES, errors, ctx="policy.")
+
+    return errors
 
 
 def _same_number(actual, expected) -> bool:
@@ -560,6 +599,15 @@ def validate(data, kind: str) -> list[str]:
             _require(proposal, "proposal_id", str, errors, ctx=ctx)
         _require(data, "proposed_actions", list, errors)
 
+    elif kind == "plan-sync":
+        _require_nonnegative_integer(data, "docs_scanned", errors)
+        _require_nonnegative_integer(data, "in_sync", errors)
+        _require_nonnegative_integer(data, "doc_patches", errors)
+        _require_nonnegative_integer(data, "github_patches", errors)
+        _require_nonnegative_integer(data, "conflicts", errors)
+        _require_nonnegative_integer(data, "excluded", errors)
+        _validate_findings(data, errors)
+
     return errors
 
 
@@ -569,7 +617,7 @@ def main():
     parser.add_argument("--kind", required=True,
                         choices=["status", "healthcheck", "refresh", "workflow-run",
                                  "fleet-membership", "impact", "repo-mutation",
-                                 "generated-artifact"])
+                                 "generated-artifact", "plan-sync"])
     args = parser.parse_args()
 
     path = Path(args.file)

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -177,6 +177,17 @@ def validate_sync_binding(block: dict) -> list[str]:
         if key not in SYNC_KEYS:
             _err(errors, f"unknown sync key: {key}")
 
+    issue = _require(block, "issue", dict, errors, ctx="sync.")
+    if issue is not None:
+        issue_repo = _require(issue, "repo", str, errors, ctx="issue.")
+        if issue_repo is not None and not issue_repo:
+            _err(errors, "issue.repo must be a non-empty string")
+        issue_number = _require(issue, "number", int, errors, ctx="issue.")
+        if issue_number is not None and (
+            isinstance(issue_number, bool) or issue_number <= 0
+        ):
+            _err(errors, "issue.number must be a positive integer")
+
     base = _require(block, "base", dict, errors, ctx="sync.")
     if base is not None:
         blob = _require(base, "blob", str, errors, ctx="base.")
@@ -607,6 +618,16 @@ def validate(data, kind: str) -> list[str]:
         _require_nonnegative_integer(data, "conflicts", errors)
         _require_nonnegative_integer(data, "excluded", errors)
         _validate_findings(data, errors)
+        proposals = _require(data, "proposals", list, errors)
+        for index, proposal in enumerate(proposals or []):
+            if not isinstance(proposal, dict):
+                _err(errors, f"proposals[{index}] is not a mapping")
+                continue
+            ctx = f"proposals[{index}]."
+            _require(proposal, "binding", str, errors, ctx=ctx)
+            _require(proposal, "transformation", str, errors, ctx=ctx)
+            _require(proposal, "proposal_id", str, errors, ctx=ctx)
+        _validate_string_list(data, "proposed_actions", errors)
 
     return errors
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = []
 dev = [
     "pytest>=8.0",
     "pyyaml>=6.0",
+    "ruamel.yaml>=0.18.0",
 ]
 
 [tool.pytest.ini_options]

--- a/skills/gh-plan-sync-headless/SKILL.md
+++ b/skills/gh-plan-sync-headless/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: gh-plan-sync-headless
+description: >
+  Headless, generic plan-document synchronization audit. Reads configured plan
+  bindings, snapshots pushed documents and GitHub issues, computes a three-way
+  reconciliation, and records document and issue proposals without applying either
+  path. Writes a validated plan-sync-result.yaml. Zero prompts; explicit inputs only.
+  Use when a scheduler detects a pushed bound document, or when an orchestrator needs
+  deterministic plan-sync proposals.
+---
+
+# Headless Plan Synchronization
+
+Reconcile configured plan documents with their bound GitHub issues using only pushed
+document bytes and remote issue evidence. The result is an auditable count summary;
+all V1 mutations remain proposals. This orchestrator never changes a document,
+issues an issue mutation, or advances a stored base.
+
+`{PLUGIN_ROOT}` is the directory containing `plugin.json`.
+
+## Inputs and outputs
+
+- `workspace_path` (required): absolute workspace root containing `.hiivmind/github/`.
+- `repo` (optional): document repository full or short name; narrows the run to
+  configured bindings for that repository. Defaults to every bound document.
+- `result_path` (optional): workspace default when usable, otherwise
+  `./plan-sync-result.yaml`.
+- `mode` (optional): `interactive` or `scheduled`; defaults to `scheduled`.
+- `mutation_policy` (optional): `propose` or `apply`; defaults to `propose`.
+  V1 always records proposals. `apply` records the same deferred proposals and the
+  V1 limitation; it never grants this orchestrator authority to mutate.
+- Result: validated `plan-sync-result.yaml` with kind `plan-sync`
+  (`lib/patterns/headless-contract.md` § plan-sync-result.yaml).
+
+## Contract
+
+- Zero prompts. Explicit inputs only. Every exit writes a result file.
+- The binding source is `CONFIG_DIR/plan-sync.yaml`, whose `docs[]` records carry
+  `id`, `repo`, `branch`, `path`, and `sync` data. A plan document remains the source
+  of its own frontmatter, while the configuration supplies the discovery scope.
+- Only `plan_sync_snapshot.collect`, `plan_sync.compute`,
+  `plan_sync.build_apply_plans`, and `plan_sync.finalize` determine the sync
+  evidence, merge, proposals, and safe base advancement candidates. Do not re-create
+  their decision rules in this document.
+- The document and GitHub paths remain separate. A document proposal is an F6
+  `plan-sync-doc-patch` proposal; an issue patch is a Pulse proposed action. Neither
+  path is an API call or a pen execution here.
+- Under `mutation_policy: propose`, both paths become proposals and neither is
+  applied. Under `mutation_policy: apply`, this V1 orchestrator still records both
+  proposals as deferred and records the apply-mode limitation from
+  `lib/patterns/plan-sync-binding.md` § V1 limitation.
+- Local dirty documents, local-ahead branches, and detected renames are excluded.
+  Snapshot errors remain explicit findings and never count as synchronized.
+- Severity is deterministic and copied from snapshot or finalize evidence;
+  `inferred: false` when this orchestrator adds a finding.
+
+## State
+
+Determine `RESULT_PATH` before validating the workspace: explicit `result_path`;
+otherwise the workspace default when `workspace_path` is non-empty and usable;
+otherwise `./plan-sync-result.yaml` in the current directory. This fallback must be
+available for every early ABORT to write and validate its result.
+
+```text
+CONFIG_DIR       = {workspace_path}/.hiivmind/github
+SYNC_CONFIG      = CONFIG_DIR/plan-sync.yaml
+RESULT_PATH      = {explicit result_path, workspace default, or current-directory fallback}
+LOGIN            = unknown
+RUN_AT           = current UTC timestamp
+MODE             = {mode, default scheduled}
+MUTATION_POLICY  = {mutation_policy, default propose}
+BINDINGS         = []
+SNAPSHOT         = empty
+FINDINGS         = []
+PROPOSED_ACTIONS = []
+ERRORS           = []
+COUNTS           = {docs_scanned: 0, in_sync: 0, doc_patches: 0, github_patches: 0, conflicts: 0, excluded: 0}
+```
+
+## Phase 1: DISCOVER
+
+1. Missing `workspace_path` → ABORT `"missing required input: workspace_path"`.
+2. Missing `CONFIG_DIR/config.yaml` or its top-level `workspace` → ABORT
+   `"not a workspace root: {workspace_path}"`.
+3. Read the authoritative `.workspace.login` from `CONFIG_DIR/config.yaml` into
+   `LOGIN`.
+4. Ensure `*-result.yaml` is present in `CONFIG_DIR/.gitignore`.
+5. Missing `SYNC_CONFIG` → ABORT `"plan-sync.yaml not found: {SYNC_CONFIG}"`.
+6. Load `SYNC_CONFIG.docs[]`. Validate every selected `sync:` mapping with
+   `validate_result.validate_sync_binding`; invalid bindings append deterministic
+   `snapshot_error` findings and are excluded from collection.
+7. When `repo` is present, resolve it against configured document repository names.
+   An unresolvable value → ABORT `"unknown repo: {repo}"`. Otherwise narrow
+   `BINDINGS` to the matching records.
+8. A valid empty selected set is a successful no-op, not an ABORT.
+
+**See:** `lib/patterns/config-parsing.md`, `lib/patterns/plan-sync-binding.md`,
+`lib/pulse/scripts/validate_result.py`.
+
+## Phase 2: SNAPSHOT
+
+Collect remote evidence for `BINDINGS`. The collector reads only pushed document
+content; a local checkout contributes only dirty/ahead exclusion metadata.
+
+Call `plan_sync_snapshot.collect(BINDINGS, workdir=workspace_path)` once and retain
+its documents and findings unchanged. Collection gaps produce explicit `error`
+documents and findings; do not assume a failed read is a no-op.
+
+For every snapshot finding, append its typed form to `FINDINGS`. Increment
+`docs_scanned` for every returned document. Documents whose state is `excluded` add
+one to `excluded`; documents whose state is `in_sync` add one to `in_sync` and do not
+enter COMPUTE.
+
+**See:** `lib/pulse/scripts/plan_sync_snapshot.py`,
+`lib/patterns/plan-sync-binding.md`.
+
+## Phase 3: COMPUTE
+
+For every changed snapshot document with complete document, GitHub, and body-base
+evidence, call:
+
+`plan_sync.compute(document.document, document.github, document.binding.sync, document.base_body)`.
+
+Keep each returned reconciliation and its snapshot together for subsequent phases.
+
+1. A reconciliation with conflicts increments `conflicts`; add a deterministic
+   `base_conflict` finding for every conflicted field. It produces no apply proposal.
+2. A reconciliation with no document patch and no GitHub patch increments `in_sync`.
+   This covers both unchanged fields and concurrent equal edits.
+3. Otherwise retain its independent document and GitHub patches. Do not count a
+   patch until the corresponding APPLY phase builds its proposal.
+
+**See:** `lib/pulse/scripts/plan_sync.py`.
+
+## Phase 4: APPLY_GITHUB
+
+For every non-conflicted reconciliation with a GitHub patch, call
+`plan_sync.build_apply_plans(reconciliation, binding, snapshot, actor)` and use only
+its `github_mutation` output.
+
+1. Verify that its mutation policy is `propose`.
+2. Increment `github_patches` once for the proposed issue patch.
+3. Append its `proposed_actions` values to `PROPOSED_ACTIONS`.
+4. Never call GitHub to apply the patch. With `mutation_policy: apply`, append a
+   deferred-action note naming the V1 limitation instead of applying it.
+
+## Phase 5: APPLY_DOC
+
+For every non-conflicted reconciliation with a document patch, use the same
+`plan_sync.build_apply_plans` result and retain only `repo_mutation` and `doc_patch`.
+
+1. Verify that the repository mutation policy is `propose` and its expected head
+   comes from the snapshot.
+2. Increment `doc_patches` once for the F6 document proposal.
+3. Append a proposed-action record that carries the proposal ID, document path, and
+   expected head guard.
+4. Never write `.hiivmind/plan-sync-patch.yaml`, run a pen, or apply a document
+   patch. With `mutation_policy: apply`, append a deferred-action note naming the
+   V1 limitation instead.
+
+**See:** `lib/pulse/scripts/plan_sync.py`, `lib/patterns/repository-mutations.md`,
+`lib/patterns/plan-sync-binding.md` § V1 limitation.
+
+## Phase 6: FINALIZE
+
+Call `plan_sync.finalize` for every computed reconciliation with
+`doc_applied: false` and `github_applied: false`. This V1 orchestrator has applied
+neither path, so it never persists `base_patch` or advances `sync.base.blob`.
+
+Copy any returned finalization findings into `FINDINGS`. A later apply-capable
+consumer must re-snapshot and pass confirmed outcomes before it may persist bases.
+
+**See:** `lib/pulse/scripts/plan_sync.py`, `lib/patterns/plan-sync-binding.md` § V1 limitation.
+
+## Phase 7: RECORD
+
+Write `RESULT_PATH` with:
+
+```yaml
+contract_version: 1
+kind: plan-sync
+workspace: {LOGIN}
+run_at: "{RUN_AT}"
+actor: { gh_login: {gh api user login or unknown}, machine: {hostname}, mode: {MODE} }
+docs_scanned: {COUNTS.docs_scanned}
+in_sync: {COUNTS.in_sync}
+doc_patches: {COUNTS.doc_patches}
+github_patches: {COUNTS.github_patches}
+conflicts: {COUNTS.conflicts}
+excluded: {COUNTS.excluded}
+findings: {FINDINGS}
+errors: {ERRORS}
+```
+
+Validate the written result with:
+`uv run "${PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py" "$RESULT_PATH" --kind plan-sync`.
+
+Non-zero validation is an orchestrator defect; report validator stderr verbatim.
+Print one line: `plan-sync: docs={docs_scanned} in_sync={in_sync} doc={doc_patches} github={github_patches} conflicts={conflicts} excluded={excluded}`.
+
+## ABORT semantics
+
+Every ABORT appends its reason to `ERRORS` and falls through to Phase 7 with zeroed
+counts and empty findings. If `CONFIG_DIR` is unusable, write to the explicit
+`result_path`, otherwise `plan-sync-result.yaml` in the current directory, and say so.
+
+## Related
+
+- `lib/pulse/scripts/plan_sync_snapshot.py` — pushed-document and issue evidence
+- `lib/pulse/scripts/plan_sync.py` — merge, proposal, and finalization functions
+- `lib/pulse/scripts/validate_result.py` — result and binding validation
+- `lib/patterns/headless-contract.md` — result schema
+- `lib/patterns/plan-sync-binding.md` — binding and V1 proposal limitation

--- a/skills/gh-plan-sync-headless/SKILL.md
+++ b/skills/gh-plan-sync-headless/SKILL.md
@@ -35,9 +35,11 @@ issues an issue mutation, or advances a stored base.
 ## Contract
 
 - Zero prompts. Explicit inputs only. Every exit writes a result file.
-- The binding source is `CONFIG_DIR/plan-sync.yaml`, whose `docs[]` records carry
-  `id`, `repo`, `branch`, `path`, and `sync` data. A plan document remains the source
-  of its own frontmatter, while the configuration supplies the discovery scope.
+- The discovery source is `CONFIG_DIR/plan-sync.yaml`, whose `docs[]` records carry
+  only the binding locator (`id`, `repo`, `branch`, and `path`). The pushed plan
+  document's parsed `sync:` frontmatter is the sole source of issue, policy, and
+  base reconciliation state; similarly named configuration data is never passed to
+  the merge engine.
 - Only `plan_sync_snapshot.collect`, `plan_sync.compute`,
   `plan_sync.build_apply_plans`, and `plan_sync.finalize` determine the sync
   evidence, merge, proposals, and safe base advancement candidates. Do not re-create
@@ -70,8 +72,10 @@ RUN_AT           = current UTC timestamp
 MODE             = {mode, default scheduled}
 MUTATION_POLICY  = {mutation_policy, default propose}
 BINDINGS         = []
+BINDING_CHECKOUTS = {}
 SNAPSHOT         = empty
 FINDINGS         = []
+PROPOSALS        = []
 PROPOSED_ACTIONS = []
 ERRORS           = []
 COUNTS           = {docs_scanned: 0, in_sync: 0, doc_patches: 0, github_patches: 0, conflicts: 0, excluded: 0}
@@ -86,13 +90,18 @@ COUNTS           = {docs_scanned: 0, in_sync: 0, doc_patches: 0, github_patches:
    `LOGIN`.
 4. Ensure `*-result.yaml` is present in `CONFIG_DIR/.gitignore`.
 5. Missing `SYNC_CONFIG` → ABORT `"plan-sync.yaml not found: {SYNC_CONFIG}"`.
-6. Load `SYNC_CONFIG.docs[]`. Validate every selected `sync:` mapping with
-   `validate_result.validate_sync_binding`; invalid bindings append deterministic
-   `snapshot_error` findings and are excluded from collection.
+6. Load `SYNC_CONFIG.docs[]` and validate only each discovery locator (`id`, `repo`,
+   `branch`, and `path`). Do not use or validate configuration `sync:` data as
+   reconciliation authority. The collector parses and validates the pushed
+   document's `sync:` mapping with `validate_result.validate_sync_binding`.
 7. When `repo` is present, resolve it against configured document repository names.
    An unresolvable value → ABORT `"unknown repo: {repo}"`. Otherwise narrow
    `BINDINGS` to the matching records.
 8. A valid empty selected set is a successful no-op, not an ABORT.
+9. For each selected binding, resolve a local checkout only when its repository
+   identity is verified to match that binding. Store that explicit per-binding path
+   in `BINDING_CHECKOUTS`; absence of a verified checkout stores no path. Never use
+   the workspace root itself as a document checkout.
 
 **See:** `lib/patterns/config-parsing.md`, `lib/patterns/plan-sync-binding.md`,
 `lib/pulse/scripts/validate_result.py`.
@@ -102,14 +111,19 @@ COUNTS           = {docs_scanned: 0, in_sync: 0, doc_patches: 0, github_patches:
 Collect remote evidence for `BINDINGS`. The collector reads only pushed document
 content; a local checkout contributes only dirty/ahead exclusion metadata.
 
-Call `plan_sync_snapshot.collect(BINDINGS, workdir=workspace_path)` once and retain
-its documents and findings unchanged. Collection gaps produce explicit `error`
-documents and findings; do not assume a failed read is a no-op.
+For each binding call `plan_sync_snapshot.collect([binding], workdir=checkout_path)`
+with its verified `BINDING_CHECKOUTS` value, or `workdir=None` when no matching
+checkout exists, then combine the returned documents and findings. The collector
+always fetches remote evidence into an isolated temporary bare repository; the
+checkout is consulted only for dirty/ahead metadata. Collection gaps produce
+explicit `error` documents and findings; do not assume a failed read is a no-op.
 
 For every snapshot finding, append its typed form to `FINDINGS`. Increment
-`docs_scanned` for every returned document. Documents whose state is `excluded` add
-one to `excluded`; documents whose state is `in_sync` add one to `in_sync` and do not
-enter COMPUTE.
+`docs_scanned` for every returned document. Documents whose state is `excluded` or
+`error` add one to `excluded`; documents whose state is `in_sync` add one to
+`in_sync` and do not enter COMPUTE. The collector snapshots GitHub even when the
+document blob equals `sync.base.blob`; it labels `in_sync` only after both peers
+equal their bases.
 
 **See:** `lib/pulse/scripts/plan_sync_snapshot.py`,
 `lib/patterns/plan-sync-binding.md`.
@@ -119,16 +133,18 @@ enter COMPUTE.
 For every changed snapshot document with complete document, GitHub, and body-base
 evidence, call:
 
-`plan_sync.compute(document.document, document.github, document.binding.sync, document.base_body)`.
+`plan_sync.compute(document.document, document.github,`
+`document.document.binding, document.base_body, document_blob=document.blob)`.
 
 Keep each returned reconciliation and its snapshot together for subsequent phases.
 
 1. A reconciliation with conflicts increments `conflicts`; add a deterministic
    `base_conflict` finding for every conflicted field. It produces no apply proposal.
-2. A reconciliation with no document patch and no GitHub patch increments `in_sync`.
-   This covers both unchanged fields and concurrent equal edits.
-3. Otherwise retain its independent document and GitHub patches. Do not count a
-   patch until the corresponding APPLY phase builds its proposal.
+2. A reconciliation with no document patch, GitHub patch, or base-advance proposal
+   increments `in_sync`. Concurrent equal edits require a frontmatter base proposal
+   and are not `in_sync` until that proposal is confirmed.
+3. Otherwise retain its independent document, GitHub, and frontmatter-base patches.
+   Do not count a patch until the corresponding APPLY phase builds its proposal.
 
 **See:** `lib/pulse/scripts/plan_sync.py`.
 
@@ -146,15 +162,21 @@ its `github_mutation` output.
 
 ## Phase 5: APPLY_DOC
 
-For every non-conflicted reconciliation with a document patch, use the same
-`plan_sync.build_apply_plans` result and retain only `repo_mutation` and `doc_patch`.
+For every non-conflicted reconciliation with a document or frontmatter-base patch,
+use the same `plan_sync.build_apply_plans` result and retain only `repo_mutation`
+and `doc_patch`.
 
 1. Verify that the repository mutation policy is `propose` and its expected head
    comes from the snapshot.
 2. Increment `doc_patches` once for the F6 document proposal.
 3. Append a proposed-action record that carries the proposal ID, document path, and
    expected head guard.
-4. Never write `.hiivmind/plan-sync-patch.yaml`, run a pen, or apply a document
+4. Append a `PROPOSALS` record carrying `binding`, `transformation`, and
+   `proposal_id` from the built repository proposal. A GitHub-only
+   state/assignees/milestone delta still enters this phase because its document
+   proposal advances the corresponding `sync.base` scalar without changing the
+   Markdown body.
+5. Never write `.hiivmind/plan-sync-patch.yaml`, run a pen, or apply a document
    patch. With `mutation_policy: apply`, append a deferred-action note naming the
    V1 limitation instead.
 
@@ -189,6 +211,8 @@ github_patches: {COUNTS.github_patches}
 conflicts: {COUNTS.conflicts}
 excluded: {COUNTS.excluded}
 findings: {FINDINGS}
+proposals: {PROPOSALS}
+proposed_actions: {PROPOSED_ACTIONS}
 errors: {ERRORS}
 ```
 
@@ -201,8 +225,9 @@ Print one line: `plan-sync: docs={docs_scanned} in_sync={in_sync} doc={doc_patch
 ## ABORT semantics
 
 Every ABORT appends its reason to `ERRORS` and falls through to Phase 7 with zeroed
-counts and empty findings. If `CONFIG_DIR` is unusable, write to the explicit
-`result_path`, otherwise `plan-sync-result.yaml` in the current directory, and say so.
+counts and empty findings, proposals, and proposed actions. If `CONFIG_DIR` is
+unusable, write to the explicit `result_path`, otherwise `plan-sync-result.yaml` in
+the current directory, and say so.
 
 ## Related
 

--- a/templates/transformations.yaml.template
+++ b/templates/transformations.yaml.template
@@ -71,6 +71,33 @@ transformations:
       kind: none
     allow_scheduled: false
 
+  # Plan synchronization carries variable patch data in this well-known file,
+  # never through argv interpolation.  The caller constrains its declared
+  # output to the binding's document path before writing it into the pen.
+  #
+  # PROPOSE-ONLY (F8 v1): this transformation is only ever *proposed*; F8 never
+  # executes it. Two things must be closed before any apply-mode consumer runs
+  # it (see lib/patterns/plan-sync-binding.md § V1 limitation):
+  #   1. Executor path — the argv below names a plugin-repo-relative script that
+  #      does not resolve inside a doc-repo pen checkout; apply mode needs the
+  #      applier on PATH (installed entry point / nave subcommand).
+  #   2. validation is `none` and the bound output path is self-attested by the
+  #      patch descriptor; apply mode needs the bound path as immutable proposal
+  #      metadata + an F6 "path changed" validation kind.
+  plan-sync-doc-patch:
+    id: plan-sync-doc-patch
+    command_argv:
+      - uv
+      - run
+      - lib/pulse/scripts/apply_doc_patch.py
+      - --patch
+      - .hiivmind/plan-sync-patch.yaml
+    applies_to:
+      - always
+    validation:
+      kind: none
+    allow_scheduled: false
+
   # Example: a dependency-lock refresh. Applies only to repos carrying a
   # capability signal (surfaced by their profile/scorecard evidence), and
   # its result is checked against a JSON Schema before it can be proposed

--- a/templates/workflows/plan-sync.yaml
+++ b/templates/workflows/plan-sync.yaml
@@ -1,0 +1,37 @@
+# hiivmind-pulse-gh - Plan Synchronization Workflow
+# Reconcile configured plan-document bindings with GitHub issues and record
+# propose-only document and issue actions. Copy to:
+# .hiivmind/github/workflows/plan-sync.yaml
+
+name: "plan-sync"
+description: "Audit bound plan documents and record propose-only reconciliation actions"
+enabled: true
+auto: false  # Runs only when requested or when a caller selects the docs trigger
+
+# INVOKE routes to the sibling headless orchestrator when available.
+headless:
+  enabled: true
+  on_ask: record
+  on_mutation: propose
+
+trigger:
+  type: on_demand
+  condition: user_requested
+
+params:
+  repo:
+    description: "Optional document repository (full or short name); empty syncs every configured document"
+    type: string
+    default: ""
+
+state: {}
+
+workflow: |
+  EXECUTE:
+    INVOKE skill hiivmind-pulse-gh:gh-plan-sync-headless
+      WITH workspace_path=workspace_root,
+           repo=params.repo,
+           mode=scheduled,
+           mutation_policy=propose
+
+cooldown_minutes: 1440  # 24 hours

--- a/uv.lock
+++ b/uv.lock
@@ -32,6 +32,7 @@ source = { virtual = "." }
 dev = [
     { name = "pytest" },
     { name = "pyyaml" },
+    { name = "ruamel-yaml" },
 ]
 
 [package.metadata]
@@ -40,6 +41,7 @@ dev = [
 dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "ruamel-yaml", specifier = ">=0.18.0" },
 ]
 
 [[package]]
@@ -158,6 +160,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## F8 — Generic Plan Synchronization (propose-only)

Bidirectional reconciliation of pushed planning-doc frontmatter with GitHub
issues/milestones via a per-field three-way merge. **Propose-only end to end** —
no writes are applied.

### Authoritative model
The pushed plan document's `sync:` frontmatter (issue ref, per-field `policy`,
scalar `base` values + `base.blob`) is the **sole arbiter** of reconciliation.
Config (`plan-sync.yaml docs[]`) is **discovery-only** — it supplies the locator
(`id`, `repo`, `branch`, `path`) and nothing that reaches the merge engine.

- **Doc and GitHub are peers.** A doc change → an F6 Nave pen repo mutation
  (propose-only, expected-SHA guarded); a GitHub change → a separate Pulse
  `github_mutation`. The two are never combined.
- **Base advances only when both peers confirm** (`finalize`); partial
  application is flagged, never silently advanced.
- **V1 fields:** title, state, assignees, milestone, body (body base = whole-doc
  blob SHA). Projects/labels/comments out of scope.
- **Fail-closed:** missing/failed GitHub evidence, unreadable blobs, invalid
  pushed bindings, and now missing locator `id` → explicit `error` document +
  finding; RECORD always writes a `plan-sync` result file.
- **Snapshot discipline** mirrors `impact_snapshot`: isolated temp bare-repo
  fetch, `--filter=blob:none`, `refs/heads/{branch}`, `FETCH_HEAD:<path>` blob
  reads, rename via `git log FETCH_HEAD --name-status --find-renames`.

### What's included
- `plan_sync.py` — lossless `parse_document`/`patch_document`, `compute`/
  `merge_field` six-way merge, `build_apply_plans`/`finalize`.
- `plan_sync_snapshot.py` — `collect()` remote-evidence snapshot.
- `validate_result.py` — new `plan-sync` result kind + `validate_sync_binding`.
- `poll.py` — trigger-only `docs` poll source.
- `skills/gh-plan-sync-headless/` — headless orchestration skill.
- `templates/workflows/plan-sync.yaml`, `templates/transformations.yaml.template`
  (`plan-sync-doc-patch`, `allow_scheduled: false`).
- `lib/patterns/plan-sync-binding.md`.

### Verification
- **793 tests passing**; workflow lint exit 0 (both re-run by the controller).
- SDD: 6 tasks with per-task review, one whole-branch review (2 Critical + 6
  Important + 1 Minor — all fixed), one whole-branch re-review (1 Important —
  fixed, `a6345a0`; 1 Minor accepted). Every gate re-run and every diff read by
  the controller.

### Deferred (user-accepted backlog — inert in propose-only mode)
1. **Apply-mode executor path** — `plan-sync-doc-patch` argv names a
   plugin-repo-relative script not on PATH inside a doc pen checkout; needs an
   installed entry point / nave subcommand.
2. **Apply-mode bound-path enforcement** — F6 registry allowlist + validation are
   static; the dynamic doc path is self-attested (`validation: none`). Needs an
   immutable per-proposal output allowlist enforced by the F6 orchestrator + a
   "path changed" validation kind.

Both are documented in `lib/patterns/plan-sync-binding.md`; neither affects
propose-mode correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
