### PR TITLE
F9: Hiivmind & Claude dogfood overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,39 @@ Deterministic, mechanical work lives in self-contained PEP 723 scripts
 | `resolve_run.py` | Deterministic run-ledger operations (create/advance/gate/lease) |
 | `workflow_lint.py` | Workflow YAML lint (v1/v2/v3 schema, FSM refs, headless policy, DAG acyclicity) |
 
+## Dogfood overlays
+
+The neutral fleet path is repository-type-agnostic: every profile is scored against
+its authoritative scorecard, and nothing in the neutral engine knows about any
+specific ecosystem. **Dogfood overlays** are opt-in extensions that let this plugin
+govern *itself* (and other Claude Code plugins) without leaking plugin-specific
+concerns into the neutral path:
+
+| Overlay | What it adds | Opt-in via |
+|---------|--------------|------------|
+| **Claude plugin scorecard** (`claude-plugin-v1`) | `claude.plugin_manifest`, `claude.skills`, `claude.context` checks | `profile:claude-plugin` |
+| **Claude context currency** (`repo_claims.py`) | Audits `CLAUDE.md` claims against actual skills/commands/manifest; the one inferred step is schema-guarded and fails to `unknown`, never a fabricated verdict | the `claude.context` check |
+| **Marketplace sync** (`marketplace_sync.py`) | Compares a plugin's newest stable release to its `marketplace.json` entry; drift → propose-only F6 mutation | a configured marketplace binding |
+| **Corpus skill generation** | One configured F7 generator (`hiivmind.corpus-navigate-skill`) — pure configuration of the generic engine | `profile:claude-plugin` |
+
+**Isolation guarantees (enforced by tests):**
+
+- **No overlay runs without an explicit profile/capability.** A plain repository is
+  never dispatched a `claude.*` check.
+- **Nothing in the neutral path imports an overlay module.** The neutral engine
+  (`profile_dispatch`, `check_adapters`, `adapters/generic`, `evaluate_checks`,
+  `generated_artifacts`, `generator_dispatch`, and the adapter registration surface)
+  imports none of `adapters.claude_plugin`, `marketplace_sync`, or `repo_claims` at
+  module level — the overlay adapters register through a separate, lazily-imported
+  `register_claude_adapters` entry point.
+- **Overlay scorecards are never merged into a neutral denominator.** Healthcheck
+  grades are scorecard-specific; an overlay scorecard's subtotal is reported on its
+  own (`overlay: true`) and never dilutes a neutral fleet grade or coverage figure.
+
+`lib/pulse/scripts/tests/test_dogfood_isolation.py` proves both the module-level
+import independence and that the neutral acceptance suite passes with the overlay
+fixtures physically absent.
+
 ## Scheduled fleet maintenance
 
 Unattended maintenance lives in a separate repo,

--- a/SKILL.md
+++ b/SKILL.md
@@ -127,6 +127,18 @@ For unlisted domains, the operations skill uses corpus lookup to find the correc
 | `lib/references/domains/*.md` | Per-domain detailed syntax (25 files) |
 | `lib/references/token-permissions.md` | Required token scopes |
 
+## Dogfood overlays
+
+Opt-in extensions let this plugin govern itself and other Claude Code plugins
+without leaking plugin-specific concerns into the neutral fleet path: the
+`claude-plugin-v1` scorecard (manifest/skills/context checks), `CLAUDE.md` claim
+currency, marketplace-release sync, and one configured corpus skill generator.
+Overlays run only under an explicit `profile:claude-plugin` (or a configured
+binding); the neutral engine imports no overlay module, and overlay scorecards are
+subtotaled separately (`overlay: true`), never merged into a neutral grade. See
+`README.md` § Dogfood overlays; isolation is enforced by
+`lib/pulse/scripts/tests/test_dogfood_isolation.py`.
+
 ## Execution Flow
 
 For any GitHub operation:

--- a/lib/pulse/scripts/adapters/__init__.py
+++ b/lib/pulse/scripts/adapters/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from lib.pulse.scripts.adapters import generic
+from lib.pulse.scripts.adapters import claude_plugin, generic
 from lib.pulse.scripts.check_adapters import AdapterRegistry
 
 
@@ -18,4 +18,16 @@ def register_universal_adapters(registry: AdapterRegistry) -> None:
     registry.register("github.actions", generic.ci)
 
 
-__all__ = ["register_universal_adapters"]
+def register_claude_adapters(registry: AdapterRegistry) -> None:
+    """Register Claude Code plugin adapters.
+
+    These adapters are intentionally opt-in — they read overlay-scoped
+    file contents that the neutral evidence snapshot does not carry.
+    Callers wire them only when the Claude plugin overlay is enabled.
+    """
+    registry.register("claude.plugin_manifest", claude_plugin.plugin_manifest)
+    registry.register("claude.skills", claude_plugin.skills)
+    registry.register("claude.context", claude_plugin.context)
+
+
+__all__ = ["register_universal_adapters", "register_claude_adapters"]

--- a/lib/pulse/scripts/adapters/__init__.py
+++ b/lib/pulse/scripts/adapters/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from lib.pulse.scripts.adapters import claude_plugin, generic
+from lib.pulse.scripts.adapters import generic
 from lib.pulse.scripts.check_adapters import AdapterRegistry
 
 
@@ -24,7 +24,14 @@ def register_claude_adapters(registry: AdapterRegistry) -> None:
     These adapters are intentionally opt-in — they read overlay-scoped
     file contents that the neutral evidence snapshot does not carry.
     Callers wire them only when the Claude plugin overlay is enabled.
+
+    The overlay module is imported LAZILY here (not at module level) so that
+    importing this package for the neutral ``register_universal_adapters``
+    entry point never pulls the overlay — and its transitive dependencies —
+    into the process. The dogfood-isolation test enforces this.
     """
+    from lib.pulse.scripts.adapters import claude_plugin
+
     registry.register("claude.plugin_manifest", claude_plugin.plugin_manifest)
     registry.register("claude.skills", claude_plugin.skills)
     registry.register("claude.context", claude_plugin.context)

--- a/lib/pulse/scripts/adapters/claude_plugin.py
+++ b/lib/pulse/scripts/adapters/claude_plugin.py
@@ -1,0 +1,263 @@
+"""Claude Code plugin healthcheck adapters.
+
+These adapters extend the neutral scorecard surface with checks that only
+make sense for repositories that follow the Claude Code plugin layout
+(````.claude-plugin/plugin.json`` plus ````skills/*/SKILL.md````). The
+content they read is sourced from an overlay-scoped ````file_contents`````
+map on the evidence; the neutral snapshot never carries content, so the
+adapters stay inert on repositories that have no overlay enabled.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+import json
+from typing import Any
+
+import yaml
+
+from lib.pulse.scripts.adapters import generic
+from lib.pulse.scripts.check_adapters import CheckContext
+
+
+F0_FILES_REF = generic.F0_FILES_REF
+
+PLUGIN_MANIFEST_PATH = ".claude-plugin/plugin.json"
+CLAUDE_CONTEXT_PATH = "CLAUDE.md"
+SKILL_PATH_PREFIX = "skills/"
+SKILL_FILENAME = "SKILL.md"
+
+
+def _result(
+    status: str,
+    detail: str,
+    *,
+    paths: Sequence[str] = (),
+    refs: Sequence[str] = (),
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "detail": detail,
+        "data": {
+            "evidence": {
+                "paths": list(paths),
+                "refs": list(refs),
+            }
+        },
+    }
+
+
+def _evidence_gap(
+    detail: str,
+    *,
+    paths: Sequence[str] = (),
+    refs: Sequence[str] = (F0_FILES_REF,),
+) -> dict[str, Any]:
+    return _result(
+        "unknown", f"Evidence gap: {detail}", paths=paths, refs=refs
+    )
+
+
+def _files(context: CheckContext) -> tuple[str, ...] | None:
+    return generic._files(context)
+
+
+def _file_content(context: CheckContext, path: str) -> str | None:
+    """Return the verbatim content of ``path`` from the overlay content map.
+
+    Returns ``None`` when the map is missing, malformed, the path is
+    absent, or the stored value is not a ``str`` — mirroring the
+    defensive shape checks used by ``generic._files``.
+    """
+    contents = context.evidence.get("file_contents")
+    if not isinstance(contents, Mapping):
+        return None
+    value = contents.get(path)
+    if not isinstance(value, str):
+        return None
+    return value
+
+
+def _is_skill_path(path: str) -> bool:
+    if not path.startswith(SKILL_PATH_PREFIX):
+        return False
+    if not path.endswith("/" + SKILL_FILENAME):
+        return False
+    remainder = path[len(SKILL_PATH_PREFIX) : -len("/" + SKILL_FILENAME)]
+    return bool(remainder) and "/" not in remainder
+
+
+def _skill_paths(files: Sequence[str]) -> list[str]:
+    return sorted(path for path in files if _is_skill_path(path))
+
+
+def _parse_frontmatter(text: str) -> tuple[Mapping[str, Any] | None, str | None]:
+    """Split a ``SKILL.md`` body into frontmatter mapping and remainder.
+
+    Returns a tuple ``(frontmatter, error)``. ``error`` is ``None`` on
+    success and a short diagnostic string on any malformation (the caller
+    surfaces this as ``fail`` rather than letting an exception escape).
+    """
+    lines = text.split("\n")
+    if not lines or lines[0] != "---":
+        return None, "missing opening fence"
+    end_index = None
+    for index in range(1, len(lines)):
+        if lines[index] == "---":
+            end_index = index
+            break
+    if end_index is None:
+        return None, "missing closing fence"
+    payload = "\n".join(lines[1:end_index])
+    try:
+        parsed = yaml.safe_load(payload)
+    except yaml.YAMLError:
+        return None, "frontmatter is not valid YAML"
+    if not isinstance(parsed, Mapping):
+        return None, "frontmatter is not a mapping"
+    return parsed, None
+
+
+def _has_nonempty_string(mapping: Mapping[str, Any], key: str) -> bool:
+    value = mapping.get(key)
+    return isinstance(value, str) and bool(value)
+
+
+def plugin_manifest(context: CheckContext) -> dict[str, Any]:
+    """Evaluate ``.claude-plugin/plugin.json`` presence and shape."""
+    files = _files(context)
+    if files is None:
+        return _evidence_gap("contents unavailable")
+
+    if PLUGIN_MANIFEST_PATH not in files:
+        return _result(
+            "fail",
+            f"{PLUGIN_MANIFEST_PATH} not declared in repository",
+            paths=(PLUGIN_MANIFEST_PATH,),
+            refs=(F0_FILES_REF,),
+        )
+
+    content = _file_content(context, PLUGIN_MANIFEST_PATH)
+    if content is None:
+        return _evidence_gap(
+            f"{PLUGIN_MANIFEST_PATH} content unavailable",
+            paths=(PLUGIN_MANIFEST_PATH,),
+        )
+
+    try:
+        manifest = json.loads(content)
+    except json.JSONDecodeError:
+        return _result(
+            "fail",
+            f"{PLUGIN_MANIFEST_PATH} is not valid JSON",
+            paths=(PLUGIN_MANIFEST_PATH,),
+            refs=(F0_FILES_REF,),
+        )
+    if not isinstance(manifest, Mapping):
+        return _result(
+            "fail",
+            f"{PLUGIN_MANIFEST_PATH} root is not a mapping",
+            paths=(PLUGIN_MANIFEST_PATH,),
+            refs=(F0_FILES_REF,),
+        )
+    if not _has_nonempty_string(manifest, "name"):
+        return _result(
+            "fail",
+            f"{PLUGIN_MANIFEST_PATH} missing non-empty string 'name'",
+            paths=(PLUGIN_MANIFEST_PATH,),
+            refs=(F0_FILES_REF,),
+        )
+    if not _has_nonempty_string(manifest, "version"):
+        return _result(
+            "fail",
+            f"{PLUGIN_MANIFEST_PATH} missing non-empty string 'version'",
+            paths=(PLUGIN_MANIFEST_PATH,),
+            refs=(F0_FILES_REF,),
+        )
+    name = manifest["name"]
+    version = manifest["version"]
+    return _result(
+        "pass",
+        f"manifest declares {name} {version}",
+        paths=(PLUGIN_MANIFEST_PATH,),
+        refs=(F0_FILES_REF,),
+    )
+
+
+def skills(context: CheckContext) -> dict[str, Any]:
+    """Evaluate every ``skills/*/SKILL.md`` against the frontmatter contract."""
+    files = _files(context)
+    if files is None:
+        return _evidence_gap("contents unavailable")
+
+    skill_paths = _skill_paths(files)
+    if not skill_paths:
+        return _result(
+            "fail",
+            "no skills/*/SKILL.md declared in repository",
+            paths=(),
+            refs=(F0_FILES_REF,),
+        )
+
+    for path in skill_paths:
+        content = _file_content(context, path)
+        if content is None:
+            return _evidence_gap(
+                f"{path} content unavailable",
+                paths=(path,),
+            )
+        frontmatter, error = _parse_frontmatter(content)
+        if error is not None:
+            return _result(
+                "fail",
+                f"{path} has {error}",
+                paths=(path,),
+                refs=(F0_FILES_REF,),
+            )
+        if not _has_nonempty_string(frontmatter, "name"):
+            return _result(
+                "fail",
+                f"{path} missing non-empty string 'name'",
+                paths=(path,),
+                refs=(F0_FILES_REF,),
+            )
+        if not _has_nonempty_string(frontmatter, "description"):
+            return _result(
+                "fail",
+                f"{path} missing non-empty string 'description'",
+                paths=(path,),
+                refs=(F0_FILES_REF,),
+            )
+
+    return _result(
+        "pass",
+        f"{len(skill_paths)} skill(s) with valid frontmatter",
+        paths=tuple(skill_paths),
+        refs=(F0_FILES_REF,),
+    )
+
+
+def context(context: CheckContext) -> dict[str, Any]:  # noqa: A002
+    """Evaluate the presence of a ``CLAUDE.md`` context document.
+
+    Task 3 extends this to claim-currency: a presence-only check today,
+    the follow-up will grade the document against the claim-currency
+    contract.
+    """
+    files = _files(context)
+    if files is None:
+        return _evidence_gap("contents unavailable")
+
+    if CLAUDE_CONTEXT_PATH in files:
+        return _result(
+            "pass",
+            "CLAUDE.md present",
+            paths=(CLAUDE_CONTEXT_PATH,),
+            refs=(F0_FILES_REF,),
+        )
+    return _result(
+        "fail",
+        "CLAUDE.md absent",
+        paths=(CLAUDE_CONTEXT_PATH,),
+        refs=(F0_FILES_REF,),
+    )

--- a/lib/pulse/scripts/adapters/claude_plugin.py
+++ b/lib/pulse/scripts/adapters/claude_plugin.py
@@ -11,11 +11,13 @@ adapters stay inert on repositories that have no overlay enabled.
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+import dataclasses
 import json
 from typing import Any
 
 import yaml
 
+from lib.pulse.scripts import repo_claims
 from lib.pulse.scripts.adapters import generic
 from lib.pulse.scripts.check_adapters import CheckContext
 
@@ -238,26 +240,96 @@ def skills(context: CheckContext) -> dict[str, Any]:
 
 
 def context(context: CheckContext) -> dict[str, Any]:  # noqa: A002
-    """Evaluate the presence of a ``CLAUDE.md`` context document.
+    """Audit ``CLAUDE.md`` for claim currency.
 
-    Task 3 extends this to claim-currency: a presence-only check today,
-    the follow-up will grade the document against the claim-currency
-    contract.
+    The audit runs in three stages, each one early-returning on the
+    smallest decisive signal:
+
+    1. **Evidence gate** — without ``files`` or ``file_contents`` there
+       is nothing to grade, so the adapter reports an evidence gap.
+    2. **Inference guard** — when an external agent has supplied
+       candidate findings under ``evidence['inferred_claims']``, they
+       must pass :func:`repo_claims.validate_inferred_findings` or the
+       whole audit downgrades to ``unknown`` (we never synthesize a
+       pass/fail from malformed input).
+    3. **Deterministic check** — the textual claims in ``CLAUDE.md`` are
+       cross-referenced against :func:`repo_claims.facts` (the
+       repository's current ground truth). Findings from the
+       deterministic pass and the (validated) inferred pass are merged
+       and graded together.
     """
     files = _files(context)
     if files is None:
         return _evidence_gap("contents unavailable")
 
-    if CLAUDE_CONTEXT_PATH in files:
+    if CLAUDE_CONTEXT_PATH not in files:
         return _result(
-            "pass",
-            "CLAUDE.md present",
+            "fail",
+            "CLAUDE.md absent",
             paths=(CLAUDE_CONTEXT_PATH,),
             refs=(F0_FILES_REF,),
         )
-    return _result(
-        "fail",
-        "CLAUDE.md absent",
-        paths=(CLAUDE_CONTEXT_PATH,),
+
+    text = _file_content(context, CLAUDE_CONTEXT_PATH)
+    if text is None:
+        return _evidence_gap(
+            "CLAUDE.md content unavailable",
+            paths=(CLAUDE_CONTEXT_PATH,),
+        )
+
+    raw_inferred = context.evidence.get("inferred_claims")
+    if raw_inferred is not None:
+        try:
+            inferred = repo_claims.validate_inferred_findings(raw_inferred)
+        except repo_claims.InferenceValidationError as exc:
+            return _result(
+                "unknown",
+                f"inferred claim validation failed: {exc}",
+                paths=(CLAUDE_CONTEXT_PATH,),
+                refs=(F0_FILES_REF,),
+            )
+    else:
+        inferred = []
+
+    facts = repo_claims.facts(context.evidence)
+    deterministic = repo_claims.check_claims(text, facts)
+    merged = sorted(
+        (*deterministic, *inferred),
+        key=lambda finding: (finding.kind, finding.subject),
+    )
+
+    stale_count = sum(
+        1
+        for finding in merged
+        if finding.kind in {"missing_claimed_skill", "stale_command"}
+    )
+    unsupported_count = sum(
+        1 for finding in merged if finding.kind == "unsupported_evidence"
+    )
+
+    if stale_count:
+        detail = f"{stale_count} stale CLAUDE.md claim(s)"
+        status = "fail"
+    else:
+        detail = "CLAUDE.md claims current"
+        if unsupported_count:
+            detail += f"; {unsupported_count} unsupported claim(s) surfaced"
+        status = "pass"
+
+    cited_paths = (CLAUDE_CONTEXT_PATH,) + tuple(
+        sorted(
+            finding.subject
+            for finding in merged
+            if "/" in finding.subject
+        )
+    )
+    result = _result(
+        status,
+        detail,
+        paths=cited_paths,
         refs=(F0_FILES_REF,),
     )
+    result["data"]["claim_findings"] = [
+        dataclasses.asdict(finding) for finding in merged
+    ]
+    return result

--- a/lib/pulse/scripts/adapters/claude_plugin.py
+++ b/lib/pulse/scripts/adapters/claude_plugin.py
@@ -293,8 +293,14 @@ def context(context: CheckContext) -> dict[str, Any]:  # noqa: A002
 
     facts = repo_claims.facts(context.evidence)
     deterministic = repo_claims.check_claims(text, facts)
+    # Dedupe across the two sources by (kind, subject); a deterministic finding
+    # wins over an inferred one for the same claim (it carries direct evidence),
+    # so one underlying problem is never double-counted in the grade or citation.
+    by_key: dict[tuple[str, str], Any] = {}
+    for finding in (*inferred, *deterministic):
+        by_key[(finding.kind, finding.subject)] = finding
     merged = sorted(
-        (*deterministic, *inferred),
+        by_key.values(),
         key=lambda finding: (finding.kind, finding.subject),
     )
 

--- a/lib/pulse/scripts/marketplace_sync.py
+++ b/lib/pulse/scripts/marketplace_sync.py
@@ -114,9 +114,10 @@ def _find_plugin_entry(marketplace_doc: Any, plugin_id: Any) -> tuple[str | None
     - `found=True, version=<str>` when the entry exists with a non-empty
       string `version`.
     - `found=True, version=None` when the entry exists but has no usable
-      version (the doc is structurally valid; the entry is malformed —
-      handled by `compare` as `missing_entry` so the proposal adds a
-      well-formed entry).
+      version (non-string or empty). The doc is structurally valid and the
+      entry is present, so `compare` classifies it as `drift` (with
+      `current_version=None`) — an UPDATE of the existing entry, not an
+      `missing_entry` add that would duplicate it.
     - `found=False, version=None` when no entry's `name` matches
       `plugin_id` (or the doc is structurally unparseable).
     """

--- a/lib/pulse/scripts/marketplace_sync.py
+++ b/lib/pulse/scripts/marketplace_sync.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Pure marketplace entry version drift decision + proposal builder.
+
+This module is the marketplace-binding equivalent of the plan-sync merge
+path (`lib.pulse.scripts.plan_sync`): it reads the marketplace document's
+recorded version for a plugin and the plugin repo's release list, decides
+whether the marketplace entry is current, and — for `drift` or
+`missing_entry` outcomes — wraps that decision in an F6 `Proposal` via
+`mutation_plan.build_proposal`. The proposal is expected-SHA-guard ready
+(F6 Task 3 will block a stale base at execution time).
+
+**Pure module**: no subprocess, no filesystem, no `gh` calls. The caller
+(the headless skill `skills/gh-marketplace-sync-headless/SKILL.md`)
+fetches the releases and the marketplace document bytes and passes the
+parsed values in.
+
+The marketplace document is the parsed JSON of `<marketplace_repo>/<marketplace_file>`
+(see `.claude-plugin/marketplace.json` for the live format): a top-level
+mapping with a `plugins` list whose entries carry `name`, `source`,
+`description`, `version`, and `keywords`. The plugin identifier field is
+`name` (NOT `id`); the recorded version for `plugin_id` is the `version`
+of the `plugins[]` entry whose `name == plugin_id`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from lib.pulse.scripts.mutation_plan import (
+    Proposal,
+    TransformationRegistry,
+    build_proposal,
+)
+
+
+# Outcome strings. Frozen literals — the headless skill and tests key on
+# these. `in_sync` is a positive outcome (no proposal). The other four
+# carry distinct semantics; see the README above for the decision rules.
+OUTCOME_NOT_APPLICABLE = "not_applicable"
+OUTCOME_UNKNOWN = "unknown"
+OUTCOME_IN_SYNC = "in_sync"
+OUTCOME_MISSING_ENTRY = "missing_entry"
+OUTCOME_DRIFT = "drift"
+
+# `build_marketplace_proposal` only accepts these two outcomes — every
+# other outcome is a caller bug (a proposal for `in_sync` would be a
+# no-op; for `not_applicable`/`unknown` there is nothing to propose).
+_PROPOSABLE_OUTCOMES = frozenset({OUTCOME_DRIFT, OUTCOME_MISSING_ENTRY})
+
+
+@dataclass(frozen=True)
+class MarketplaceDrift:
+    """Pure decision from comparing a binding to its marketplace entry.
+
+    `outcome` is one of the `OUTCOME_*` constants. `current_version` /
+    `target_version` are `None` for `not_applicable` / `unknown`. The
+    proposal-building function only accepts `drift` or `missing_entry`.
+    """
+
+    outcome: str
+    plugin_id: str
+    marketplace_repo: str
+    marketplace_file: str
+    current_version: str | None
+    target_version: str | None
+    reason: str | None = None
+
+
+def _newest_stable_tag(releases: Any) -> str | None:
+    """Return the newest STABLE `tagName` from a `gh release list --json` payload.
+
+    `gh release list --json` returns newest-first; the first entry whose
+    `isPrerelease` is not truthy AND `isDraft` is not truthy is the
+    newest STABLE release. Defensive:
+
+    - A non-mapping entry (e.g. `None`, stray `str`) is skipped.
+    - A release with `isPrerelease is True` is skipped (prerelease).
+    - A release with `isDraft is True` is skipped (draft).
+    - Missing/non-bool `isPrerelease`/`isDraft` are treated as not-excluded
+      only when their value is explicitly `False`; any other value
+      (`None`, missing, non-bool truthy) is treated as excluded
+      (fail-closed against accidental misrelease).
+
+    Returns `None` when no entry is a stable release.
+    """
+    if not isinstance(releases, list):
+        return None
+    for entry in releases:
+        if not isinstance(entry, dict):
+            continue
+        tag = entry.get("tagName")
+        if not isinstance(tag, str) or not tag:
+            continue
+        is_prerelease = entry.get("isPrerelease")
+        is_draft = entry.get("isDraft")
+        # Only an explicit `False` counts as "not excluded". `True`/missing
+        # /`None`/non-bool is treated as "excluded" — fail-closed against
+        # misrelease of a release that lacks the flags.
+        if is_prerelease is not False or is_draft is not False:
+            continue
+        return tag
+    return None
+
+
+def _find_plugin_entry(marketplace_doc: Any, plugin_id: Any) -> tuple[str | None, bool]:
+    """Find the `plugins[]` entry whose `name == plugin_id`.
+
+    Returns `(recorded_version, found)`:
+    - `found=True, version=<str>` when the entry exists with a non-empty
+      string `version`.
+    - `found=True, version=None` when the entry exists but has no usable
+      version (the doc is structurally valid; the entry is malformed —
+      handled by `compare` as `missing_entry` so the proposal adds a
+      well-formed entry).
+    - `found=False, version=None` when no entry's `name` matches
+      `plugin_id` (or the doc is structurally unparseable).
+    """
+    if not isinstance(marketplace_doc, dict):
+        return None, False
+    plugins = marketplace_doc.get("plugins")
+    if not isinstance(plugins, list):
+        return None, False
+    for entry in plugins:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("name") == plugin_id:
+            version = entry.get("version")
+            if isinstance(version, str) and version:
+                return version, True
+            return None, True
+    return None, False
+
+
+def _binding_fields(binding: dict[str, Any] | None) -> tuple[str, str, str]:
+    """Extract the three fields every outcome carries, defensively."""
+    if not isinstance(binding, dict):
+        return "", "", ""
+    return (
+        str(binding.get("plugin_id") or ""),
+        str(binding.get("marketplace_repo") or ""),
+        str(binding.get("marketplace_file") or ""),
+    )
+
+
+def compare(
+    binding: dict[str, Any] | None,
+    releases: Any,
+    marketplace_doc: Any,
+) -> MarketplaceDrift:
+    """Compare the recorded marketplace entry to the newest stable plugin release.
+
+    Returns a `MarketplaceDrift` whose `outcome` is one of:
+    - `not_applicable` when `binding is None` (no marketplace binding for
+      this repo — global F9 v1 constraint).
+    - `unknown` (fail-closed, no decision) when no stable release is
+      found, OR the marketplace document is unparseable / not the
+      expected mapping shape. `reason` names the gap.
+    - `in_sync` when the recorded `plugins[]` entry's `version` equals
+      the newest stable `tagName`.
+    - `missing_entry` when `plugin_id` is absent from `plugins[]` —
+      treated as drift with an add; `current_version=None`,
+      `target_version=<tag>`.
+    - `drift` when the recorded version is present but ≠ the newest
+      stable `tagName`; `current_version=<recorded>`, `target_version=<tag>`.
+    """
+    if binding is None:
+        return MarketplaceDrift(
+            outcome=OUTCOME_NOT_APPLICABLE,
+            plugin_id="",
+            marketplace_repo="",
+            marketplace_file="",
+            current_version=None,
+            target_version=None,
+            reason="no binding configured",
+        )
+
+    plugin_id, marketplace_repo, marketplace_file = _binding_fields(binding)
+    newest = _newest_stable_tag(releases)
+
+    if newest is None:
+        return MarketplaceDrift(
+            outcome=OUTCOME_UNKNOWN,
+            plugin_id=plugin_id,
+            marketplace_repo=marketplace_repo,
+            marketplace_file=marketplace_file,
+            current_version=None,
+            target_version=None,
+            reason="no stable release found",
+        )
+
+    if not isinstance(marketplace_doc, dict):
+        return MarketplaceDrift(
+            outcome=OUTCOME_UNKNOWN,
+            plugin_id=plugin_id,
+            marketplace_repo=marketplace_repo,
+            marketplace_file=marketplace_file,
+            current_version=None,
+            target_version=newest,
+            reason="marketplace_doc is not a mapping",
+        )
+    plugins = marketplace_doc.get("plugins")
+    if not isinstance(plugins, list):
+        return MarketplaceDrift(
+            outcome=OUTCOME_UNKNOWN,
+            plugin_id=plugin_id,
+            marketplace_repo=marketplace_repo,
+            marketplace_file=marketplace_file,
+            current_version=None,
+            target_version=newest,
+            reason="marketplace_doc.plugins is not a list",
+        )
+
+    recorded, found = _find_plugin_entry(marketplace_doc, plugin_id)
+    if not found:
+        return MarketplaceDrift(
+            outcome=OUTCOME_MISSING_ENTRY,
+            plugin_id=plugin_id,
+            marketplace_repo=marketplace_repo,
+            marketplace_file=marketplace_file,
+            current_version=None,
+            target_version=newest,
+            reason=f"plugin_id {plugin_id!r} not in marketplace plugins[]",
+        )
+    if recorded == newest:
+        return MarketplaceDrift(
+            outcome=OUTCOME_IN_SYNC,
+            plugin_id=plugin_id,
+            marketplace_repo=marketplace_repo,
+            marketplace_file=marketplace_file,
+            current_version=recorded,
+            target_version=newest,
+            reason=None,
+        )
+    return MarketplaceDrift(
+        outcome=OUTCOME_DRIFT,
+        plugin_id=plugin_id,
+        marketplace_repo=marketplace_repo,
+        marketplace_file=marketplace_file,
+        current_version=recorded,
+        target_version=newest,
+        reason=f"recorded version {recorded!r} != newest stable {newest!r}",
+    )
+
+
+def build_marketplace_proposal(
+    drift: MarketplaceDrift,
+    head_sha: str,
+    actor: dict[str, Any],
+    registry: TransformationRegistry | None = None,
+) -> Proposal:
+    """Wrap a `drift` or `missing_entry` decision in an F6 `Proposal`.
+
+    The proposal selects the `marketplace_repo` (single selection) and
+    carries `expected_shas={marketplace_repo: head_sha}` so the F6
+    expected-SHA guard (see `pen_orchestrator.execute`) blocks a stale
+    base at execution. `mutation_policy="propose"` — this orchestrator
+    is propose-only, exactly like `plan-sync-doc-patch`.
+
+    Raises `ValueError` when `drift.outcome` is not in
+    `{OUTCOME_DRIFT, OUTCOME_MISSING_ENTRY}` — the caller (the headless
+    skill) is expected to only invoke this for those two outcomes.
+    """
+    if drift.outcome not in _PROPOSABLE_OUTCOMES:
+        raise ValueError(
+            f"build_marketplace_proposal requires drift or missing_entry, "
+            f"got outcome={drift.outcome!r}"
+        )
+    return build_proposal(
+        id=f"marketplace-{drift.plugin_id}",
+        selection=[drift.marketplace_repo],
+        transformation="marketplace-entry-update",
+        expected_shas={drift.marketplace_repo: head_sha},
+        actor=actor,
+        mutation_policy="propose",
+        registry=registry,
+    )

--- a/lib/pulse/scripts/repo_claims.py
+++ b/lib/pulse/scripts/repo_claims.py
@@ -49,9 +49,11 @@ COMMAND_FILENAME_SUFFIX = ".md"
 HOOKS_PATH_PREFIX = "hooks/"
 
 
-_SKILL_RE = re.compile(r"skills/([^/\s]+)/SKILL\.md")
-_COMMAND_RE = re.compile(r"commands/([^/\s]+)\.md")
-_HOOKS_RE = re.compile(r"hooks/([\w\-]+(?:\.[\w\-]+)*)")
+# A left word-boundary lookbehind keeps a reference from matching mid-word, so
+# prose like "subskills/x/SKILL.md" or "ghooks/y.sh" is NOT read as a claim.
+_SKILL_RE = re.compile(r"(?<![\w-])skills/([^/\s]+)/SKILL\.md")
+_COMMAND_RE = re.compile(r"(?<![\w-])commands/([^/\s]+)\.md")
+_HOOKS_RE = re.compile(r"(?<![\w-])hooks/([\w\-]+(?:\.[\w\-]+)*)")
 
 
 UNSUPPORTED_EVIDENCE_DETAIL = (
@@ -67,9 +69,9 @@ class ClaimFinding:
     ``inferred`` distinguishes deterministic findings (extracted by
     :func:`check_claims` from the text) from inferred findings (produced
     by an external inference step and validated by
-    :func:`validate_inferred_findings`). Downstream consumers treat
-    inferred findings as advisory unless paired with deterministic
-    evidence.
+    :func:`validate_inferred_findings`). Once an inferred finding passes
+    schema validation it contributes to the grade on equal footing with a
+    deterministic finding; the flag records provenance, not lower weight.
     """
 
     kind: str

--- a/lib/pulse/scripts/repo_claims.py
+++ b/lib/pulse/scripts/repo_claims.py
@@ -1,0 +1,302 @@
+"""Pure claim-currency audit for the Claude Code plugin overlay.
+
+This module is a strict one-way dependency: ``claude_plugin`` imports
+``repo_claims``, never the reverse. It is pure (no filesystem, no
+subprocess, no GitHub) and the deterministic helpers (``facts`` and
+``check_claims``) accept no inferred input.
+
+Three responsibilities:
+
+* ``facts``  — derive the repository's current ground truth
+  (``skill_paths``, ``command_names``, ``manifest``) from the evidence
+  snapshot. Deterministic; trusts only ``files`` and ``file_contents``.
+
+* ``check_claims`` — scan a ``CLAUDE.md`` body for textual path
+  references and report which ones disagree with the current facts.
+  Deterministic; every finding carries ``inferred=False``.
+
+* ``validate_inferred_findings`` — the schema guard for candidate
+  findings produced by an external (non-deterministic) inference step.
+  Any violation raises :class:`InferenceValidationError`; on success the
+  returned findings are marked ``inferred=True``.
+
+The reasoning for the split: extracting claims from prose is genuinely
+non-deterministic and belongs to a skill or model. Once those raw
+candidate findings exist, this module is the only place that decides
+whether they are well-formed enough to fold into the deterministic
+audit.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+import json
+import re
+from typing import Any
+
+
+CLAIM_KINDS = frozenset(
+    {"missing_claimed_skill", "stale_command", "unsupported_evidence"}
+)
+
+
+PLUGIN_MANIFEST_PATH = ".claude-plugin/plugin.json"
+SKILL_PATH_PREFIX = "skills/"
+SKILL_FILENAME = "SKILL.md"
+COMMAND_PATH_PREFIX = "commands/"
+COMMAND_FILENAME_SUFFIX = ".md"
+HOOKS_PATH_PREFIX = "hooks/"
+
+
+_SKILL_RE = re.compile(r"skills/([^/\s]+)/SKILL\.md")
+_COMMAND_RE = re.compile(r"commands/([^/\s]+)\.md")
+_HOOKS_RE = re.compile(r"hooks/([\w\-]+(?:\.[\w\-]+)*)")
+
+
+UNSUPPORTED_EVIDENCE_DETAIL = (
+    "hooks are a recognized Claude artifact class that facts() does not "
+    "model — claim surfaced, not verified"
+)
+
+
+@dataclass(frozen=True)
+class ClaimFinding:
+    """A single claim-currency disagreement or surfaced reference.
+
+    ``inferred`` distinguishes deterministic findings (extracted by
+    :func:`check_claims` from the text) from inferred findings (produced
+    by an external inference step and validated by
+    :func:`validate_inferred_findings`). Downstream consumers treat
+    inferred findings as advisory unless paired with deterministic
+    evidence.
+    """
+
+    kind: str
+    subject: str
+    detail: str
+    inferred: bool
+
+
+@dataclass(frozen=True)
+class RepoFacts:
+    """Current ground truth about a repository, derived deterministically."""
+
+    skill_paths: frozenset[str]
+    command_names: frozenset[str]
+    manifest: dict[str, Any]
+
+
+class InferenceValidationError(ValueError):
+    """Raised when an inferred-claim candidate fails schema validation."""
+
+
+def _safe_files(evidence: Any) -> tuple[str, ...]:
+    """Return ``evidence['files']`` as a tuple of ``str`` or ``()``.
+
+    Mirrors the defensive shape checks used by
+    :func:`lib.pulse.scripts.adapters.generic._files` so that an
+    evidence payload with a malformed ``files`` field yields an empty
+    fact set rather than a crash.
+    """
+    value = evidence.get("files") if isinstance(evidence, Mapping) else None
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        return ()
+    if not all(isinstance(path, str) for path in value):
+        return ()
+    return tuple(value)
+
+
+def _safe_contents(evidence: Any) -> dict[str, str]:
+    """Return ``evidence['file_contents']`` as ``{path: str}`` or ``{}``."""
+    value = (
+        evidence.get("file_contents") if isinstance(evidence, Mapping) else None
+    )
+    if not isinstance(value, Mapping):
+        return {}
+    return {path: text for path, text in value.items() if isinstance(text, str)}
+
+
+def _is_skill_path(path: str) -> bool:
+    if not path.startswith(SKILL_PATH_PREFIX):
+        return False
+    if not path.endswith("/" + SKILL_FILENAME):
+        return False
+    remainder = path[len(SKILL_PATH_PREFIX) : -len("/" + SKILL_FILENAME)]
+    return bool(remainder) and "/" not in remainder
+
+
+def _is_command_path(path: str) -> bool:
+    if not path.startswith(COMMAND_PATH_PREFIX):
+        return False
+    if not path.endswith(COMMAND_FILENAME_SUFFIX):
+        return False
+    remainder = path[len(COMMAND_PATH_PREFIX) : -len(COMMAND_FILENAME_SUFFIX)]
+    return bool(remainder) and "/" not in remainder
+
+
+def facts(evidence: Any) -> RepoFacts:
+    """Derive :class:`RepoFacts` from an evidence mapping.
+
+    Pure and deterministic. Only ``evidence['files']`` and
+    ``evidence['file_contents']`` are read. The plugin manifest is
+    parsed defensively: any absence, invalid JSON, or non-mapping root
+    collapses to ``{}``.
+    """
+    files = _safe_files(evidence)
+    skill_paths = frozenset(path for path in files if _is_skill_path(path))
+    command_names = frozenset(
+        path[len(COMMAND_PATH_PREFIX) : -len(COMMAND_FILENAME_SUFFIX)]
+        for path in files
+        if _is_command_path(path)
+    )
+    contents = _safe_contents(evidence)
+    raw_manifest = contents.get(PLUGIN_MANIFEST_PATH)
+    manifest: dict[str, Any] = {}
+    if isinstance(raw_manifest, str):
+        try:
+            parsed = json.loads(raw_manifest)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, Mapping):
+            manifest = dict(parsed)
+    return RepoFacts(
+        skill_paths=skill_paths,
+        command_names=command_names,
+        manifest=manifest,
+    )
+
+
+def check_claims(
+    claude_md_text: str, facts: RepoFacts
+) -> list[ClaimFinding]:
+    """Scan ``claude_md_text`` for path references and audit them.
+
+    Every returned finding is deterministic and carries
+    ``inferred=False``. Findings are deduplicated by ``(kind, subject)``
+    and sorted by the same key so that the result is stable across
+    runs.
+
+    The supported references are:
+
+    * ``skills/<seg>/SKILL.md`` — must exist in ``facts.skill_paths``,
+      otherwise a ``missing_claimed_skill`` finding is produced.
+    * ``commands/<name>.md`` — ``name`` must exist in
+      ``facts.command_names``, otherwise a ``stale_command`` finding
+      is produced.
+    * ``hooks/<file>`` — a recognized Claude artifact class that
+      :func:`facts` does not model. The reference is always surfaced
+      as ``unsupported_evidence`` (never guessed at).
+    """
+    findings: dict[tuple[str, str], ClaimFinding] = {}
+
+    for match in _SKILL_RE.finditer(claude_md_text):
+        path = match.group(0)
+        if path in facts.skill_paths:
+            continue
+        findings[("missing_claimed_skill", path)] = ClaimFinding(
+            kind="missing_claimed_skill",
+            subject=path,
+            detail=f"CLAUDE.md references {path} but no such skill exists",
+            inferred=False,
+        )
+
+    for match in _COMMAND_RE.finditer(claude_md_text):
+        name = match.group(1)
+        if name in facts.command_names:
+            continue
+        findings[("stale_command", name)] = ClaimFinding(
+            kind="stale_command",
+            subject=name,
+            detail=(
+                f"CLAUDE.md references commands/{name}.md but no such "
+                "command exists"
+            ),
+            inferred=False,
+        )
+
+    for match in _HOOKS_RE.finditer(claude_md_text):
+        path = match.group(0)
+        findings[("unsupported_evidence", path)] = ClaimFinding(
+            kind="unsupported_evidence",
+            subject=path,
+            detail=UNSUPPORTED_EVIDENCE_DETAIL,
+            inferred=False,
+        )
+
+    return [findings[key] for key in sorted(findings)]
+
+
+def validate_inferred_findings(raw: Any) -> list[ClaimFinding]:
+    """Validate a raw list of inferred-claim candidates.
+
+    The schema for each item is:
+
+    * ``kind``   — must be in :data:`CLAIM_KINDS`.
+    * ``subject`` — must be a non-empty ``str``.
+    * ``detail`` — must be a ``str``.
+    * ``inferred`` — if present, must be ``True`` (absent is allowed and
+      coerced to ``True``).
+
+    Any violation raises :class:`InferenceValidationError` naming the
+    first offending item; the candidate list is never silently truncated
+    or coerced. ``raw`` is accepted as any :class:`collections.abc.Sequence`
+    so that callers passing the frozen :class:`CheckContext` evidence
+    (where lists are normalised to tuples) still validate correctly —
+    the schema is about the shape of the payload, not its concrete
+    Python container type.
+    """
+    if isinstance(raw, (str, bytes)) or not isinstance(raw, Sequence):
+        raise InferenceValidationError(
+            "inferred claims must be a list, got "
+            f"{type(raw).__name__}"
+        )
+
+    validated: list[ClaimFinding] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, Mapping):
+            raise InferenceValidationError(
+                f"inferred claim at index {index} is not a mapping"
+            )
+        kind = item.get("kind")
+        if not isinstance(kind, str) or kind not in CLAIM_KINDS:
+            raise InferenceValidationError(
+                f"inferred claim at index {index} has invalid kind: "
+                f"{kind!r}"
+            )
+        subject = item.get("subject")
+        if not isinstance(subject, str) or not subject:
+            raise InferenceValidationError(
+                f"inferred claim at index {index} has invalid subject: "
+                f"{subject!r}"
+            )
+        detail = item.get("detail")
+        if not isinstance(detail, str):
+            raise InferenceValidationError(
+                f"inferred claim at index {index} has invalid detail: "
+                f"{detail!r}"
+            )
+        if "inferred" in item and item["inferred"] is not True:
+            raise InferenceValidationError(
+                f"inferred claim at index {index} has inferred != True"
+            )
+        validated.append(
+            ClaimFinding(
+                kind=kind,
+                subject=subject,
+                detail=detail,
+                inferred=True,
+            )
+        )
+    return validated
+
+
+__all__ = [
+    "CLAIM_KINDS",
+    "ClaimFinding",
+    "InferenceValidationError",
+    "RepoFacts",
+    "check_claims",
+    "facts",
+    "validate_inferred_findings",
+]

--- a/lib/pulse/scripts/tests/fixtures/marketplace-sync-invalid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/marketplace-sync-invalid.yaml
@@ -1,0 +1,23 @@
+contract_version: 1
+kind: marketplace-sync
+workspace: testorg
+run_at: "2026-07-21T09:15:00Z"
+# actor intentionally omitted -> missing required key: actor
+# bindings_scanned intentionally omitted -> missing required key: bindings_scanned
+in_sync: 1
+drift: -1            # negative -> must be a non-negative integer
+missing_entry: 0
+unknown: 0
+not_applicable: 0
+findings:
+  - kind: unreadable_head
+    repo: testorg/marketplace
+    severity: catastrophic   # not in SEVERITIES -> findings[0].severity invalid
+    detail: "bad severity value"
+proposals:
+  - binding: widget
+    transformation: marketplace-entry-update
+    # proposal_id omitted -> proposals[0].proposal_id missing
+proposed_actions:
+  - 42                 # not a string -> proposed_actions[0] is not a string
+errors: []

--- a/lib/pulse/scripts/tests/fixtures/marketplace-sync-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/marketplace-sync-valid.yaml
@@ -1,0 +1,26 @@
+contract_version: 1
+kind: marketplace-sync
+workspace: testorg
+run_at: "2026-07-21T09:15:00Z"
+actor:
+  gh_login: octocat
+  machine: mba-m4
+  mode: scheduled
+bindings_scanned: 3
+in_sync: 1
+drift: 1
+missing_entry: 1
+unknown: 0
+not_applicable: 0
+findings:
+  - kind: unreadable_head
+    repo: testorg/marketplace
+    severity: high
+    detail: "Could not resolve marketplace repo HEAD for the widget plugin."
+proposals:
+  - binding: widget
+    transformation: marketplace-entry-update
+    proposal_id: marketplace-widget
+proposed_actions:
+  - propose marketplace entry update for widget to v2.1.0
+errors: []

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/content-unavailable.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/content-unavailable.yaml
@@ -1,0 +1,16 @@
+files:
+  - .claude-plugin/plugin.json
+  - skills/example/SKILL.md
+  - CLAUDE.md
+  - README.md
+file_contents:
+  skills/example/SKILL.md: |
+    ---
+    name: example-skill
+    description: A skill whose sibling manifest has no content available.
+    ---
+    # example
+  CLAUDE.md: |
+    # context
+  README.md: |
+    # readme

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/inference-invalid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/inference-invalid.yaml
@@ -1,0 +1,28 @@
+files:
+  - .claude-plugin/plugin.json
+  - skills/example/SKILL.md
+  - commands/gh.md
+  - CLAUDE.md
+  - README.md
+file_contents:
+  .claude-plugin/plugin.json: |
+    {
+      "name": "plugin-with-invalid-inference",
+      "version": "0.1.0"
+    }
+  skills/example/SKILL.md: |
+    ---
+    name: example-skill
+    description: A skill living alongside a malformed inferred-claim payload.
+    ---
+    # example
+  CLAUDE.md: |
+    # Project context for Claude
+
+    Use skills/example/SKILL.md and run commands/gh.md.
+  README.md: |
+    # readme
+inferred_claims:
+  - kind: not_a_kind
+    subject: skills/ghost/SKILL.md
+    detail: a maliciously-typed inference payload

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/inference-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/inference-valid.yaml
@@ -1,0 +1,28 @@
+files:
+  - .claude-plugin/plugin.json
+  - skills/example/SKILL.md
+  - commands/gh.md
+  - CLAUDE.md
+  - README.md
+file_contents:
+  .claude-plugin/plugin.json: |
+    {
+      "name": "plugin-with-valid-inference",
+      "version": "0.1.0"
+    }
+  skills/example/SKILL.md: |
+    ---
+    name: example-skill
+    description: A skill living alongside a well-formed inferred-claim payload.
+    ---
+    # example
+  CLAUDE.md: |
+    # Project context for Claude
+
+    Use skills/example/SKILL.md and run commands/gh.md.
+  README.md: |
+    # readme
+inferred_claims:
+  - kind: missing_claimed_skill
+    subject: skills/inferred-only/SKILL.md
+    detail: the agent inferred a skill reference from prose not yet in CLAUDE.md

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/malformed-manifest.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/malformed-manifest.yaml
@@ -1,0 +1,20 @@
+files:
+  - .claude-plugin/plugin.json
+  - skills/example/SKILL.md
+  - CLAUDE.md
+  - README.md
+file_contents:
+  .claude-plugin/plugin.json: |
+    {
+      "name": "missing-version"
+    }
+  skills/example/SKILL.md: |
+    ---
+    name: example-skill
+    description: A skill living alongside a manifest missing the version field.
+    ---
+    # example
+  CLAUDE.md: |
+    # context
+  README.md: |
+    # readme

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/malformed-skill-frontmatter.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/malformed-skill-frontmatter.yaml
@@ -1,0 +1,24 @@
+files:
+  - .claude-plugin/plugin.json
+  - skills/good/SKILL.md
+  - skills/broken/SKILL.md
+  - CLAUDE.md
+  - README.md
+file_contents:
+  .claude-plugin/plugin.json: |
+    {
+      "name": "plugin-with-broken-skill",
+      "version": "0.1.0"
+    }
+  skills/good/SKILL.md: |
+    ---
+    name: good-skill
+    description: A well-formed skill proving the other one is the offender.
+    ---
+    # good
+  skills/broken/SKILL.md: |
+    This file has no frontmatter at all and is therefore malformed.
+  CLAUDE.md: |
+    # context
+  README.md: |
+    # readme

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/missing-claude-md.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/missing-claude-md.yaml
@@ -1,0 +1,18 @@
+files:
+  - .claude-plugin/plugin.json
+  - skills/example/SKILL.md
+  - README.md
+file_contents:
+  .claude-plugin/plugin.json: |
+    {
+      "name": "plugin-without-claude-md",
+      "version": "0.0.1"
+    }
+  skills/example/SKILL.md: |
+    ---
+    name: example-skill
+    description: A skill in a repository that omits CLAUDE.md.
+    ---
+    # example
+  README.md: |
+    # readme

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/missing-manifest.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/missing-manifest.yaml
@@ -1,0 +1,15 @@
+files:
+  - skills/example/SKILL.md
+  - CLAUDE.md
+  - README.md
+file_contents:
+  skills/example/SKILL.md: |
+    ---
+    name: example-skill
+    description: A skill living in a repository without a plugin manifest.
+    ---
+    # example
+  CLAUDE.md: |
+    # context
+  README.md: |
+    # readme

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/no-skills.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/no-skills.yaml
@@ -1,0 +1,14 @@
+files:
+  - .claude-plugin/plugin.json
+  - CLAUDE.md
+  - README.md
+file_contents:
+  .claude-plugin/plugin.json: |
+    {
+      "name": "plugin-without-skills",
+      "version": "0.0.1"
+    }
+  CLAUDE.md: |
+    # context
+  README.md: |
+    # readme

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/plain-python-profiles.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/plain-python-profiles.yaml
@@ -1,0 +1,21 @@
+repository_profiles:
+  acme/python-lib:
+    profiles: [python]
+    scorecard: generic-v1
+
+scorecards:
+  generic-v1:
+    checks:
+      - id: documentation
+        adapter: generic.docs
+        weight: 1
+      - id: ci
+        adapter: github.actions
+        applicability: capability:ci
+        weight: 1
+
+adapters:
+  generic.docs:
+    state: available
+  github.actions:
+    state: available

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/stale-claim.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/stale-claim.yaml
@@ -1,0 +1,25 @@
+files:
+  - .claude-plugin/plugin.json
+  - skills/example/SKILL.md
+  - commands/gh.md
+  - CLAUDE.md
+  - README.md
+file_contents:
+  .claude-plugin/plugin.json: |
+    {
+      "name": "plugin-with-stale-claims",
+      "version": "0.1.0"
+    }
+  skills/example/SKILL.md: |
+    ---
+    name: example-skill
+    description: The only skill that actually exists in this plugin.
+    ---
+    # example
+  CLAUDE.md: |
+    # Project context for Claude
+
+    Use skills/ghost/SKILL.md for the audit procedure, and run
+    commands/deprecated.md to refresh the scorecard.
+  README.md: |
+    # readme

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/unsupported-claim.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/unsupported-claim.yaml
@@ -1,0 +1,26 @@
+files:
+  - .claude-plugin/plugin.json
+  - skills/example/SKILL.md
+  - commands/gh.md
+  - CLAUDE.md
+  - hooks/heartbeat.sh
+  - README.md
+file_contents:
+  .claude-plugin/plugin.json: |
+    {
+      "name": "plugin-with-unsupported-claim",
+      "version": "0.1.0"
+    }
+  skills/example/SKILL.md: |
+    ---
+    name: example-skill
+    description: A skill living alongside an unmodeled hooks reference.
+    ---
+    # example
+  CLAUDE.md: |
+    # Project context for Claude
+
+    Use skills/example/SKILL.md and run commands/gh.md. The heartbeat
+    is wired up via hooks/heartbeat.sh.
+  README.md: |
+    # readme

--- a/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/valid-plugin.yaml
+++ b/lib/pulse/scripts/tests/fixtures/overlays/claude-plugin/valid-plugin.yaml
@@ -1,0 +1,29 @@
+files:
+  - .claude-plugin/plugin.json
+  - skills/example/SKILL.md
+  - skills/audit/SKILL.md
+  - CLAUDE.md
+  - README.md
+file_contents:
+  .claude-plugin/plugin.json: |
+    {
+      "name": "example-plugin",
+      "version": "1.2.3"
+    }
+  skills/example/SKILL.md: |
+    ---
+    name: example-skill
+    description: An example skill demonstrating valid frontmatter.
+    ---
+    # example skill body
+  skills/audit/SKILL.md: |
+    ---
+    name: audit-skill
+    description: Audits configuration drift across workspace repositories.
+    ---
+    # audit skill body
+  CLAUDE.md: |
+    # Project context for Claude
+    This is the project context.
+  README.md: |
+    # example plugin

--- a/lib/pulse/scripts/tests/test_claude_plugin_adapter.py
+++ b/lib/pulse/scripts/tests/test_claude_plugin_adapter.py
@@ -183,3 +183,85 @@ def test_unregistered_claude_adapters_are_unsupported_when_dispatched():
 
     assert out["status"] == "unsupported"
     assert "no adapter registered" in out["detail"].lower()
+
+
+# --- claim-currency audit (Task 3) ---------------------------------------
+
+
+def test_stale_claim_fails_and_attach_claim_findings():
+    out = _evaluate("claude.context", _load_evidence("stale-claim"))
+
+    assert out["status"] == "fail"
+    assert "2 stale CLAUDE.md claim(s)" in out["detail"]
+
+    findings = out["data"]["claim_findings"]
+    assert {f["kind"] for f in findings} == {
+        "missing_claimed_skill",
+        "stale_command",
+    }
+    assert out["data"]["evidence"]["paths"] == [
+        "CLAUDE.md",
+        "skills/ghost/SKILL.md",
+    ]
+    assert out["data"]["evidence"]["refs"] == ["f0:files"]
+
+
+def test_stale_claim_reports_correct_subjects_sorted():
+    out = _evaluate("claude.context", _load_evidence("stale-claim"))
+
+    findings = out["data"]["claim_findings"]
+    assert findings == sorted(findings, key=lambda f: (f["kind"], f["subject"]))
+
+    by_kind = {f["kind"]: f for f in findings}
+    assert by_kind["missing_claimed_skill"]["subject"] == "skills/ghost/SKILL.md"
+    assert by_kind["stale_command"]["subject"] == "deprecated"
+    assert by_kind["missing_claimed_skill"]["inferred"] is False
+    assert by_kind["stale_command"]["inferred"] is False
+
+
+def test_unsupported_claim_passes_and_surfaces_hooks_finding():
+    out = _evaluate("claude.context", _load_evidence("unsupported-claim"))
+
+    assert out["status"] == "pass"
+    assert "CLAUDE.md claims current" in out["detail"]
+    assert "1 unsupported claim(s) surfaced" in out["detail"]
+
+    findings = out["data"]["claim_findings"]
+    assert len(findings) == 1
+    assert findings[0]["kind"] == "unsupported_evidence"
+    assert findings[0]["subject"] == "hooks/heartbeat.sh"
+    assert findings[0]["inferred"] is False
+    assert out["data"]["evidence"]["paths"] == ["CLAUDE.md", "hooks/heartbeat.sh"]
+
+
+def test_inference_invalid_payload_yields_unknown_status():
+    out = _evaluate("claude.context", _load_evidence("inference-invalid"))
+
+    assert out["status"] == "unknown"
+    assert "inferred claim validation failed" in out["detail"].lower()
+    assert out["data"]["evidence"]["paths"] == ["CLAUDE.md"]
+
+
+def test_inference_valid_payload_folds_into_findings_with_inferred_flag():
+    out = _evaluate("claude.context", _load_evidence("inference-valid"))
+
+    assert out["status"] == "fail"
+    assert "1 stale CLAUDE.md claim(s)" in out["detail"]
+
+    findings = out["data"]["claim_findings"]
+    assert len(findings) == 1
+    assert findings[0]["kind"] == "missing_claimed_skill"
+    assert findings[0]["subject"] == "skills/inferred-only/SKILL.md"
+    assert findings[0]["inferred"] is True
+    assert out["data"]["evidence"]["paths"] == [
+        "CLAUDE.md",
+        "skills/inferred-only/SKILL.md",
+    ]
+
+
+def test_valid_plugin_context_still_passes_with_no_claim_findings():
+    out = _evaluate("claude.context", _load_evidence("valid-plugin"))
+
+    assert out["status"] == "pass"
+    assert out["data"]["evidence"]["paths"] == ["CLAUDE.md"]
+    assert out["data"]["claim_findings"] == []

--- a/lib/pulse/scripts/tests/test_claude_plugin_adapter.py
+++ b/lib/pulse/scripts/tests/test_claude_plugin_adapter.py
@@ -1,0 +1,185 @@
+"""Behavioral tests for the Claude Code plugin healthcheck adapters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lib.pulse.scripts.adapters import register_claude_adapters
+from lib.pulse.scripts.check_adapters import AdapterRegistry, CheckContext
+from lib.pulse.scripts.profile_dispatch import (
+    dispatch,
+    load_profiles,
+    resolve_scorecard,
+)
+
+
+FIXTURES = Path(__file__).parent / "fixtures" / "overlays" / "claude-plugin"
+TEMPLATE = Path("templates/profiles.yaml.template")
+
+
+def _load_evidence(name: str) -> dict:
+    return yaml.safe_load((FIXTURES / f"{name}.yaml").read_text())
+
+
+def _make_registry() -> AdapterRegistry:
+    registry = AdapterRegistry()
+    register_claude_adapters(registry)
+    return registry
+
+
+def _context(adapter: str, evidence: dict) -> CheckContext:
+    return CheckContext(
+        repo=evidence.get("repo", "test/plugin"),
+        evidence=evidence,
+        check={"id": adapter.rsplit(".", 1)[-1], "weight": 1},
+        workspace=Path("/workspace/that/must/not/be/read"),
+    )
+
+
+def _evaluate(adapter: str, evidence: dict) -> dict:
+    return _make_registry().evaluate(adapter, _context(adapter, evidence))
+
+
+def test_valid_plugin_manifest_passes_and_cites_manifest_path():
+    out = _evaluate("claude.plugin_manifest", _load_evidence("valid-plugin"))
+
+    assert out["status"] == "pass"
+    assert out["data"]["evidence"]["paths"] == [".claude-plugin/plugin.json"]
+    assert out["data"]["evidence"]["refs"] == ["f0:files"]
+
+
+def test_valid_skills_pass_and_cite_sorted_skill_paths():
+    out = _evaluate("claude.skills", _load_evidence("valid-plugin"))
+
+    assert out["status"] == "pass"
+    assert out["data"]["evidence"]["paths"] == [
+        "skills/audit/SKILL.md",
+        "skills/example/SKILL.md",
+    ]
+    assert out["data"]["evidence"]["refs"] == ["f0:files"]
+
+
+def test_valid_claude_context_passes_and_cites_context_file():
+    out = _evaluate("claude.context", _load_evidence("valid-plugin"))
+
+    assert out["status"] == "pass"
+    assert out["data"]["evidence"]["paths"] == ["CLAUDE.md"]
+    assert out["data"]["evidence"]["refs"] == ["f0:files"]
+
+
+def test_missing_manifest_fails_citing_the_layout_required_path():
+    out = _evaluate("claude.plugin_manifest", _load_evidence("missing-manifest"))
+
+    assert out["status"] == "fail"
+    assert out["data"]["evidence"]["paths"] == [".claude-plugin/plugin.json"]
+    assert out["data"]["evidence"]["refs"] == ["f0:files"]
+
+
+def test_malformed_manifest_fails_citing_the_manifest():
+    out = _evaluate("claude.plugin_manifest", _load_evidence("malformed-manifest"))
+
+    assert out["status"] == "fail"
+    assert out["data"]["evidence"]["paths"] == [".claude-plugin/plugin.json"]
+    assert out["data"]["evidence"]["refs"] == ["f0:files"]
+
+
+def test_content_unavailable_manifest_is_unknown_evidence_gap():
+    out = _evaluate(
+        "claude.plugin_manifest", _load_evidence("content-unavailable")
+    )
+
+    assert out["status"] == "unknown"
+    assert "evidence gap" in out["detail"].lower()
+    assert out["data"]["evidence"]["paths"] == [".claude-plugin/plugin.json"]
+    assert out["data"]["evidence"]["refs"] == ["f0:files"]
+
+
+def test_malformed_skill_frontmatter_fails_citing_the_offending_file():
+    out = _evaluate("claude.skills", _load_evidence("malformed-skill-frontmatter"))
+
+    assert out["status"] == "fail"
+    assert out["data"]["evidence"]["paths"] == ["skills/broken/SKILL.md"]
+    assert out["data"]["evidence"]["refs"] == ["f0:files"]
+
+
+def test_no_skills_fails_with_no_path_to_cite():
+    out = _evaluate("claude.skills", _load_evidence("no-skills"))
+
+    assert out["status"] == "fail"
+    assert out["data"]["evidence"]["paths"] == []
+    assert out["data"]["evidence"]["refs"] == ["f0:files"]
+
+
+def test_missing_claude_md_fails_citing_the_context_file():
+    out = _evaluate("claude.context", _load_evidence("missing-claude-md"))
+
+    assert out["status"] == "fail"
+    assert out["data"]["evidence"]["paths"] == ["CLAUDE.md"]
+    assert out["data"]["evidence"]["refs"] == ["f0:files"]
+
+
+def test_template_loads_and_claude_plugin_v1_resolves_to_inherited_plus_new_checks():
+    config = load_profiles(TEMPLATE)
+
+    resolved = resolve_scorecard(config, "claude-plugin-v1")
+    check_ids = [check.id for check in resolved]
+
+    assert check_ids == [
+        "documentation",
+        "ci",
+        "plugin-manifest",
+        "plugin-skills",
+        "claude-context",
+    ]
+    for check in resolved:
+        assert check.weight == 1
+    for check in resolved[-3:]:
+        assert check.applicability == "profile:claude-plugin"
+    assert config.adapters["claude.plugin_manifest"].state == "available"
+    assert config.adapters["claude.skills"].state == "available"
+    assert config.adapters["claude.context"].state == "available"
+
+
+def test_plain_python_repo_dispatch_invokes_no_claude_adapter():
+    config = load_profiles(FIXTURES / "plain-python-profiles.yaml")
+    evidence = {
+        "repos": [
+            {
+                "repo": "acme/python-lib",
+                "files": ["pyproject.toml", "README.md"],
+                "capabilities": ["ci", "python"],
+                "structural_signals": [],
+            }
+        ]
+    }
+
+    plan = dispatch("acme/python-lib", evidence, config)
+
+    invocable_claude = [
+        check
+        for check in plan.checks.values()
+        if check.state is None and check.adapter.startswith("claude.")
+    ]
+    assert invocable_claude == []
+    assert {check.adapter for check in plan.checks.values() if check.state is None} == {
+        "generic.docs",
+        "github.actions",
+    }
+
+
+def test_unregistered_claude_adapters_are_unsupported_when_dispatched():
+    registry = AdapterRegistry()
+    context = CheckContext(
+        repo="acme/plugin",
+        evidence=_load_evidence("valid-plugin"),
+        check={"id": "plugin_manifest", "weight": 1},
+        workspace=Path("/workspace/that/must/not/be/read"),
+    )
+
+    out = registry.evaluate("claude.plugin_manifest", context)
+
+    assert out["status"] == "unsupported"
+    assert "no adapter registered" in out["detail"].lower()

--- a/lib/pulse/scripts/tests/test_corpus_generator_overlay.py
+++ b/lib/pulse/scripts/tests/test_corpus_generator_overlay.py
@@ -177,3 +177,30 @@ def test_dispatch_rejects_binding_file_outside_allowlist(registry_and_generators
 
     assert "README.md" in str(exc.value)
     assert "allowlist" in str(exc.value).lower() or "output_paths" in str(exc.value)
+
+
+# 6. scheduled-actor gate (parity with the marketplace overlay) --------------
+
+
+def test_corpus_transformation_rejects_scheduled_actor(registry_and_generators):
+    """The corpus transformation is allow_scheduled: false, so a proposal built
+    for a scheduled actor must be rejected by validate_proposal — parity with
+    marketplace-entry-update. (generator_dispatch.dispatch does not itself gate
+    on the registry; the scheduled gate lives in validate_proposal, enforced by
+    pen_orchestrator at execution.)"""
+    registry, generators = registry_and_generators
+    gen = generators[CORPUS_ID]
+
+    binding = {
+        "id": "corpus-navigate-skill",
+        "source": SOURCE,
+        "branch": BRANCH,
+        "files": [{"path": CORPUS_OUTPUT_PATH}],
+    }
+    snapshot = {SOURCE: {BRANCH: {"head": "headsha"}}}
+    scheduled_actor = {"gh_login": "bot", "machine": "ci", "mode": "scheduled"}
+
+    proposal = generator_dispatch.dispatch(gen, binding, snapshot, scheduled_actor)
+
+    with pytest.raises(mutation_plan.MutationPlanError):
+        mutation_plan.validate_proposal(proposal, registry)

--- a/lib/pulse/scripts/tests/test_corpus_generator_overlay.py
+++ b/lib/pulse/scripts/tests/test_corpus_generator_overlay.py
@@ -1,0 +1,179 @@
+"""Contract checks for the corpus-overlay generator configuration.
+
+The F9 v1 dogfood generator entry `hiivmind.corpus-navigate-skill` is the one
+configured overlay under the F7 generic engine. These tests load the shipped
+templates, prove they cross-validate, and exercise the generic engine
+end-to-end on the corpus overlay — without touching any overlay-specific
+engine code.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.pulse.scripts import (
+    generated_artifacts,
+    generator_dispatch,
+    mutation_plan,
+)
+
+
+GENERATORS_TEMPLATE = "templates/generators.yaml.template"
+TRANSFORMATIONS_TEMPLATE = "templates/transformations.yaml.template"
+
+CORPUS_ID = "hiivmind.corpus-navigate-skill"
+CORPUS_TRANSFORMATION = "regenerate-corpus-navigate-skill"
+CORPUS_TEMPLATE_PATH = "templates/corpus/navigate-skill.md.tmpl"
+CORPUS_OUTPUT_PATH = "skills/hiivmind-corpus-navigate/SKILL.md"
+SOURCE = "hiivmind/hiivmind-pulse-gh"
+BRANCH = "main"
+
+
+@pytest.fixture(scope="module")
+def registry_and_generators():
+    """Load the shipped registry + generators together; fail-closed on either."""
+    registry = mutation_plan.load_registry(TRANSFORMATIONS_TEMPLATE)
+    generators = generator_dispatch.load_generators(GENERATORS_TEMPLATE, registry)
+    return registry, generators
+
+
+def _binding(**overrides):
+    base = {
+        "id": "corpus-navigate-skill",
+        "source": SOURCE,
+        "branch": BRANCH,
+        "template_path": CORPUS_TEMPLATE_PATH,
+        "template_tree": "tree-A",
+        "generator": CORPUS_ID,
+        "files": [{"path": CORPUS_OUTPUT_PATH, "blob": "blob-A"}],
+        "generated_at": "2026-07-22T10:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+def _actor():
+    return {"gh_login": "octocat", "machine": "laptop", "mode": "interactive"}
+
+
+# 1. Templates load & cross-validate ----------------------------------------
+
+
+def test_templates_load_and_cross_validate(registry_and_generators):
+    _, generators = registry_and_generators
+
+    assert CORPUS_ID in generators
+    gen = generators[CORPUS_ID]
+    assert gen.transformation == CORPUS_TRANSFORMATION
+    assert gen.applies_to == ("profile:claude-plugin",)
+    assert gen.output_paths == (CORPUS_OUTPUT_PATH,)
+    assert gen.source_paths == (CORPUS_TEMPLATE_PATH,)
+    assert gen.validation.kind == "none"
+
+
+# 2. audit → template-drift → proposal --------------------------------------
+
+
+def test_audit_classifies_template_drift_and_returns_proposal(
+    registry_and_generators,
+):
+    _, _ = registry_and_generators
+    manifest = {"bindings": [_binding()]}
+
+    snapshot = {
+        SOURCE: {
+            BRANCH: {
+                "head": "headsha",
+                "trees": {CORPUS_TEMPLATE_PATH: "tree-B"},
+                "blobs": {CORPUS_OUTPUT_PATH: "blob-A"},
+            }
+        }
+    }
+
+    report = generated_artifacts.audit(manifest, snapshot)
+
+    assert len(report.bindings) == 1
+    result = report.bindings[0]
+    assert result.state == "template-drift"
+    assert result.proposal is not None
+    assert result.proposal.new_tree == "tree-B"
+    assert result.proposal.expected_tree == "tree-A"
+    assert report.findings == []
+
+
+# 3. audit → local-customization → no proposal ------------------------------
+
+
+def test_audit_classifies_local_customization_without_proposal(
+    registry_and_generators,
+):
+    _, _ = registry_and_generators
+    manifest = {"bindings": [_binding()]}
+
+    snapshot = {
+        SOURCE: {
+            BRANCH: {
+                "head": "headsha",
+                "trees": {CORPUS_TEMPLATE_PATH: "tree-A"},
+                "blobs": {CORPUS_OUTPUT_PATH: "blob-B"},
+            }
+        }
+    }
+
+    report = generated_artifacts.audit(manifest, snapshot)
+
+    assert len(report.bindings) == 1
+    result = report.bindings[0]
+    assert result.state == "local-customization"
+    assert result.proposal is None
+    assert any(f.kind == "local_customization" for f in report.findings)
+
+
+# 4. dispatch builds a valid F6 proposal ------------------------------------
+
+
+def test_dispatch_builds_valid_proposal_for_corpus_overlay(
+    registry_and_generators,
+):
+    _, generators = registry_and_generators
+    gen = generators[CORPUS_ID]
+
+    binding = {
+        "id": "corpus-navigate-skill",
+        "source": SOURCE,
+        "branch": BRANCH,
+        "files": [{"path": CORPUS_OUTPUT_PATH}],
+    }
+    snapshot = {SOURCE: {BRANCH: {"head": "headsha"}}}
+
+    proposal = generator_dispatch.dispatch(gen, binding, snapshot, _actor())
+
+    assert isinstance(proposal, mutation_plan.Proposal)
+    assert proposal.id == f"generate-{CORPUS_ID}-corpus-navigate-skill"
+    assert proposal.selection == (SOURCE,)
+    assert proposal.expected_shas == {SOURCE: "headsha"}
+    assert proposal.transformation == CORPUS_TRANSFORMATION
+    assert proposal.mutation_policy == "propose"
+    assert proposal.actor.gh_login == "octocat"
+
+
+# 5. output-allowlist enforcement -------------------------------------------
+
+
+def test_dispatch_rejects_binding_file_outside_allowlist(registry_and_generators):
+    _, generators = registry_and_generators
+    gen = generators[CORPUS_ID]
+
+    binding = {
+        "id": "corpus-navigate-skill",
+        "source": SOURCE,
+        "branch": BRANCH,
+        "files": [{"path": "README.md"}],
+    }
+    snapshot = {SOURCE: {BRANCH: {"head": "headsha"}}}
+
+    with pytest.raises(mutation_plan.MutationPlanError) as exc:
+        generator_dispatch.dispatch(gen, binding, snapshot, _actor())
+
+    assert "README.md" in str(exc.value)
+    assert "allowlist" in str(exc.value).lower() or "output_paths" in str(exc.value)

--- a/lib/pulse/scripts/tests/test_dogfood_isolation.py
+++ b/lib/pulse/scripts/tests/test_dogfood_isolation.py
@@ -1,0 +1,136 @@
+"""Isolation proof: the neutral fleet path is provably overlay-independent.
+
+Two guarantees, per the F9 plan (Task 5):
+
+(a) No neutral engine module imports a dogfood-overlay module at module load
+    time — importing the neutral path never pulls an overlay into the process.
+    Verified by walking each neutral module's module-level import statements
+    with `ast` (lazy imports inside functions are intentionally allowed: they
+    execute only when an overlay is explicitly enabled).
+
+(b) The neutral acceptance tests pass with the overlay fixture directories
+    absent — proving no neutral test depends on an overlay fixture. Verified by
+    copying the package into a tmp tree minus `tests/fixtures/overlays/` and
+    running the neutral acceptance suite there.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+# Neutral engine modules: the fleet path that must never know an overlay exists.
+# `adapters/__init__.py` is included deliberately — it is the shared registration
+# surface, and importing it (to get `register_universal_adapters`) must NOT drag
+# in the overlay adapters. Its `register_claude_adapters` entry point may import
+# the overlay LAZILY (inside the function body), which this module-level scan
+# does not see.
+NEUTRAL_MODULES = (
+    "lib/pulse/scripts/profile_dispatch.py",
+    "lib/pulse/scripts/check_adapters.py",
+    "lib/pulse/scripts/adapters/generic.py",
+    "lib/pulse/scripts/adapters/__init__.py",
+    "lib/pulse/scripts/evaluate_checks.py",
+    "lib/pulse/scripts/generated_artifacts.py",
+    "lib/pulse/scripts/generator_dispatch.py",
+)
+
+# The dogfood-overlay modules introduced by F9. None of the neutral modules
+# above may import any of these at module level.
+OVERLAY_MODULES = (
+    "lib.pulse.scripts.adapters.claude_plugin",
+    "lib.pulse.scripts.marketplace_sync",
+    "lib.pulse.scripts.repo_claims",
+)
+
+# Neutral acceptance tests that must pass with overlay fixtures absent. Each of
+# these builds its own fixtures inline or reads only neutral fixture dirs
+# (fixtures/profiles, fixtures/checks) — never fixtures/overlays.
+NEUTRAL_ACCEPTANCE_TESTS = (
+    "lib/pulse/scripts/tests/test_profile_acceptance.py",
+    "lib/pulse/scripts/tests/test_fleet_healthcheck_acceptance.py",
+    "lib/pulse/scripts/tests/test_generic_adapters.py",
+    "lib/pulse/scripts/tests/test_healthcheck_dispatch.py",
+)
+
+
+def _module_level_imports(source: str) -> set[str]:
+    """Return the dotted names imported at MODULE LEVEL by `source`.
+
+    Only statements in the module body are inspected; imports nested inside
+    functions/classes (lazy imports) are excluded on purpose. For an
+    ``ImportFrom`` both the source module and each ``module.name`` are recorded
+    so `from a.b import c` surfaces as both ``a.b`` and ``a.b.c``.
+    """
+    tree = ast.parse(source)
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:  # relative import — not used for overlays here
+                continue
+            module = node.module or ""
+            if module:
+                names.add(module)
+            for alias in node.names:
+                names.add(f"{module}.{alias.name}" if module else alias.name)
+    return names
+
+
+def _imports_any_overlay(imported: set[str]) -> list[str]:
+    hits: list[str] = []
+    for name in imported:
+        for overlay in OVERLAY_MODULES:
+            if name == overlay or name.startswith(overlay + "."):
+                hits.append(name)
+    return hits
+
+
+@pytest.mark.parametrize("module_path", NEUTRAL_MODULES)
+def test_neutral_module_does_not_import_overlay_at_module_level(module_path):
+    source = (REPO_ROOT / module_path).read_text()
+    imported = _module_level_imports(source)
+    leaked = _imports_any_overlay(imported)
+    assert leaked == [], (
+        f"{module_path} imports overlay module(s) at module level: {leaked}. "
+        "Neutral modules must stay overlay-independent; move the import into a "
+        "lazily-invoked function if it is truly needed."
+    )
+
+
+def test_neutral_acceptance_passes_without_overlay_fixtures(tmp_path):
+    # Copy the package into an isolated tree, then delete the overlay fixtures.
+    dst = tmp_path / "tree"
+    shutil.copytree(
+        REPO_ROOT / "lib",
+        dst / "lib",
+        ignore=shutil.ignore_patterns("__pycache__"),
+    )
+    overlays = dst / "lib/pulse/scripts/tests/fixtures/overlays"
+    assert overlays.is_dir(), "overlay fixtures must exist before removal"
+    shutil.rmtree(overlays)
+
+    env = {**os.environ, "PYTHONPATH": str(dst)}
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", *NEUTRAL_ACCEPTANCE_TESTS, "-q"],
+        cwd=dst,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        "neutral acceptance suite failed with overlay fixtures absent:\n"
+        + result.stdout
+        + result.stderr
+    )

--- a/lib/pulse/scripts/tests/test_generated_artifact_skill.py
+++ b/lib/pulse/scripts/tests/test_generated_artifact_skill.py
@@ -20,7 +20,8 @@ def read_workflow() -> str:
 def test_neutrality_forbidden_strings_absent():
     for path in (GENERATED_ARTIFACTS, GENERATOR_DISPATCH, SKILL, WORKFLOW):
         content = path.read_text().lower()
-        for forbidden in ("claude", "corpus", "plugin manifest", "skill.md"):
+        for forbidden in ("claude", "corpus", "plugin manifest", "skill.md",
+                          "hiivmind.corpus-navigate-skill"):
             assert forbidden not in content, f"{forbidden!r} found in {path}"
 
 

--- a/lib/pulse/scripts/tests/test_marketplace_sync.py
+++ b/lib/pulse/scripts/tests/test_marketplace_sync.py
@@ -1,0 +1,531 @@
+"""Tests for the marketplace entry version drift decision + proposal builder.
+
+Pure module (`lib.pulse.scripts.marketplace_sync`) is the unit under test.
+The single integration test reuses the `test_pen_orchestrator` harness
+idiom (re-implemented locally to keep the test file self-contained, the
+same pattern `test_plan_sync.py` already uses) to prove the marketplace
+proposal is guard-compatible end to end — the expected-SHA guard blocks
+the run when the marketplace repo's HEAD has moved past the proposal's
+recorded `expected_shas`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lib.pulse.scripts import (
+    marketplace_sync,
+    mutation_plan,
+    nave_adapter,
+    pen_orchestrator,
+)
+
+
+# Stub nave_adapter.probe: it issues several `--help`/`--version` calls of
+# its own (see nave_adapter.probe docstring) — noise unrelated to what this
+# test's QueuedRunner sequence is checking. Mirrors the autouse fixture
+# `test_pen_orchestrator.py` uses; the test that exercises the guard
+# already has a queue sized for the *post-probe* pen state machine.
+@pytest.fixture(autouse=True)
+def _stub_probe(monkeypatch):
+    def fake_probe(_runner):
+        return {"available": True, "version": "0.0.8", "protocol": 1}
+
+    monkeypatch.setattr(pen_orchestrator.nave_adapter, "probe", fake_probe)
+
+
+# Paths -----------------------------------------------------------------
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]  # tests/ -> scripts/ -> pulse/ -> lib/ -> repo root
+TEMPLATE_PATH = REPO_ROOT / "templates" / "transformations.yaml.template"
+
+
+# Fixtures --------------------------------------------------------------
+
+
+PLUGIN_ID = "hiivmind-pulse-gh"
+PLUGIN_REPO = "hiivmind/hiivmind-pulse-gh"
+MARKETPLACE_REPO = "hiivmind/claude-marketplace"
+MARKETPLACE_FILE = ".claude-plugin/marketplace.json"
+ACTOR = {"gh_login": "octocat", "machine": "laptop", "mode": "interactive"}
+
+
+def binding(
+    plugin_id: str = PLUGIN_ID,
+    marketplace_repo: str = MARKETPLACE_REPO,
+    marketplace_file: str = MARKETPLACE_FILE,
+):
+    return {
+        "plugin_id": plugin_id,
+        "repo": PLUGIN_REPO,
+        "marketplace_repo": marketplace_repo,
+        "marketplace_file": marketplace_file,
+    }
+
+
+def marketplace_doc(plugin_id: str, version):
+    return {
+        "name": "hiivmind",
+        "owner": {"name": "Discrete Data Systems"},
+        "repository": "https://github.com/hiivmind/hiivmind",
+        "metadata": {"version": "1.0.0"},
+        "plugins": [
+            {
+                "name": plugin_id,
+                "source": "./",
+                "description": "...",
+                "version": version,
+                "keywords": ["github"],
+            }
+        ],
+    }
+
+
+# --- compare(): release-selection / exclusion logic ---------------------
+
+
+def test_compare_drift_when_recorded_version_is_older_than_newest_stable():
+    b = binding()
+    releases = [
+        {"tagName": "v2.0.0", "isPrerelease": False, "isDraft": False},
+        {"tagName": "v1.5.0", "isPrerelease": False, "isDraft": False},
+    ]
+    doc = marketplace_doc(PLUGIN_ID, "1.5.0")
+
+    drift = marketplace_sync.compare(b, releases, doc)
+
+    assert drift.outcome == "drift"
+    assert drift.plugin_id == PLUGIN_ID
+    assert drift.marketplace_repo == MARKETPLACE_REPO
+    assert drift.marketplace_file == MARKETPLACE_FILE
+    assert drift.current_version == "1.5.0"
+    assert drift.target_version == "v2.0.0"
+
+
+def test_compare_excludes_prerelease_and_draft_releases():
+    """A newer prerelease/draft present but the newest STABLE is older → excluded correctly."""
+    b = binding()
+    releases = [
+        {"tagName": "v3.0.0-rc.1", "isPrerelease": True, "isDraft": False},
+        {"tagName": "v2.5.0-rc.2", "isPrerelease": True, "isDraft": False},
+        {"tagName": "v2.0.0", "isPrerelease": False, "isDraft": False},
+        {"tagName": "v1.5.0", "isPrerelease": False, "isDraft": False},
+    ]
+    doc = marketplace_doc(PLUGIN_ID, "1.5.0")
+
+    drift = marketplace_sync.compare(b, releases, doc)
+
+    assert drift.outcome == "drift"
+    assert drift.current_version == "1.5.0"
+    assert drift.target_version == "v2.0.0"
+
+
+def test_compare_excludes_draft_only_release_when_no_stable_present():
+    b = binding()
+    releases = [
+        {"tagName": "v2.0.0", "isPrerelease": False, "isDraft": True},
+        {"tagName": "v1.5.0", "isPrerelease": False, "isDraft": False},
+    ]
+    doc = marketplace_doc(PLUGIN_ID, "1.5.0")
+
+    drift = marketplace_sync.compare(b, releases, doc)
+
+    assert drift.outcome == "drift"
+    assert drift.target_version == "v1.5.0"
+
+
+def test_compare_skips_non_mapping_release_entries():
+    """A non-mapping entry (e.g. None, str) is silently skipped, not a failure."""
+    b = binding()
+    releases = [
+        None,
+        "garbage",
+        {"tagName": "v2.0.0", "isPrerelease": False, "isDraft": False},
+        {"tagName": "v1.5.0", "isPrerelease": False, "isDraft": False},
+    ]
+    doc = marketplace_doc(PLUGIN_ID, "1.5.0")
+
+    drift = marketplace_sync.compare(b, releases, doc)
+
+    assert drift.target_version == "v2.0.0"
+
+
+def test_compare_treats_missing_or_non_bool_flags_as_excluded_defensively():
+    """Defensive: a missing/non-bool `isPrerelease`/`isDraft` is treated as
+    excluded. Only an explicit `False` lets a release through as a stable
+    candidate. A release whose flags are `None` (the most common "unknown"
+    shape) must NOT silently become the newest stable release."""
+    b = binding()
+    releases = [
+        # isPrerelease=None — treated as excluded (defensive against
+        # misrelease of a release that lacks the flag).
+        {"tagName": "v2.0.0", "isPrerelease": None, "isDraft": False},
+        {"tagName": "v1.5.0", "isPrerelease": False, "isDraft": False},
+    ]
+    doc = marketplace_doc(PLUGIN_ID, "v1.5.0")
+
+    drift = marketplace_sync.compare(b, releases, doc)
+
+    assert drift.outcome == "in_sync"
+    assert drift.target_version == "v1.5.0"
+
+
+def test_compare_treats_non_bool_truthy_flags_as_excluded():
+    """Defensive: a non-bool truthy value (e.g. the string "true") is also
+    treated as excluded — only the literal `False` is "not excluded"."""
+    b = binding()
+    releases = [
+        {"tagName": "v2.0.0", "isPrerelease": "true", "isDraft": False},
+        {"tagName": "v1.5.0", "isPrerelease": False, "isDraft": False},
+    ]
+    doc = marketplace_doc(PLUGIN_ID, "v1.5.0")
+
+    drift = marketplace_sync.compare(b, releases, doc)
+
+    assert drift.target_version == "v1.5.0"
+
+
+# --- compare(): not_applicable / missing_entry / unknown / in_sync ------
+
+
+def test_compare_binding_none_returns_not_applicable():
+    drift = marketplace_sync.compare(None, [], {})
+
+    assert drift.outcome == "not_applicable"
+    assert drift.current_version is None
+    assert drift.target_version is None
+
+
+def test_compare_missing_entry_when_plugin_id_not_in_plugins():
+    b = binding(plugin_id="not-registered")
+    releases = [
+        {"tagName": "v2.0.0", "isPrerelease": False, "isDraft": False},
+    ]
+    doc = marketplace_doc(PLUGIN_ID, "1.5.0")
+
+    drift = marketplace_sync.compare(b, releases, doc)
+
+    assert drift.outcome == "missing_entry"
+    assert drift.current_version is None
+    assert drift.target_version == "v2.0.0"
+
+
+def test_compare_unknown_when_no_stable_release_present():
+    b = binding()
+    releases = [
+        {"tagName": "v3.0.0-rc.1", "isPrerelease": True, "isDraft": False},
+        {"tagName": "v2.5.0-rc.1", "isPrerelease": True, "isDraft": True},
+    ]
+    doc = marketplace_doc(PLUGIN_ID, "1.5.0")
+
+    drift = marketplace_sync.compare(b, releases, doc)
+
+    assert drift.outcome == "unknown"
+    assert drift.current_version is None
+    assert drift.target_version is None
+    assert drift.reason is not None
+    assert "stable" in drift.reason
+
+
+def test_compare_unknown_when_marketplace_doc_is_not_a_mapping():
+    b = binding()
+    releases = [
+        {"tagName": "v2.0.0", "isPrerelease": False, "isDraft": False},
+    ]
+
+    drift = marketplace_sync.compare(b, releases, [])
+
+    assert drift.outcome == "unknown"
+    assert drift.current_version is None
+    # The newest stable tag is still observed (the doc is the unparseable side).
+    assert drift.target_version == "v2.0.0"
+    assert drift.reason is not None
+
+
+def test_compare_unknown_when_marketplace_doc_plugins_not_a_list():
+    b = binding()
+    releases = [
+        {"tagName": "v2.0.0", "isPrerelease": False, "isDraft": False},
+    ]
+    doc = {"name": "hiivmind", "plugins": "not a list"}
+
+    drift = marketplace_sync.compare(b, releases, doc)
+
+    assert drift.outcome == "unknown"
+    assert drift.reason is not None
+
+
+def test_compare_in_sync_when_recorded_equals_newest_stable():
+    b = binding()
+    releases = [
+        {"tagName": "v2.0.0", "isPrerelease": False, "isDraft": False},
+        {"tagName": "v1.5.0", "isPrerelease": False, "isDraft": False},
+    ]
+    doc = marketplace_doc(PLUGIN_ID, "v2.0.0")
+
+    drift = marketplace_sync.compare(b, releases, doc)
+
+    assert drift.outcome == "in_sync"
+    assert drift.current_version == "v2.0.0"
+    assert drift.target_version == "v2.0.0"
+
+
+# --- build_marketplace_proposal ----------------------------------------
+
+
+def _drift_drift():
+    return marketplace_sync.MarketplaceDrift(
+        outcome="drift",
+        plugin_id=PLUGIN_ID,
+        marketplace_repo=MARKETPLACE_REPO,
+        marketplace_file=MARKETPLACE_FILE,
+        current_version="1.5.0",
+        target_version="v2.0.0",
+    )
+
+
+def _drift_missing():
+    return marketplace_sync.MarketplaceDrift(
+        outcome="missing_entry",
+        plugin_id=PLUGIN_ID,
+        marketplace_repo=MARKETPLACE_REPO,
+        marketplace_file=MARKETPLACE_FILE,
+        current_version=None,
+        target_version="v2.0.0",
+    )
+
+
+def test_build_marketplace_proposal_for_drift_outcome_builds_expected_sha_guarded_proposal():
+    drift = _drift_drift()
+    head_sha = "deadbeef0001"
+
+    proposal = marketplace_sync.build_marketplace_proposal(drift, head_sha, ACTOR)
+
+    assert proposal.id == f"marketplace-{PLUGIN_ID}"
+    assert proposal.selection == (MARKETPLACE_REPO,)
+    assert proposal.transformation == "marketplace-entry-update"
+    assert proposal.expected_shas == {MARKETPLACE_REPO: head_sha}
+    assert proposal.mutation_policy == "propose"
+    assert proposal.actor.gh_login == "octocat"
+    assert proposal.actor.mode == "interactive"
+
+
+def test_build_marketplace_proposal_for_missing_entry_outcome_builds_proposal():
+    proposal = marketplace_sync.build_marketplace_proposal(
+        _drift_missing(), "cafef00d", ACTOR
+    )
+
+    assert proposal.selection == (MARKETPLACE_REPO,)
+    assert proposal.transformation == "marketplace-entry-update"
+    assert proposal.expected_shas == {MARKETPLACE_REPO: "cafef00d"}
+
+
+def test_build_marketplace_proposal_raises_for_in_sync_outcome():
+    drift = marketplace_sync.MarketplaceDrift(
+        outcome="in_sync",
+        plugin_id=PLUGIN_ID,
+        marketplace_repo=MARKETPLACE_REPO,
+        marketplace_file=MARKETPLACE_FILE,
+        current_version="v2.0.0",
+        target_version="v2.0.0",
+    )
+    with pytest.raises(ValueError, match="drift or missing_entry"):
+        marketplace_sync.build_marketplace_proposal(drift, "deadbeef", ACTOR)
+
+
+def test_build_marketplace_proposal_raises_for_not_applicable_outcome():
+    drift = marketplace_sync.MarketplaceDrift(
+        outcome="not_applicable",
+        plugin_id=PLUGIN_ID,
+        marketplace_repo=MARKETPLACE_REPO,
+        marketplace_file=MARKETPLACE_FILE,
+        current_version=None,
+        target_version=None,
+    )
+    with pytest.raises(ValueError):
+        marketplace_sync.build_marketplace_proposal(drift, "deadbeef", ACTOR)
+
+
+def test_build_marketplace_proposal_raises_for_unknown_outcome():
+    drift = marketplace_sync.MarketplaceDrift(
+        outcome="unknown",
+        plugin_id=PLUGIN_ID,
+        marketplace_repo=MARKETPLACE_REPO,
+        marketplace_file=MARKETPLACE_FILE,
+        current_version=None,
+        target_version=None,
+    )
+    with pytest.raises(ValueError):
+        marketplace_sync.build_marketplace_proposal(drift, "deadbeef", ACTOR)
+
+
+# --- registry gate: transformation loads + scheduled-mode rejection -----
+
+
+def test_registry_loads_marketplace_entry_update_from_template():
+    registry = mutation_plan.load_registry(TEMPLATE_PATH)
+
+    entry = registry.get("marketplace-entry-update")
+
+    assert entry.id == "marketplace-entry-update"
+    assert entry.allow_scheduled is False
+    assert entry.validation.kind == "none"
+    # Profile-gating mirrors plan-sync-doc-patch's `always`/`profile:claude-plugin`
+    # contract. marketplace-entry-update is profile:claude-plugin per the brief.
+    assert "profile:claude-plugin" in entry.applies_to
+
+
+def test_build_marketplace_proposal_with_registry_succeeds_for_interactive_actor():
+    registry = mutation_plan.load_registry(TEMPLATE_PATH)
+
+    proposal = marketplace_sync.build_marketplace_proposal(
+        _drift_drift(), "deadbeef", ACTOR, registry=registry
+    )
+
+    assert proposal.transformation == "marketplace-entry-update"
+
+
+def test_build_marketplace_proposal_with_registry_rejects_scheduled_actor():
+    registry = mutation_plan.load_registry(TEMPLATE_PATH)
+    scheduled_actor = dict(ACTOR, mode="scheduled")
+
+    with pytest.raises(
+        mutation_plan.MutationPlanError, match="not allowed in scheduled mode"
+    ):
+        marketplace_sync.build_marketplace_proposal(
+            _drift_drift(), "deadbeef", scheduled_actor, registry=registry
+        )
+
+
+def test_validate_proposal_rejects_scheduled_for_marketplace_entry_update():
+    """A scheduled actor's proposal built without a registry must still be rejected
+    by `validate_proposal` against the loaded registry."""
+    registry = mutation_plan.load_registry(TEMPLATE_PATH)
+    scheduled_actor = dict(ACTOR, mode="scheduled")
+
+    proposal = marketplace_sync.build_marketplace_proposal(
+        _drift_drift(), "deadbeef", scheduled_actor
+    )
+
+    with pytest.raises(
+        mutation_plan.MutationPlanError, match="not allowed in scheduled mode"
+    ):
+        mutation_plan.validate_proposal(proposal, registry)
+
+
+# --- one guard integration test ----------------------------------------
+
+
+class _QueuedRunner:
+    """Mirror of `test_pen_orchestrator.QueuedRunner`: returns a distinct
+    Completed per call, in order."""
+
+    def __init__(self, results):
+        self.calls = []
+        self._results = list(results)
+
+    def run(self, args):
+        self.calls.append(list(args))
+        return self._results.pop(0)
+
+
+def _pen_show_completed(repos):
+    payload = {
+        "name": "nave/marketplace-audit",
+        "created_at": "2026-07-22T00:00:00Z",
+        "branch": "nave/marketplace-audit",
+        "filter": {"terms": []},
+        "repos": [
+            {
+                "owner": o,
+                "name": n,
+                "default_branch": "main",
+                "clone_url": "x",
+                "synced_at": "2026-07-22T00:00:00Z",
+            }
+            for o, n in repos
+        ],
+        "ops": [],
+    }
+    return nave_adapter.Completed(0, json.dumps(payload), "")
+
+
+def _pen_status_completed(entries):
+    return nave_adapter.Completed(0, json.dumps(entries), "")
+
+
+def _repo_state(owner, name, **overrides):
+    state = {
+        "owner": owner,
+        "repo": name,
+        "working_tree": "clean",
+        "freshness": "fresh",
+        "run_state": "not-run",
+        "divergence": "up-to-date",
+        "ahead": 0,
+        "behind": 0,
+    }
+    state.update(overrides)
+    return state
+
+
+def _marketplace_repos():
+    return [(MARKETPLACE_REPO.split("/")[0], MARKETPLACE_REPO.split("/")[1])]
+
+
+def test_marketplace_drift_proposal_is_blocked_by_stale_head_sha():
+    """End-to-end guard integration: a marketplace drift proposal whose
+    `expected_shas` no longer matches the marketplace repo's current HEAD
+    is blocked before any exec by the F6 expected-SHA guard."""
+    import json as _json  # noqa: F401  # used by helper functions
+
+    from lib.pulse.scripts.pen_orchestrator import nave_adapter as _na
+
+    registry = mutation_plan.load_registry(TEMPLATE_PATH)
+
+    drift = marketplace_sync.MarketplaceDrift(
+        outcome="drift",
+        plugin_id=PLUGIN_ID,
+        marketplace_repo=MARKETPLACE_REPO,
+        marketplace_file=MARKETPLACE_FILE,
+        current_version="1.5.0",
+        target_version="v2.0.0",
+    )
+    head_sha_at_proposal = "expected_sha_xxx"
+    proposal = marketplace_sync.build_marketplace_proposal(
+        drift, head_sha_at_proposal, ACTOR, registry=registry
+    )
+    entry = registry.get("marketplace-entry-update")
+
+    plan = pen_orchestrator.PenPlan(
+        proposal=proposal,
+        entry=entry,
+        pen_name="nave/marketplace-audit",
+        query=nave_adapter.PenQuery(terms=[]),
+    )
+
+    repos = _marketplace_repos()
+    runner = _QueuedRunner(
+        [
+            nave_adapter.Completed(0, "created\n", ""),
+            _pen_show_completed(repos),
+            _pen_status_completed([_repo_state(*repos[0])]),
+        ]
+    )
+
+    def read_repo_head(_repo):
+        # Marketplace repo's HEAD has moved past the proposal's recorded SHA.
+        return "different_current_sha_yyy"
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=read_repo_head)
+
+    assert result.state == "blocked"
+    assert result.repo_outcomes == {MARKETPLACE_REPO: "blocked"}
+    assert "expected SHA" in result.reason
+    # Exec must never be reached: only create (2 calls) + status (1 call).
+    assert len(runner.calls) == 3
+    assert not any("exec" in call for call in runner.calls)

--- a/lib/pulse/scripts/tests/test_repo_claims.py
+++ b/lib/pulse/scripts/tests/test_repo_claims.py
@@ -483,10 +483,31 @@ def test_validate_inferred_findings_claim_kinds_contains_required_keys():
 
 
 def test_module_does_not_import_claude_plugin():
-    """One-way dependency: repo_claims never imports claude_plugin."""
-    import sys
+    """One-way dependency: repo_claims never imports claude_plugin.
 
-    module = sys.modules[repo_claims.__name__]
-    for name in sys.modules:
-        if name.endswith("claude_plugin"):
-            assert module is not sys.modules[name]
+    A real static scan of repo_claims' MODULE-LEVEL imports (not a module-object
+    identity check, which would pass whether or not the import existed). If a
+    maintainer adds a top-level `from ...adapters import claude_plugin`, this
+    fails loudly.
+    """
+    import ast
+    from pathlib import Path
+
+    forbidden = "lib.pulse.scripts.adapters.claude_plugin"
+    tree = ast.parse(Path(repo_claims.__file__).read_text())
+    imported: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name)
+        elif isinstance(node, ast.ImportFrom) and not node.level:
+            module = node.module or ""
+            if module:
+                imported.add(module)
+            for alias in node.names:
+                imported.add(f"{module}.{alias.name}" if module else alias.name)
+
+    leaked = [n for n in imported if n == forbidden or n.startswith(forbidden + ".")]
+    assert leaked == [], (
+        f"repo_claims imports claude_plugin at module level: {leaked}"
+    )

--- a/lib/pulse/scripts/tests/test_repo_claims.py
+++ b/lib/pulse/scripts/tests/test_repo_claims.py
@@ -1,0 +1,492 @@
+"""Tests for the pure claim-currency helper in :mod:`lib.pulse.scripts.repo_claims`.
+
+The module is pure: it does not read the filesystem, run subprocesses, or
+import :mod:`claude_plugin` (one-way dependency). ``facts`` and
+``check_claims`` are deterministic and trust no inferred input. Inference
+is the caller's job; ``validate_inferred_findings`` is the schema guard.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import pytest
+
+from lib.pulse.scripts import repo_claims
+from lib.pulse.scripts.repo_claims import (
+    CLAIM_KINDS,
+    ClaimFinding,
+    InferenceValidationError,
+    RepoFacts,
+    check_claims,
+    facts,
+    validate_inferred_findings,
+)
+
+
+def _evidence(
+    files: list[str] | None = None,
+    file_contents: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    evidence: dict[str, Any] = {}
+    if files is not None:
+        evidence["files"] = files
+    if file_contents is not None:
+        evidence["file_contents"] = dict(file_contents)
+    return evidence
+
+
+# --- facts() --------------------------------------------------------------
+
+
+def test_facts_extracts_skill_paths():
+    evidence = _evidence(
+        files=[
+            "skills/example/SKILL.md",
+            "skills/audit/SKILL.md",
+            "README.md",
+            "CLAUDE.md",
+        ]
+    )
+
+    result = facts(evidence)
+
+    assert result.skill_paths == frozenset(
+        {"skills/example/SKILL.md", "skills/audit/SKILL.md"}
+    )
+
+
+def test_facts_skill_paths_ignores_nested_or_non_skill_files():
+    evidence = _evidence(
+        files=[
+            "skills/example/SKILL.md",
+            "skills/team/sub/SKILL.md",
+            "skills/README.md",
+            "skills/SKILL.md",
+            "skills",
+        ]
+    )
+
+    result = facts(evidence)
+
+    assert result.skill_paths == frozenset({"skills/example/SKILL.md"})
+
+
+def test_facts_command_names_includes_only_md_files():
+    evidence = _evidence(
+        files=[
+            "commands/gh.md",
+            "commands/intent-mapping.yaml",
+            "commands/pulse.md",
+        ]
+    )
+
+    result = facts(evidence)
+
+    assert result.command_names == frozenset({"gh", "pulse"})
+
+
+def test_facts_command_names_ignores_nested_paths():
+    evidence = _evidence(
+        files=[
+            "commands/gh.md",
+            "commands/nested/extra.md",
+        ]
+    )
+
+    result = facts(evidence)
+
+    assert result.command_names == frozenset({"gh"})
+
+
+def test_facts_parses_plugin_manifest_mapping():
+    evidence = _evidence(
+        files=[".claude-plugin/plugin.json"],
+        file_contents={
+            ".claude-plugin/plugin.json": (
+                '{"name": "example-plugin", "version": "1.2.3"}'
+            )
+        },
+    )
+
+    result = facts(evidence)
+
+    assert result.manifest == {
+        "name": "example-plugin",
+        "version": "1.2.3",
+    }
+
+
+def test_facts_manifest_is_empty_mapping_when_absent():
+    result = facts(_evidence(files=["CLAUDE.md"]))
+
+    assert result.manifest == {}
+
+
+def test_facts_manifest_is_empty_mapping_when_invalid_json():
+    evidence = _evidence(
+        files=[".claude-plugin/plugin.json"],
+        file_contents={".claude-plugin/plugin.json": "{not valid json"},
+    )
+
+    result = facts(evidence)
+
+    assert result.manifest == {}
+
+
+def test_facts_manifest_is_empty_mapping_when_root_is_not_mapping():
+    evidence = _evidence(
+        files=[".claude-plugin/plugin.json"],
+        file_contents={".claude-plugin/plugin.json": "[1, 2, 3]"},
+    )
+
+    result = facts(evidence)
+
+    assert result.manifest == {}
+
+
+def test_facts_defensive_on_non_list_files():
+    result = facts({"files": "not a list"})
+
+    assert result == RepoFacts(
+        skill_paths=frozenset(),
+        command_names=frozenset(),
+        manifest={},
+    )
+
+
+def test_facts_defensive_on_files_with_non_string_entries():
+    result = facts({"files": ["CLAUDE.md", 42]})
+
+    assert result.skill_paths == frozenset()
+    assert result.command_names == frozenset()
+
+
+def test_facts_facts_returns_frozensets_and_immutable_manifest_dict():
+    result = facts(_evidence(files=["skills/example/SKILL.md", "commands/gh.md"]))
+
+    assert isinstance(result.skill_paths, frozenset)
+    assert isinstance(result.command_names, frozenset)
+    assert isinstance(result.manifest, dict)
+
+
+# --- check_claims() -------------------------------------------------------
+
+
+def test_check_claims_flags_missing_claimed_skill():
+    claude_md = "See skills/ghost/SKILL.md for the audit procedure."
+    current = RepoFacts(
+        skill_paths=frozenset({"skills/example/SKILL.md"}),
+        command_names=frozenset(),
+        manifest={},
+    )
+
+    findings = check_claims(claude_md, current)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.kind == "missing_claimed_skill"
+    assert finding.subject == "skills/ghost/SKILL.md"
+    assert finding.inferred is False
+
+
+def test_check_claims_flags_stale_command():
+    claude_md = "Run `commands/deprecated.md` to refresh the scorecard."
+    current = RepoFacts(
+        skill_paths=frozenset(),
+        command_names=frozenset({"gh"}),
+        manifest={},
+    )
+
+    findings = check_claims(claude_md, current)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.kind == "stale_command"
+    assert finding.subject == "deprecated"
+    assert finding.inferred is False
+
+
+def test_check_claims_always_flags_hooks_reference_as_unsupported_evidence():
+    claude_md = "The heartbeat lives at hooks/heartbeat.sh."
+    current = RepoFacts(
+        skill_paths=frozenset(),
+        command_names=frozenset(),
+        manifest={},
+    )
+
+    findings = check_claims(claude_md, current)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.kind == "unsupported_evidence"
+    assert finding.subject == "hooks/heartbeat.sh"
+    assert finding.inferred is False
+    assert "surfaced" in finding.detail
+
+
+def test_check_claims_surfaces_hooks_even_when_facts_are_full():
+    claude_md = "Audit via skills/audit/SKILL.md; heartbeat via hooks/heartbeat.sh."
+    current = RepoFacts(
+        skill_paths=frozenset({"skills/audit/SKILL.md"}),
+        command_names=frozenset({"gh"}),
+        manifest={},
+    )
+
+    findings = check_claims(claude_md, current)
+
+    assert [f.kind for f in findings] == ["unsupported_evidence"]
+
+
+def test_check_claims_returns_empty_when_every_reference_resolves():
+    claude_md = (
+        "Use skills/audit/SKILL.md and run commands/gh.md. "
+        "No hooks here."
+    )
+    current = RepoFacts(
+        skill_paths=frozenset({"skills/audit/SKILL.md"}),
+        command_names=frozenset({"gh"}),
+        manifest={},
+    )
+
+    assert check_claims(claude_md, current) == []
+
+
+def test_check_claims_all_deterministic_findings_carry_inferred_false():
+    claude_md = (
+        "Use skills/ghost/SKILL.md. "
+        "Run commands/deprecated.md. "
+        "Heartbeat at hooks/heartbeat.sh."
+    )
+    current = RepoFacts(
+        skill_paths=frozenset(),
+        command_names=frozenset(),
+        manifest={},
+    )
+
+    findings = check_claims(claude_md, current)
+
+    assert findings
+    for finding in findings:
+        assert finding.inferred is False
+
+
+def test_check_claims_dedupes_repeated_subjects():
+    claude_md = (
+        "First see skills/ghost/SKILL.md; later skills/ghost/SKILL.md again."
+    )
+    current = RepoFacts(
+        skill_paths=frozenset(),
+        command_names=frozenset(),
+        manifest={},
+    )
+
+    findings = check_claims(claude_md, current)
+
+    assert len(findings) == 1
+    assert findings[0].subject == "skills/ghost/SKILL.md"
+
+
+def test_check_claims_sort_order_is_deterministic():
+    claude_md = (
+        "skills/zebra/SKILL.md "
+        "commands/zzz.md "
+        "skills/alpha/SKILL.md "
+        "hooks/zzz.sh "
+    )
+    current = RepoFacts(
+        skill_paths=frozenset(),
+        command_names=frozenset(),
+        manifest={},
+    )
+
+    findings = check_claims(claude_md, current)
+
+    keys = [(f.kind, f.subject) for f in findings]
+    assert keys == sorted(keys)
+    assert keys == [
+        ("missing_claimed_skill", "skills/alpha/SKILL.md"),
+        ("missing_claimed_skill", "skills/zebra/SKILL.md"),
+        ("stale_command", "zzz"),
+        ("unsupported_evidence", "hooks/zzz.sh"),
+    ]
+
+
+def test_check_claims_recognizes_references_inside_backticks_and_links():
+    claude_md = (
+        "- [audit skill](skills/ghost/SKILL.md)\n"
+        "- `commands/legacy.md`\n"
+        "- hooks/heartbeat.sh\n"
+    )
+    current = RepoFacts(
+        skill_paths=frozenset(),
+        command_names=frozenset(),
+        manifest={},
+    )
+
+    findings = check_claims(claude_md, current)
+
+    kinds = {f.kind for f in findings}
+    subjects = {f.subject for f in findings}
+    assert kinds == {"missing_claimed_skill", "stale_command", "unsupported_evidence"}
+    assert "skills/ghost/SKILL.md" in subjects
+    assert "legacy" in subjects
+    assert "hooks/heartbeat.sh" in subjects
+
+
+# --- validate_inferred_findings() ----------------------------------------
+
+
+def test_validate_inferred_findings_accepts_well_formed_list():
+    raw = [
+        {
+            "kind": "missing_claimed_skill",
+            "subject": "skills/inferred/SKILL.md",
+            "detail": "the agent inferred this from prose",
+        },
+        {
+            "kind": "stale_command",
+            "subject": "old",
+            "detail": "removed last quarter",
+            "inferred": True,
+        },
+    ]
+
+    findings = validate_inferred_findings(raw)
+
+    assert len(findings) == 2
+    assert all(isinstance(f, ClaimFinding) for f in findings)
+    assert all(f.inferred is True for f in findings)
+    assert {f.kind for f in findings} == {"missing_claimed_skill", "stale_command"}
+
+
+def test_validate_inferred_findings_coerces_absent_inferred_to_true():
+    raw = [
+        {
+            "kind": "missing_claimed_skill",
+            "subject": "skills/x/SKILL.md",
+            "detail": "d",
+        }
+    ]
+
+    findings = validate_inferred_findings(raw)
+
+    assert findings[0].inferred is True
+
+
+def test_validate_inferred_findings_rejects_non_list():
+    with pytest.raises(InferenceValidationError):
+        validate_inferred_findings({"kind": "missing_claimed_skill"})
+
+
+def test_validate_inferred_findings_rejects_non_mapping_item():
+    with pytest.raises(InferenceValidationError):
+        validate_inferred_findings(
+            [
+                {
+                    "kind": "missing_claimed_skill",
+                    "subject": "skills/x/SKILL.md",
+                    "detail": "ok",
+                },
+                "not a mapping",
+            ]
+        )
+
+
+def test_validate_inferred_findings_rejects_bad_kind():
+    with pytest.raises(InferenceValidationError):
+        validate_inferred_findings(
+            [
+                {
+                    "kind": "not_a_kind",
+                    "subject": "skills/x/SKILL.md",
+                    "detail": "d",
+                }
+            ]
+        )
+
+
+def test_validate_inferred_findings_rejects_missing_kind():
+    with pytest.raises(InferenceValidationError):
+        validate_inferred_findings(
+            [
+                {
+                    "subject": "skills/x/SKILL.md",
+                    "detail": "d",
+                }
+            ]
+        )
+
+
+def test_validate_inferred_findings_rejects_empty_subject():
+    with pytest.raises(InferenceValidationError):
+        validate_inferred_findings(
+            [
+                {
+                    "kind": "missing_claimed_skill",
+                    "subject": "",
+                    "detail": "d",
+                }
+            ]
+        )
+
+
+def test_validate_inferred_findings_rejects_non_string_subject():
+    with pytest.raises(InferenceValidationError):
+        validate_inferred_findings(
+            [
+                {
+                    "kind": "missing_claimed_skill",
+                    "subject": 42,
+                    "detail": "d",
+                }
+            ]
+        )
+
+
+def test_validate_inferred_findings_rejects_non_string_detail():
+    with pytest.raises(InferenceValidationError):
+        validate_inferred_findings(
+            [
+                {
+                    "kind": "missing_claimed_skill",
+                    "subject": "skills/x/SKILL.md",
+                    "detail": 42,
+                }
+            ]
+        )
+
+
+def test_validate_inferred_findings_rejects_inferred_false():
+    with pytest.raises(InferenceValidationError):
+        validate_inferred_findings(
+            [
+                {
+                    "kind": "missing_claimed_skill",
+                    "subject": "skills/x/SKILL.md",
+                    "detail": "d",
+                    "inferred": False,
+                }
+            ]
+        )
+
+
+def test_validate_inferred_findings_accepts_empty_list():
+    assert validate_inferred_findings([]) == []
+
+
+def test_validate_inferred_findings_claim_kinds_contains_required_keys():
+    assert CLAIM_KINDS == frozenset(
+        {"missing_claimed_skill", "stale_command", "unsupported_evidence"}
+    )
+
+
+def test_module_does_not_import_claude_plugin():
+    """One-way dependency: repo_claims never imports claude_plugin."""
+    import sys
+
+    module = sys.modules[repo_claims.__name__]
+    for name in sys.modules:
+        if name.endswith("claude_plugin"):
+            assert module is not sys.modules[name]

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -19,6 +19,7 @@ FIXTURES = Path("lib/pulse/scripts/tests/fixtures")
 KINDS = [
     "status", "healthcheck", "refresh", "workflow-run", "fleet-membership",
     "impact", "repo-mutation", "generated-artifact", "plan-sync",
+    "marketplace-sync",
 ]
 
 
@@ -1005,6 +1006,87 @@ def test_plan_sync_requires_actionable_proposal_fields(tmp_path, field):
 
     assert result.returncode == 1
     assert f"missing required key: {field}" in result.stderr
+
+
+MARKETPLACE_SYNC_COUNTS = [
+    "bindings_scanned", "in_sync", "drift", "missing_entry", "unknown",
+    "not_applicable",
+]
+
+
+@pytest.mark.parametrize("field", MARKETPLACE_SYNC_COUNTS)
+def test_marketplace_sync_requires_count(tmp_path, field):
+    doc = yaml.safe_load((FIXTURES / "marketplace-sync-valid.yaml").read_text())
+    doc.pop(field)
+    path = tmp_path / "marketplace-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "marketplace-sync")
+
+    assert result.returncode == 1
+    assert f"missing required key: {field}" in result.stderr
+
+
+@pytest.mark.parametrize("field", MARKETPLACE_SYNC_COUNTS)
+def test_marketplace_sync_rejects_mistyped_count(tmp_path, field):
+    doc = yaml.safe_load((FIXTURES / "marketplace-sync-valid.yaml").read_text())
+    doc[field] = "not-an-int"
+    path = tmp_path / "marketplace-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "marketplace-sync")
+
+    assert result.returncode == 1
+    assert f"wrong type for {field}" in result.stderr
+
+
+def test_marketplace_sync_rejects_negative_count(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "marketplace-sync-valid.yaml").read_text())
+    doc["drift"] = -1
+    path = tmp_path / "marketplace-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "marketplace-sync")
+
+    assert result.returncode == 1
+    assert "drift must be a non-negative integer" in result.stderr
+
+
+@pytest.mark.parametrize("field", ["proposals", "proposed_actions"])
+def test_marketplace_sync_requires_actionable_proposal_fields(tmp_path, field):
+    doc = yaml.safe_load((FIXTURES / "marketplace-sync-valid.yaml").read_text())
+    doc.pop(field, None)
+    path = tmp_path / "marketplace-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "marketplace-sync")
+
+    assert result.returncode == 1
+    assert f"missing required key: {field}" in result.stderr
+
+
+def test_marketplace_sync_requires_string_proposed_actions(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "marketplace-sync-valid.yaml").read_text())
+    doc["proposed_actions"] = [42]
+    path = tmp_path / "marketplace-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "marketplace-sync")
+
+    assert result.returncode == 1
+    assert "proposed_actions[0] is not a string" in result.stderr
+
+
+def test_marketplace_sync_requires_proposal_id(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "marketplace-sync-valid.yaml").read_text())
+    doc["proposals"][0].pop("proposal_id")
+    path = tmp_path / "marketplace-sync.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "marketplace-sync")
+
+    assert result.returncode == 1
+    assert "proposals[0].proposal_id" in result.stderr
 
 
 def test_validate_sync_binding_accepts_valid_fixture():

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -5,7 +5,7 @@
 # ///
 """Validate a headless result file against the pulse result contract.
 
-Usage: validate_result.py <result.yaml> --kind status|healthcheck|refresh|workflow-run|fleet-membership|impact|repo-mutation
+Usage: validate_result.py <result.yaml> --kind status|healthcheck|refresh|workflow-run|fleet-membership|impact|repo-mutation|generated-artifact|plan-sync|marketplace-sync
 
 See lib/patterns/headless-contract.md for the schemas.
 
@@ -629,6 +629,25 @@ def validate(data, kind: str) -> list[str]:
             _require(proposal, "proposal_id", str, errors, ctx=ctx)
         _validate_string_list(data, "proposed_actions", errors)
 
+    elif kind == "marketplace-sync":
+        _require_nonnegative_integer(data, "bindings_scanned", errors)
+        _require_nonnegative_integer(data, "in_sync", errors)
+        _require_nonnegative_integer(data, "drift", errors)
+        _require_nonnegative_integer(data, "missing_entry", errors)
+        _require_nonnegative_integer(data, "unknown", errors)
+        _require_nonnegative_integer(data, "not_applicable", errors)
+        _validate_findings(data, errors)
+        proposals = _require(data, "proposals", list, errors)
+        for index, proposal in enumerate(proposals or []):
+            if not isinstance(proposal, dict):
+                _err(errors, f"proposals[{index}] is not a mapping")
+                continue
+            ctx = f"proposals[{index}]."
+            _require(proposal, "binding", str, errors, ctx=ctx)
+            _require(proposal, "transformation", str, errors, ctx=ctx)
+            _require(proposal, "proposal_id", str, errors, ctx=ctx)
+        _validate_string_list(data, "proposed_actions", errors)
+
     return errors
 
 
@@ -638,7 +657,8 @@ def main():
     parser.add_argument("--kind", required=True,
                         choices=["status", "healthcheck", "refresh", "workflow-run",
                                  "fleet-membership", "impact", "repo-mutation",
-                                 "generated-artifact", "plan-sync"])
+                                 "generated-artifact", "plan-sync",
+                                 "marketplace-sync"])
     args = parser.parse_args()
 
     path = Path(args.file)

--- a/skills/gh-healthcheck-headless/SKILL.md
+++ b/skills/gh-healthcheck-headless/SKILL.md
@@ -167,7 +167,24 @@ coverage: <DISPATCH_JSON.coverage>
 errors: <ERRORS>
 ```
 
-There is no top-level mixed-scorecard score, total, or grade. Validate:
+There is no top-level mixed-scorecard score, total, or grade.
+
+### Overlay scorecards (dogfood)
+
+Some scorecards are **dogfood overlays** — plugin-specific scorecards that extend
+the neutral set (e.g. `claude-plugin-v1`, which adds the `claude.plugin_manifest`,
+`claude.skills`, and `claude.context` checks) and apply only to repositories whose
+reviewed F1 profile opts in (`profile:claude-plugin`). Grades in
+`aggregate.by_scorecard` are already scorecard-specific, so an overlay scorecard's
+subtotal is presented under its own key exactly like any neutral scorecard and is
+**never merged into a neutral scorecard's `score`/`total` denominator or into fleet
+`coverage`**. When rendering or grouping this result, mark each overlay scorecard's
+subtotal `overlay: true` and keep it in its own block; a repository graded under an
+overlay scorecard contributes only to that overlay's subtotal. The overlay scorecard
+set is documented in `README.md` § Dogfood overlays; neutral fleet behavior is
+provably independent of the overlays (`lib/pulse/scripts/tests/test_dogfood_isolation.py`).
+
+Validate:
 
 ```bash
 uv run "${PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py" \

--- a/skills/gh-marketplace-sync-headless/SKILL.md
+++ b/skills/gh-marketplace-sync-headless/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: gh-marketplace-sync-headless
+description: >
+  Headless, generic marketplace entry version drift audit. Reads configured
+  marketplace bindings, compares each plugin repo's newest stable release to
+  the version recorded in the marketplace document, and records propose-only
+  F6 proposals for any drift or missing entry. Never applies. Writes a
+  marketplace-sync-result.yaml envelope. Zero prompts; explicit inputs only.
+  Use when a scheduler detects a pushed plugin release, or when an
+  orchestrator needs deterministic marketplace-sync proposals.
+---
+
+# Headless Marketplace Synchronization
+
+Reconcile configured marketplace entries with their bound plugin repos'
+newest stable release, recording propose-only F6 `marketplace-entry-update`
+proposals for any drift or missing entry. This orchestrator never writes a
+marketplace document, runs a pen, or applies a binding; F9 v1 is propose-only
+end to end.
+
+`{PLUGIN_ROOT}` is the directory containing `plugin.json`.
+
+## Inputs and outputs
+
+- `workspace_path` (required): absolute workspace root containing
+  `.hiivmind/github/`.
+- `repo` (optional): plugin repository full or short name; narrows the run
+  to a single configured binding. Defaults to every configured binding.
+- `result_path` (optional): workspace default when usable, otherwise
+  `./marketplace-sync-result.yaml`.
+- `mode` (optional): `interactive` or `scheduled`; defaults to `scheduled`.
+  `marketplace-entry-update` is `allow_scheduled: false`, so scheduled runs
+  are recorded as gated and never produce a runnable proposal.
+- `mutation_policy` (optional): `propose` or `apply`; defaults to `propose`.
+  V1 always records proposals. `apply` records the same deferred proposals
+  and the V1 limitation; it never grants this orchestrator authority to
+  mutate.
+- Result: `marketplace-sync-result.yaml` envelope (`lib/patterns/headless-contract.md`
+  § plan-sync-result.yaml shape, mirrored). No result-validator kind is
+  registered for `marketplace-sync` in F9 v1; the controller decides when
+  to validate and what to do with the envelope.
+
+## Contract
+
+- Zero prompts. Explicit inputs only. Every exit writes a result file.
+- The discovery source is `CONFIG_DIR/marketplace-sync.yaml`, whose
+  `bindings[]` records carry only the binding locator (`plugin_id`, `repo`,
+  `marketplace_repo`, `marketplace_file`). The marketplace document's parsed
+  JSON and the plugin repo's release list are the only decision inputs.
+- Only `marketplace_sync.compare` and `marketplace_sync.build_marketplace_proposal`
+  determine the drift evidence and the proposal. Do not re-create their
+  decision rules in this document.
+- A binding is `not_applicable` (no output emitted for the bound repo) when
+  the workspace config has no marketplace binding for the target plugin
+  repo. This is a global F9 v1 constraint: marketplace sync applies only
+  to repos with a configured binding. The result still records the run;
+  the proposal count is zero.
+- The discovery, comparison, and proposal paths remain separate. A
+  marketplace proposal is an F6 `marketplace-entry-update` proposal; never
+  combined with anything else; never applied here.
+- Under `mutation_policy: propose`, drift and missing-entry outcomes become
+  proposals and neither is applied. Under `mutation_policy: apply`, this V1
+  orchestrator still records the same proposals as deferred and records
+  the apply-mode limitation; it never grants this orchestrator authority
+  to mutate.
+- `unknown` outcomes (no stable release found, or unparseable marketplace
+  document) are recorded as findings with a `severity: medium` typed
+  `unknown_marketplace_doc` / `no_stable_release` finding. They never
+  count as synchronized and never produce a proposal.
+- Severity is deterministic and copied from `compare` evidence; no LLM
+  judgment is involved at this layer.
+
+## State
+
+Determine `RESULT_PATH` before validating the workspace: explicit
+`result_path`; otherwise the workspace default when `workspace_path` is
+non-empty and usable; otherwise `./marketplace-sync-result.yaml` in the
+current directory. This fallback must be available for every early ABORT
+to write its result.
+
+```text
+CONFIG_DIR         = {workspace_path}/.hiivmind/github
+SYNC_CONFIG        = CONFIG_DIR/marketplace-sync.yaml
+RESULT_PATH        = {explicit result_path, workspace default, or current-directory fallback}
+LOGIN              = unknown
+RUN_AT             = current UTC timestamp
+MODE               = {mode, default scheduled}
+MUTATION_POLICY    = {mutation_policy, default propose}
+BINDINGS           = []
+SNAPSHOT           = empty    # releases + marketplace_doc per binding
+FINDINGS           = []
+PROPOSALS          = []
+PROPOSED_ACTIONS   = []
+ERRORS             = []
+COUNTS             = {bindings_scanned: 0, in_sync: 0, drift: 0, missing_entry: 0, unknown: 0, not_applicable: 0}
+```
+
+## Phase 1: CONTEXT
+
+1. Missing `workspace_path` → ABORT `"missing required input: workspace_path"`.
+2. Missing `CONFIG_DIR/config.yaml` or its top-level `workspace` → ABORT
+   `"not a workspace root: {workspace_path}"`.
+3. Read the authoritative `.workspace.login` from `CONFIG_DIR/config.yaml`
+   into `LOGIN`.
+4. Ensure `*-result.yaml` is present in `CONFIG_DIR/.gitignore`.
+5. Read the marketplace-sync bindings list from `SYNC_CONFIG.bindings[]`
+   and validate each binding's locator (`plugin_id`, `repo`,
+   `marketplace_repo`, `marketplace_file`). Do not use configuration
+   `metadata` blocks as decision authority.
+6. When `repo` is present, resolve it against configured binding `repo`
+   values. An unresolvable value → ABORT `"unknown repo: {repo}"`.
+   Otherwise narrow `BINDINGS` to the matching records.
+7. A valid empty selected set is a successful no-op, not an ABORT.
+8. For each binding, if the binding locator is malformed (missing required
+   fields, non-string `repo` / `marketplace_repo`, etc.) → append a typed
+   `invalid_binding` finding (`severity: medium`) and skip the binding;
+   do not count it as scanned.
+
+**See:** `lib/patterns/config-parsing.md`,
+`lib/patterns/headless-contract.md`.
+
+## Phase 2: DISCOVER
+
+For each selected binding, fetch the remote evidence into `SNAPSHOT[binding]`.
+
+1. Resolve the binding's `marketplace_repo` and `marketplace_file`. Use the
+   `gh api` REST surface to read the file at the binding's default branch
+   HEAD; parse the response body as JSON. A fetch or parse failure → set
+   `marketplace_doc = None` and record a typed `unreadable_marketplace_file`
+   finding (`severity: medium`) on the binding. The discoverer never
+   fabricates a `marketplace_doc` from cached bytes.
+2. Resolve the binding's `repo` and run
+   `gh release list --json tagName,isPrerelease,isDraft --limit 100 --repo
+   {owner}/{name}` (or the equivalent `gh api` route) to fetch the release
+   list. A fetch failure → set `releases = []` and record a typed
+   `unreadable_release_list` finding (`severity: medium`) on the binding.
+3. Increment `bindings_scanned` once per binding whose `DISCOVER` step
+   returned (any outcome). Bindings with a malformed locator counted in
+   Phase 1 do not enter `DISCOVER` and do not increment `bindings_scanned`.
+
+**See:** `lib/references/api-routing.md`, `lib/patterns/id-resolution.md`.
+
+## Phase 3: COMPARE
+
+For each selected binding, call
+`marketplace_sync.compare(binding, releases, marketplace_doc)` and store
+the returned `MarketplaceDrift` keyed by binding.
+
+1. A `not_applicable` drift means the binding was not configured for the
+   target repo. Increment `not_applicable`; do not enter Phase 4.
+2. An `unknown` drift (no stable release, or unparseable
+   `marketplace_doc`) increments `unknown`; record a typed finding with
+   `drift.reason` in the finding's `detail`. Do not enter Phase 4.
+3. An `in_sync` drift increments `in_sync`; do not enter Phase 4.
+4. A `drift` or `missing_entry` drift increments the matching counter and
+   enters Phase 4.
+
+**See:** `lib/pulse/scripts/marketplace_sync.py`.
+
+## Phase 4: PROPOSE
+
+For every non-`in_sync` / non-`not_applicable` / non-`unknown` drift (so
+`drift` or `missing_entry` only):
+
+1. Resolve the binding's `marketplace_repo` HEAD SHA via
+   `gh api repos/{owner}/{repo}/commits/HEAD --jq .sha`. A failure →
+   append a typed `unreadable_head` finding (`severity: high`) and skip
+   the binding; do not build a proposal without an `expected_shas`
+   entry — the F6 guard requires it.
+2. Call
+   `marketplace_sync.build_marketplace_proposal(drift, head_sha, actor,
+   registry=...)`. The proposal selects `drift.marketplace_repo` and
+   carries `expected_shas={marketplace_repo: head_sha}`. `mutation_policy`
+   is always `propose` (this orchestrator is propose-only).
+3. Append a `PROPOSALS` record carrying `binding` (the binding's
+   `plugin_id`), `transformation` (`marketplace-entry-update`), and
+   `proposal_id` from the built proposal.
+4. Append a `PROPOSED_ACTIONS` record naming the proposal ID, the
+   marketplace repo, and the planned target version.
+5. Never call `gh api` to apply the patch, write the marketplace document,
+   or run a pen. With `mutation_policy: apply`, append a deferred-action
+   note naming the F9 v1 limitation instead of applying.
+
+**See:** `lib/pulse/scripts/marketplace_sync.py`,
+`lib/pulse/scripts/mutation_plan.py`,
+`lib/patterns/repository-mutations.md`.
+
+## Phase 5: RECORD
+
+Write `RESULT_PATH` with:
+
+```yaml
+contract_version: 1
+kind: marketplace-sync
+workspace: {LOGIN}
+run_at: "{RUN_AT}"
+actor: { gh_login: {gh api user login or unknown}, machine: {hostname}, mode: {MODE} }
+bindings_scanned: {COUNTS.bindings_scanned}
+in_sync: {COUNTS.in_sync}
+drift: {COUNTS.drift}
+missing_entry: {COUNTS.missing_entry}
+unknown: {COUNTS.unknown}
+not_applicable: {COUNTS.not_applicable}
+findings: {FINDINGS}
+proposals: {PROPOSALS}
+proposed_actions: {PROPOSED_ACTIONS}
+errors: {ERRORS}
+```
+
+This envelope is validated by the `marketplace-sync` kind in
+`lib/pulse/scripts/validate_result.py` (non-negative int counts +
+`findings` + `proposals[]` with `binding`/`transformation`/`proposal_id`
++ string `proposed_actions`). Skills MUST write the file on every exit
+(including early ABORT) so a missing file is never indistinguishable from
+a crashed run.
+
+Print one line:
+`marketplace-sync: bindings={bindings_scanned} in_sync={in_sync} drift={drift} missing={missing_entry} unknown={unknown} not_applicable={not_applicable}`.
+
+## ABORT semantics
+
+Every ABORT appends its reason to `ERRORS` and falls through to Phase 5
+with zeroed counts and empty findings, proposals, and proposed actions.
+If `CONFIG_DIR` is unusable, write to the explicit `result_path`,
+otherwise `marketplace-sync-result.yaml` in the current directory, and say
+so.
+
+## Related
+
+- `lib/pulse/scripts/marketplace_sync.py` — decision and proposal builder
+- `lib/pulse/scripts/mutation_plan.py` — F6 `Proposal` + registry
+- `lib/patterns/headless-contract.md` — envelope shape (plan-sync mirror)
+- `lib/patterns/repository-mutations.md` — F6 mutation vocabulary
+- `lib/patterns/config-parsing.md` — workspace + binding config reads

--- a/skills/gh-marketplace-sync-headless/SKILL.md
+++ b/skills/gh-marketplace-sync-headless/SKILL.md
@@ -36,9 +36,8 @@ end to end.
   and the V1 limitation; it never grants this orchestrator authority to
   mutate.
 - Result: `marketplace-sync-result.yaml` envelope (`lib/patterns/headless-contract.md`
-  § plan-sync-result.yaml shape, mirrored). No result-validator kind is
-  registered for `marketplace-sync` in F9 v1; the controller decides when
-  to validate and what to do with the envelope.
+  § plan-sync-result.yaml shape, mirrored). It is validated by the
+  `marketplace-sync` kind in `lib/pulse/scripts/validate_result.py` (see Phase 5).
 
 ## Contract
 
@@ -147,7 +146,11 @@ For each selected binding, call
 the returned `MarketplaceDrift` keyed by binding.
 
 1. A `not_applicable` drift means the binding was not configured for the
-   target repo. Increment `not_applicable`; do not enter Phase 4.
+   target repo (`compare` returns it only for a `None` binding). Phase 1
+   iterates configured bindings, so this arm is unreachable on the normal
+   path; the counter is retained for envelope symmetry and a future
+   single-binding/repo-filtered entry point. Increment `not_applicable`; do
+   not enter Phase 4.
 2. An `unknown` drift (no stable release, or unparseable
    `marketplace_doc`) increments `unknown`; record a typed finding with
    `drift.reason` in the finding's `detail`. Do not enter Phase 4.

--- a/templates/generators.yaml.template
+++ b/templates/generators.yaml.template
@@ -77,4 +77,21 @@
 #   validation:
 #     kind: none
 
-generators: {}
+generators:
+
+  # F9 v1 dogfood overlay: this is the ONE configured F9 dogfood generator,
+  # not a generic default. It applies only under `profile:claude-plugin` and
+  # is CONFIGURATION of the generic F7 engine — no engine code is
+  # corpus-aware. The argv is fixed in
+  # templates/transformations.yaml.template (`regenerate-corpus-navigate-skill`).
+  hiivmind.corpus-navigate-skill:
+    id: hiivmind.corpus-navigate-skill
+    applies_to:
+      - profile:claude-plugin
+    transformation: regenerate-corpus-navigate-skill
+    source_paths:
+      - templates/corpus/navigate-skill.md.tmpl
+    output_paths:
+      - skills/hiivmind-corpus-navigate/SKILL.md
+    validation:
+      kind: none

--- a/templates/profiles.yaml.template
+++ b/templates/profiles.yaml.template
@@ -15,10 +15,32 @@ scorecards:
         applicability: capability:ci
         weight: 1
 
+  claude-plugin-v1:
+    extends: generic-v1
+    checks:
+      - id: plugin-manifest
+        adapter: claude.plugin_manifest
+        applicability: profile:claude-plugin
+        weight: 1
+      - id: plugin-skills
+        adapter: claude.skills
+        applicability: profile:claude-plugin
+        weight: 1
+      - id: claude-context
+        adapter: claude.context
+        applicability: profile:claude-plugin
+        weight: 1
+
 adapters:
   generic.docs:
     state: available
   github.actions:
+    state: available
+  claude.plugin_manifest:
+    state: available
+  claude.skills:
+    state: available
+  claude.context:
     state: available
 
 # Non-authoritative detection policy. Matching rules create review proposals only.

--- a/templates/transformations.yaml.template
+++ b/templates/transformations.yaml.template
@@ -98,6 +98,32 @@ transformations:
       kind: none
     allow_scheduled: false
 
+  # F9 v1 dogfood overlay: regenerate the corpus-navigation skill under the
+  # Claude plugin profile. The generator that names this transformation
+  # (`hiivmind.corpus-navigate-skill`) is the ONE configured F9 overlay in
+  # templates/generators.yaml.template — it is CONFIGURATION of the
+  # generic F7 engine, not engine code. The `--generator <id>` argv is
+  # fixed here; the engine's fail-closed checks still apply.
+  #
+  # PROPOSE-ONLY (F9 v1): only ever *proposed*, never executed by F9 — same
+  # apply-mode deferral as the other overlay transformations. Until the
+  # apply-mode limitations noted on `plan-sync-doc-patch` and
+  # `marketplace-entry-update` are closed, this transformation is
+  # intentionally a "propose-only" dead end rather than a working pipeline.
+  regenerate-corpus-navigate-skill:
+    id: regenerate-corpus-navigate-skill
+    command_argv:
+      - nave
+      - generate
+      - --from-template
+      - --generator
+      - hiivmind.corpus-navigate-skill
+    applies_to:
+      - profile:claude-plugin
+    validation:
+      kind: none
+    allow_scheduled: false
+
   # Marketplace entry update carries variable patch data in this well-known file,
   # never through argv interpolation. The caller constrains its declared output
   # to the binding's marketplace_file path before writing it into the pen.

--- a/templates/transformations.yaml.template
+++ b/templates/transformations.yaml.template
@@ -98,6 +98,39 @@ transformations:
       kind: none
     allow_scheduled: false
 
+  # Marketplace entry update carries variable patch data in this well-known file,
+  # never through argv interpolation. The caller constrains its declared output
+  # to the binding's marketplace_file path before writing it into the pen.
+  #
+  # PROPOSE-ONLY (F9 v1): this transformation is only ever *proposed*; F9 never
+  # executes it. Two things must be closed before any apply-mode consumer runs
+  # it (the same two apply-mode limitations as plan-sync-doc-patch above):
+  #   1. Executor path — the argv below names a plugin-repo-relative script that
+  #      does not resolve inside a marketplace-repo pen checkout; apply mode needs
+  #      the applier on PATH (installed entry point / nave subcommand).
+  #   2. validation is `none` and the bound output path is self-attested by the
+  #      patch descriptor; apply mode needs the bound path as immutable proposal
+  #      metadata + an F6 "path changed" validation kind.
+  #
+  # The apply path script `lib/pulse/scripts/apply_marketplace_entry.py` is NOT
+  # implemented in F9 v1 — apply-mode is deferred and already backlogged; the
+  # script is inert under propose-only mutation_policy. Until an apply-mode
+  # consumer lands, this entry is intentionally a "propose-only" dead end
+  # rather than a working pipeline.
+  marketplace-entry-update:
+    id: marketplace-entry-update
+    command_argv:
+      - uv
+      - run
+      - lib/pulse/scripts/apply_marketplace_entry.py
+      - --patch
+      - .hiivmind/marketplace-entry-patch.yaml
+    applies_to:
+      - profile:claude-plugin
+    validation:
+      kind: none
+    allow_scheduled: false
+
   # Example: a dependency-lock refresh. Applies only to repos carrying a
   # capability signal (surfaced by their profile/scorecard evidence), and
   # its result is checked against a JSON Schema before it can be proposed

--- a/templates/workflows/marketplace-sync.yaml
+++ b/templates/workflows/marketplace-sync.yaml
@@ -1,0 +1,38 @@
+# hiivmind-pulse-gh - Marketplace Synchronization Workflow
+# Audit configured marketplace bindings against their bound plugin repos'
+# newest stable release and record propose-only F6 marketplace-entry-update
+# proposals for any drift or missing entry. Copy to:
+# .hiivmind/github/workflows/marketplace-sync.yaml
+
+name: "marketplace-sync"
+description: "Audit bound marketplace entries and record propose-only marketplace-entry-update proposals"
+enabled: true
+auto: false  # Runs only when requested or when a caller selects the marketplace trigger
+
+# INVOKE routes to the sibling headless orchestrator when available.
+headless:
+  enabled: true
+  on_ask: record
+  on_mutation: propose
+
+trigger:
+  type: on_demand
+  condition: user_requested
+
+params:
+  repo:
+    description: "Optional plugin repository (full or short name); empty audits every configured binding"
+    type: string
+    default: ""
+
+state: {}
+
+workflow: |
+  EXECUTE:
+    INVOKE skill hiivmind-pulse-gh:gh-marketplace-sync-headless
+      WITH workspace_path=workspace_root,
+           repo=params.repo,
+           mode=scheduled,
+           mutation_policy=propose
+
+cooldown_minutes: 1440  # 24 hours


### PR DESCRIPTION
## Summary

F9 adds **dogfood overlays** — opt-in extensions that let this plugin govern itself and other Claude Code plugins **without leaking plugin-specific concerns into the neutral fleet path**. Five tasks, one commit each, plus a whole-branch review fix wave.

| Task | What landed |
|------|-------------|
| **T1** — Claude plugin scorecard | `claude-plugin-v1` scorecard + `claude.plugin_manifest`/`claude.skills`/`claude.context` adapters, registered via a separate opt-in `register_claude_adapters`. Adapters read content from an overlay-scoped `evidence["file_contents"]` map the neutral snapshot never carries. |
| **T2** — Marketplace sync | Pure `compare()` (in_sync/drift/missing_entry/not_applicable/unknown) over a plugin's newest **stable** release vs its `marketplace.json` entry + expected-SHA-guarded propose-only F6 proposal; profile-gated headless skill + workflow + `marketplace-entry-update` transformation + a `marketplace-sync` result-validator kind. |
| **T3** — Claude context currency | `repo_claims.py`: deterministic `facts()`/`check_claims()` (CLAUDE.md path references vs actual skills/commands; `hooks/…`→`unsupported_evidence`). The one inferred step is schema-guarded by `validate_inferred_findings()`; invalid inference → `unknown`, never a fabricated verdict. |
| **T4** — Corpus generator overlay | Pure **configuration** of the generic F7 engine (`hiivmind.corpus-navigate-skill` generator + transformation) — zero engine code; a test drives the generic audit/dispatch path on it. |
| **T5** — Isolation + reporting | `test_dogfood_isolation.py` (AST import-graph + overlay-fixture-absence), the `register_claude_adapters` lazy-import fix, and overlay-model docs in README/SKILL.md/healthcheck skill. |

## Isolation guarantees (test-enforced)

- No overlay runs without an explicit `profile:claude-plugin` (or configured binding).
- No neutral engine module imports an overlay module at load time (7 neutral modules AST-checked, including the adapter registration surface).
- Overlay scorecards are subtotaled separately (`overlay: true`), never merged into a neutral denominator.
- All overlay mutations are propose-only, expected-SHA guarded (apply-mode deferred/backlogged).

## Validation

- **899 tests pass** (`uv run pytest lib/pulse/scripts/tests -q`); controller re-ran every gate and read every diff.
- Whole-branch adversarial review (glm-5.2) → 1 important test-integrity finding + 7 minors, **all fixed** in `ed4cc42` (tautological dependency test replaced with a real AST scan; regex anchoring; cross-list finding dedup; corpus scheduled-gate parity test; doc corrections).
- Templates (`profiles`/`transformations`/`generators`) still load and cross-validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)