### PR TITLE
docs: F-series architecture — audit, explainer, and F10 runnable-spine plan

### DIFF
--- a/docs/f-series-explained.md
+++ b/docs/f-series-explained.md
@@ -1,0 +1,355 @@
+# The F-Series, Explained
+
+A guided reference to the heterogeneous fleet-management program that hiivmind-pulse-gh
+implements — **what** each phase is for (what it looks at, what it detects, what risk it
+mitigates) and **how** it works (skill, Python, Nave, config, persisted evidence).
+
+For the architecture *health* of this program — which phases are actually runnable in
+production — see the companion audit `docs/superpowers/audits/2026-07-22-f-series-runnable-spine-audit.md`
+and the remediation plan `docs/superpowers/plans/2026-07-22-f10-runnable-spine.md`. This
+document explains what the phases *do*; the audit explains what currently *runs*.
+
+---
+
+## 1. The system in one paragraph
+
+hiivmind-pulse-gh is a **general GitHub multi-repo fleet manager**. It looks at a
+workspace of many repositories, decides what each repository *is* (its profile), scores
+each against the scorecard for that profile, watches cross-repo dependency edges for
+drift, and proposes safe, guarded changes — GitHub-object changes through the `gh` API and
+repository-file changes through Nave pen workspaces. Everything it changes it proposes for
+review first; nothing about a repository's language or layout is assumed.
+
+### The Pulse / Nave split
+
+- **Pulse** (this plugin) owns orchestration, repository **profiles**, **scorecards**,
+  GitHub mutations, cross-repo **bindings**, and the **result contract**.
+- **Nave** (an external CLI, consumed as versioned normalized JSON) owns fleet
+  projection, structural **evidence**, schema checks, and **pen** workspaces — the
+  transaction boundary for repository-file changes. Pulse never reads Nave's cache
+  internals; it consumes only Nave's documented JSON and supports a fixture mode.
+
+### Five invariants that run through every phase
+
+1. **Authoritative intent, not inference.** A repository's profile is *reviewed workspace
+   metadata*. Detection may only ever emit a `profile_proposal` — it never silently
+   reclassifies a repository.
+2. **Typed result states.** Every check is `pass | warn | fail | unknown | not_applicable
+   | unsupported | error`. `not_applicable`/`unsupported` are excluded from the score
+   denominator; `unsupported` is counted as *coverage debt*, never silently skipped.
+3. **Fail-closed.** A missing baseline, an unreadable file, an unparseable document → the
+   phase degrades to `unknown`/`blocked`, never a fabricated pass or a guessed value.
+4. **Propose-only by default.** Mutations are created and validated locally; pushing/
+   applying is a separate, gated step. Repository-file writes happen only inside Nave
+   pens; GitHub-object writes stay Pulse-owned.
+5. **Guarded, idempotent advancement.** Every marker/base advance is guarded by an
+   expected SHA (or blob) and is a no-op on repeat — concurrent runs cannot race a marker
+   forward.
+
+### The three layers (how to read each phase's "How")
+
+Every phase is built from a **library** (pure, tested Python), a **driver** (a runnable
+CLI that assembles inputs and writes a result), and a **skill** (`SKILL.md` orchestration).
+The read/score phases have all three; the propose/mutate phases (F6–F9) are missing the
+driver layer today — that is exactly what F10 adds. Where a phase's driver is missing, the
+"How" below says so.
+
+### Quick map
+
+| Phase | Core Python | Config it reads | Evidence it persists | Nave? |
+|---|---|---|---|---|
+| F0 | `evidence_snapshot`, `nave_adapter` | fleet projection | F0 evidence snapshot (files, capabilities) | ✅ projection/structure |
+| F1 | `profile_dispatch` | `profiles.yaml` scorecards/adapters | — (resolves a plan) | — |
+| F2 | `fleet_membership`, `profile_proposals` | `profiles.yaml` `repository_profiles` | reviewed profile metadata | — |
+| F3 | `healthcheck_dispatch` | `profiles.yaml` | `healthcheck.yaml` governance record | — |
+| Pre-F4 | `dependency_evidence`, `validate_dependency_evidence` | dependency-evidence contract | materialized manifest/lock contents | ✅ `materialize_json` |
+| F4 | *(deferred — not built)* | — | — | — |
+| F5 | `impact`, `impact_snapshot` | `relationships.yaml` edges | `integration_tested_sha` markers | optional path evidence |
+| F6 | `mutation_plan`, `pen_orchestrator` | `transformations.yaml` registry | `repo-mutation` result | ✅ pens |
+| F7 | `generated_artifacts`, `generator_dispatch`, `contract_versions` | `generated.yaml`, `generators.yaml`, contract edges | template-tree/blob bases | ✅ pens (regen) |
+| F8 | `plan_sync`, `plan_sync_snapshot`, `apply_doc_patch` | doc frontmatter `sync:` block | per-field reconciliation bases | ✅ pen (doc patch) |
+| F9 | `marketplace_sync`, `adapters/claude_plugin`, `repo_claims` | `claude-plugin-v1` scorecard, `marketplace-sync.yaml` | overlay subtotals | ✅ pen (regen) |
+
+---
+
+## 2. The read / score spine
+
+### F0 — Nave CLI evidence
+
+**Goal.** Establish one authoritative evidence boundary for the fleet and remove
+duplicated fetching.
+
+**What it looks at.** The fleet projection and per-repository structural facts Nave
+reports — the file list and capability signals for each repository.
+
+**What it detects.** Which repositories exist in the fleet; each repository's structural
+shape (does it have workflows, a README, the files a later check will key on).
+
+**Risk it mitigates.** Every later phase inventing its own repo-fetching path; coupling
+Pulse to Nave's cache internals; unpredictable failure when Nave is absent.
+
+**How.** `evidence_snapshot.py` (CLI) drives `nave_adapter.py`, which shells the Nave CLI
+(`search`/`build`/`check --json`) and normalizes the output to a versioned JSON contract;
+a fixture mode substitutes recorded JSON. The persisted artifact is the **F0 evidence
+snapshot** — a `{repos: [{repo, files, capabilities, …}]}` structure that F1/F3/F5/F9 all
+consume. Deliberately **content-free**: it carries file *paths*, never file *bytes* (the
+content channel is a bounded, phase-specific concern — see Pre-F4 and F9). Skill:
+`gh-fleet-evidence-headless`.
+
+### F1 — Profiles, scorecards, applicability
+
+**Goal.** Make each repository's *intent* explicit before anything is scored.
+
+**What it looks at.** The authoritative `repository_profiles` map plus the scorecard
+catalog in `templates/profiles.yaml.template`.
+
+**What it detects.** Which **scorecard** governs a repository (`generic-v1`,
+`python-library-v1`, `claude-plugin-v1`, …), and for each check whether it is applicable
+(`always`, `profile:<id>`, `capability:<id>`, `evidence_path:<glob>`), `not_applicable`,
+or `unsupported` (adapter not implemented).
+
+**Risk it mitigates.** Running language- or plugin-specific checks against repositories
+that aren't those things; conflating "check failed" with "check doesn't apply here".
+
+**How.** `profile_dispatch.py` (library) resolves a scorecard (with inheritance via
+`extends`) into a `DispatchPlan` of `PlannedCheck`s, each carrying an adapter id, weight,
+and applicability state. Pure — no I/O; it turns config + evidence into a plan the
+dispatcher executes.
+
+### F2 — Fleet membership and profile proposals
+
+**Goal.** Keep fleet scope honest and assign *reviewed* intent metadata.
+
+**What it looks at.** The set of repositories in the workspace versus the
+`repository_profiles` already recorded; evidence signals (`proposal_rules`) that suggest a
+profile.
+
+**What it detects.** Repositories in/out of the managed fleet; **candidate** profiles for
+unclassified repositories (e.g. `pyproject.toml` → `python`, `.claude-plugin/plugin.json`
++ `skills/*/SKILL.md` → `claude-plugin`), each emitted as a `profile_proposal` with a
+confidence and the evidence that triggered it.
+
+**Risk it mitigates.** Scope creep (untracked repos silently ignored or silently
+managed); auto-classification that changes behaviour without a human reviewing the intent.
+
+**How.** `fleet_membership.py` + `profile_proposals.py` (CLIs). Proposals are output;
+they become authoritative only when merged into `repository_profiles` as a reviewed
+workspace commit. Skill: `gh-fleet-membership-headless`.
+
+### F3 — Dispatched healthcheck and coverage
+
+**Goal.** Prove generic top-level dispatch across a heterogeneous fleet without any
+language assumption, and report coverage honestly.
+
+**What it looks at.** The F0 evidence for every profiled repository, run through that
+repository's resolved scorecard.
+
+**What it detects.** Per-repository weighted **grade** (A–F), and fleet **coverage debt**
+— the weight of checks that are `unsupported` because their adapter isn't implemented.
+
+**Risk it mitigates.** A fleet report that mixes scorecard populations (a docs repo's
+"grade" averaged against a service's); silent gaps where an unimplemented check is dropped
+rather than surfaced as debt.
+
+**How.** `healthcheck_dispatch.py` (CLI) is the read-spine's orchestrator:
+`--evidence <F0 snapshot> --profiles <config> --workspace <path>`. It registers the
+universal adapters, dispatches each repo's plan, evaluates each applicable check through
+`AdapterRegistry`, and aggregates **by scorecard** (never mixing populations). The
+persisted artifact is the governance record `templates/healthcheck.yaml.template`
+(`last_run.by_scorecard`, `coverage`, durable per-repo/check records, and `dismissals`).
+Skill: `gh-healthcheck-headless`. *(Note: this dispatcher registers only the universal
+adapters today — the F9 overlay is not wired in; F10 Task 4 fixes that.)*
+
+### Pre-F4 — Nave dependency evidence
+
+**Goal.** Give dependency checks authoritative, **bounded** file contents without exposing
+Nave cache internals or re-fetching from GitHub.
+
+**What it looks at.** The dependency manifests and locks Nave can materialize (Python and,
+per Nave's tracked paths, pre-commit/Dependabot/Actions; arbitrary Node/docs are not yet
+covered).
+
+**What it detects.** The exact, current contents of those files at a pinned point — the
+raw material a coherence check would compare.
+
+**Risk it mitigates.** Reading Nave's private cache; duplicating GitHub retrieval;
+unbounded content pulls.
+
+**How.** Nave protocol-v2 `materialize_json` exposes the bytes; `nave_adapter.py`
+consumes it; `dependency_evidence.py` shapes it and `validate_dependency_evidence.py`
+gates the contract. Persisted as materialized manifest/lock content keyed to a repo/ref.
+This is code-complete; the remaining task is releasing Nave and pinning its minimum
+version.
+
+### F4 — Dependency-coherence adapters *(deferred — not built)*
+
+**Intended goal.** The first language-*dispatched* workflow: consume Pre-F4's materialized
+manifests/locks and check dependency coherence per ecosystem (Python `pyproject`/`uv.lock`,
+Node `package.json`), surfacing unsupported ecosystems as coverage debt rather than false
+failures.
+
+**Status.** Pre-F4 (the evidence) merged; **F4 (the adapters that would consume it) was
+never implemented.** The `dependency-updates` check therefore reports `unsupported` /
+"not implemented." This is an open read-spine gap, independent of the F6–F9 driver gap.
+
+---
+
+## 3. The propose / mutate spine
+
+These phases decide *what should change* and record guarded, propose-only proposals. They
+share the mutation machinery (F6) and the binding conventions (F5). All four currently
+lack a runnable driver — their skills describe the orchestration but cite library function
+signatures rather than shelling a CLI, so a headless run requires improvised glue (see the
+audit; F10 supplies the drivers).
+
+### F5 — Generic impact bindings and branch currency
+
+**Goal.** Detect path-scoped upstream drift beyond each dependency edge's last validated
+commit — language-independent integration currency.
+
+**What it looks at.** Object-shaped relationship **edges**
+(`templates/relationships.yaml.template`): `{repo, watch_paths, watch_branch,
+integration_tested_sha, tested_at, integration_workflow}`. The currency test is
+`git diff integration_tested_sha..remote_head -- watch_paths`.
+
+**What it detects.** Edges gone **stale** — an upstream dependency has changed files under
+the watched paths since the last SHA the dependent was validated against. Missing or
+unreachable baselines **block closed** (never silently pass).
+
+**Risk it mitigates.** Silent integration drift; cutting a release against a dependency
+that moved under you; markers racing forward under concurrency.
+
+**How.** `impact.py` (`audit`, `mark`) is pure; `impact_snapshot.py` collects remote
+evidence (`git ls-remote` / bare fetch, `FETCH_HEAD` discipline, argv-guarded).
+`poll.py`'s `branch_heads` source is trigger-only — it notices an upstream head moved and
+wakes the workflow; it never diffs content itself. The persisted artifact is the
+committed `integration_tested_sha` marker, advanced only by expected-base-guarded,
+idempotent patches, and only from evidence of the edge's configured `integration_workflow`
+succeeding. Skill: `gh-impact-audit-headless`. Also contributes a `binding_edges_current`
+release gate.
+
+### F6 — Nave pen mutation orchestration
+
+**Goal.** Route every repository-file change through a Nave pen with freshness,
+cleanliness, validation, attribution, and mutation-policy gates.
+
+**What it looks at.** A typed **mutation proposal** (`{id, selection, transformation,
+expected_shas, mutation_policy, actor}`) and the **transformation registry**
+(`templates/transformations.yaml.template`: `{id, command_argv, applies_to, validation,
+allow_scheduled}`).
+
+**What it detects / enforces.** Stale pens (remote moved since selection) and dirty pens
+block *before* execution; schema validation gates the result; a forbidden push is
+refused; `allow_scheduled: false` transformations are refused for scheduled actors. Only
+**registered** transformation IDs run automatically; arbitrary `nave pen exec` commands
+are user-gated.
+
+**Risk it mitigates.** Unsafe or unattributed repository-file writes; shell injection
+(the registry is strict `argv`, never a shell string, never templated); pushing without
+review; a second multi-repo checkout system competing with Nave.
+
+**How.** `mutation_plan.py` (proposal + registry, `build_proposal` requiring exact
+`expected_shas` coverage of the selection) and `pen_orchestrator.py` (the state machine
+`planned → created → executed → validated → proposed | blocked | failed`, propose-only,
+fail-closed) over `nave_adapter.py`'s pen JSON ops. Pulse records actor, machine, Nave
+version, pen name, selection, command ID, and per-repo outcome as the `repo-mutation`
+result. **`pen_orchestrator.execute` has no caller outside tests today** — F6 is the
+engine the other mutate phases build proposals *for*, but nothing runs them.
+
+### F7 — Generated-artifact drift and contract propagation
+
+**Goal.** Detect when a generated file has drifted from its template, and when a
+producer/consumer contract version has skewed — using explicit configuration, never
+inferred layouts.
+
+**What it looks at.** `generated.yaml` bindings (`{source, template_path, template_tree
+(tree SHA), generator, files:[{path, blob}]}`), `generators.yaml` generator adapters
+(source/output paths + a referenced F6 transformation), and optional `contract:` blocks on
+F5 edges (producer/consumer `{path, parser}`, `version_scheme: pep440`).
+
+**What it detects.** Per binding, comparing content-addressed tree/blob SHAs:
+`current` (nothing moved); **`template-drift`** (template tree changed, outputs unchanged →
+a regeneration is warranted → an F6 proposal); **`local-customization`** (outputs changed
+but template didn't → a finding, deliberately **no** proposal, so local edits aren't
+clobbered); **`conflict`** (both changed). For contracts: `compatible | gap | unknown`
+between a producer's declared version and a consumer's.
+
+**Risk it mitigates.** Blindly regenerating over intentional local edits; letting a
+generated file silently rot behind its template; producer/consumer version skew; an LLM
+inferring *what* to regenerate or *how* (forbidden — generators are explicit config, argv
+lives only in the F6 registry).
+
+**How.** `generated_artifacts.py` (`backfill`/`audit`/`advance`, pure; `collect` does the
+git reads via `git rev-parse FETCH_HEAD:<path>` for tree/blob SHAs) + `generator_dispatch.py`
+(`load_generators`, `dispatch` → an F6 proposal with output-allowlist enforcement) +
+`contract_versions.py` (regex/toml/json/yaml parsers, `packaging` comparison). Skill:
+`gh-generated-artifact-headless`.
+
+### F8 — Generic plan synchronization
+
+**Goal.** Keep planning documents and their GitHub issues/milestones in agreement, in
+*both* directions, without either side being "primary".
+
+**What it looks at.** A planning doc's artifact-carried frontmatter `sync:` block
+(`issue: {repo, number}`, per-field `policy`, and a per-field `base` — the three-way merge
+base) versus the live GitHub issue. V1 fields: `title`, `state`, `assignees`, `milestone`,
+`body`. The body base is fetched by reconciled blob SHA from **pushed** git history, never
+a working tree.
+
+**What it detects.** Per field: `noop`, `apply_to_github` (doc changed), `apply_to_doc`
+(GitHub changed), `agree` (both to the same value), or **`conflict`** (both changed
+differently, no resolving policy). Local dirty/unpushed docs are reported and **excluded**,
+never merged.
+
+**Risk it mitigates.** Doc/issue drift; a lossy edit destroying frontmatter comments or
+ordering; one side clobbering the other; a base advancing before both sides confirm.
+
+**How.** `plan_sync.py` (lossless `ruamel` parse/patch — a no-op patch is byte-identical;
+per-field three-way `merge_field`/`compute`; `build_apply_plans` produces up to two
+*separate* proposals) + `plan_sync_snapshot.py` (`collect` via git + `gh_api` seams;
+rename detection via `git log --follow`) + `apply_doc_patch.py` (the tiny script the
+`plan-sync-doc-patch` F6 transformation runs inside a pen, reading its patch from a
+well-known repo-relative path since F6 forbids argv templating). `poll.py`'s `docs` source
+is the trigger. Skill: `gh-plan-sync-headless`.
+
+### F9 — Hiivmind / Claude dogfood overlays
+
+**Goal.** Let the plugin govern *itself* — score its own manifest, skills, and context —
+without polluting the neutral fleet scorecards.
+
+**What it looks at.** Only repositories whose reviewed profile opts in
+(`profile:claude-plugin`). It reads `.claude-plugin/plugin.json`, every `skills/*/SKILL.md`,
+`CLAUDE.md`, the `claude-plugin-v1` scorecard, and `marketplace-sync.yaml` bindings.
+
+**What it detects.** A malformed/absent plugin manifest; skills with invalid frontmatter;
+**stale `CLAUDE.md` claims** (a referenced skill/command that no longer exists) via a
+deterministic scan plus a schema-guarded inference step; **marketplace version drift**
+(the plugin's newest stable release vs the version recorded in `marketplace.json`); corpus
+generated-skill drift (reusing F7). Overlay subtotals are reported under their own
+scorecard key — **never merged into a neutral denominator**.
+
+**Risk it mitigates.** The plugin's self-documentation silently rotting; the plugin's
+marketplace entry lagging its releases; and — critically — the overlay's plugin-specific
+assumptions leaking into how it scores *other* repositories. The engine imports **no**
+overlay module at load time; overlay adapters register through a lazily-imported
+`register_claude_adapters`, and an isolation test (`test_dogfood_isolation.py`) proves the
+neutral fleet is unaffected.
+
+**How.** `marketplace_sync.py` (`compare` → `MarketplaceDrift`, `build_marketplace_proposal`
+→ F6 proposal), `adapters/claude_plugin.py` (the `plugin_manifest`/`skills`/`context`
+adapters), and `repo_claims.py` (the deterministic claim scan + the
+`validate_inferred_findings` schema guard that keeps the one non-deterministic step — an
+agent extracting claims from prose — from ever fabricating a pass/fail). All mutations are
+propose-only and expected-SHA guarded. Skills: `gh-marketplace-sync-headless`, and the
+overlay subsection of `gh-healthcheck-headless`. *(The overlay adapters are not yet
+registered by the dispatcher, and marketplace-sync has no driver — F10 Tasks 1 and 4.)*
+
+---
+
+## 4. What actually runs today
+
+The read/score spine (F0–F3) runs from the scheduler (**status → refresh → healthcheck →
+PR**) and on demand. The propose/mutate spine (F5–F9) is built and tested but only F5 has
+a partial trigger (poll-surfaced); F6–F9 have no driver and no trigger. F4 is unbuilt. The
+gap and its fix are the subject of the audit and the F10 plan referenced at the top of this
+document.

--- a/docs/superpowers/audits/2026-07-22-f-series-runnable-spine-audit.md
+++ b/docs/superpowers/audits/2026-07-22-f-series-runnable-spine-audit.md
@@ -1,0 +1,129 @@
+# F-Series Runnable-Spine Audit: Library vs Driver vs Skill
+
+**Date:** 2026-07-22
+**Scope:** The F0–F9 fleet program (`docs/superpowers/plans/2026-07-*-f*.md`) as merged to `develop`, viewed as a runnable production system rather than as unit-tested modules.
+**Question:** For each F-phase capability, is there an actual production path — a real trigger through a runnable driver to a validated result — or is the phase a tested library whose orchestration exists only as prose that an agent must improvise a driver for?
+
+## How this surfaced
+
+While dogfooding the F9 overlays against this repo, there was no shell entry point
+that would score `claude-plugin-v1` or run marketplace-sync. The only way to
+exercise the merged capability was to **hand-write a Python driver** that imported
+the shipped functions (`profile_dispatch.dispatch`, `register_claude_adapters`,
+`marketplace_sync.compare`) and assembled their inputs. That improvisation was
+not an F9 quirk — it is the normal state of the entire propose/mutate half of the
+program.
+
+## Executive finding
+
+Every F-phase capability is built from three layers:
+
+1. **Library** — a pure, tested module (`marketplace_sync`, `pen_orchestrator`,
+   `profile_dispatch`, `plan_sync`, `generator_dispatch`, …).
+2. **Driver** — a CLI (`*.py` with a `__main__`/argparse entry) that assembles
+   inputs, calls the library, and writes a validated `result.yaml`. This is the
+   layer a `SKILL.md` or a scheduler can actually **run** (`uv run …`).
+3. **Skill** — the `SKILL.md` orchestration document an agent or scheduler follows.
+
+**The read/score half of the program (F0–F3, Pre-F4, F5) built all three layers
+and is runnable. The propose/mutate half (F6–F9) built layers 1 and 3 but skipped
+layer 2.** For those phases the `SKILL.md` substitutes a **function signature** for
+a runnable command — `plan_sync.compute(...)`, `pen_orchestrator.execute(...)`,
+`marketplace_sync.compare(...)` — which an agent cannot execute from prose without
+writing glue. Consequently nothing (heartbeat, scheduler, or CLI) invokes F6–F9,
+and the guarded mutation executor `pen_orchestrator.execute` has **no caller
+anywhere but tests**.
+
+This passed review because a skill that pastes the exact function contract *reads*
+as a complete orchestration. It is not executable, and "propose-only / apply-mode
+deferred" hid the gap rather than excusing it: a propose-only headless run still
+needs a driver to emit its proposals into a validated result for review.
+
+## What actually triggers work in production
+
+| Trigger | Path | Reaches |
+|---|---|---|
+| Heartbeat (SessionStart) | `hooks/heartbeat.sh` → `lib/pulse/scripts/poll.py` | Detects due workflows / branch-head changes and **surfaces** them; runs no mutation itself |
+| Scheduler (external `hiivmind-pulse-scheduler`) | `TEMPLATE-workspace-maintenance.md` composes **status → refresh → healthcheck → PR** | The read spine only |
+| Interactive | `/gh` gateway → `gh-operations` | Direct GitHub operations |
+
+No trigger composes impact (F5), pen (F6), generator (F7), plan-sync (F8), or
+marketplace/overlays (F9).
+
+## Phase matrix
+
+| Phase | Library module | CLI driver? | Skill | Runnable unattended today? |
+|---|---|---|---|---|
+| F0 Nave evidence | `evidence_snapshot`, `nave_adapter` | ✅ CLI | `gh-fleet-evidence-headless` | ✅ |
+| F1 profiles/scorecard | `profile_dispatch` | ✅ via `healthcheck_dispatch` | `gh-healthcheck-headless` | ✅ neutral only |
+| F2 fleet membership | `fleet_membership`, `profile_proposals` | ✅ CLI | `gh-fleet-membership-headless` | ✅ (not scheduled) |
+| F3 dispatched healthcheck | `healthcheck_dispatch` | ✅ CLI | `gh-healthcheck-headless` | ✅ scheduled |
+| Pre-F4 dependency evidence | `dependency_evidence` | ✅ `validate_dependency_evidence` | (folded into evidence) | ✅ |
+| F5 impact bindings | `impact`, `impact_snapshot` | ✅ CLI | `gh-impact-audit-headless` | ✅ (poll-surfaced trigger only) |
+| **F6 pen mutations** | `pen_orchestrator`, `mutation_plan` | ❌ **none** | (used by gen/workflow skills) | ❌ improvise |
+| **F7 generator dispatch** | `generator_dispatch`, `generated_artifacts` | ❌ **none** (only `validate_result`) | `gh-generated-artifact-headless` | ❌ improvise |
+| **F8 plan sync** | `plan_sync`, `plan_sync_snapshot` | ❌ **none** (only `validate_result`) | `gh-plan-sync-headless` | ❌ improvise |
+| **F9 overlays / marketplace** | `marketplace_sync`, `adapters/claude_plugin`, `repo_claims` | ❌ **none / not registered** | `gh-marketplace-sync-headless` | ❌ improvise |
+
+### F9-specific wiring gaps (the concrete instance of the pattern)
+
+1. `healthcheck_dispatch.py` registers `register_universal_adapters` only, never
+   `register_claude_adapters` — a `claude-plugin-v1` repo run through it resolves
+   all three `claude.*` checks to `unsupported` ("No adapter registered").
+2. The F0 evidence snapshot carries file **paths** only, never `file_contents`;
+   the claude adapters read content, so even if registered they return `unknown`.
+   Nothing builds the overlay content channel.
+3. `marketplace_sync` has an agent-runnable `SKILL.md` but no CLI and no
+   scheduler/heartbeat trigger.
+4. The `claude.context` inference step has no orchestration hook: the skill never
+   instructs the agent to extract claims and feed `inferred_claims`, so it
+   silently never runs — a headless run hands out a clean `pass` over stale docs
+   (observed live: deterministic pass = A grade; with the inferred `stale_command`
+   finding folded in the grade is B / 4-of-5).
+
+## Root cause
+
+1. **SDD rewards pure modules.** They unit-test cleanly and let the controller
+   re-run gates, so every phase produced a pristine library first.
+2. **Apply-mode was deferred.** The mutation phases are propose-only dead-ends, so
+   a runnable driver felt premature — but propose-only still needs a driver to
+   emit proposals for review, so this hid the missing layer rather than removing
+   the need for it.
+3. **Skills cite signatures instead of commands.** A `SKILL.md` that pastes
+   `module.func(...)` reads as complete and passes review, but is not executable
+   and forces per-run improvisation with no result-contract guarantee.
+
+Charitable reading considered and rejected: "the agent is the runtime and writes
+the glue each run." The read phases got real CLIs, so the intended pattern is a
+driver; and an improvised per-run driver is unschedulable and has no validated
+result contract. Under either reading, F6–F9 are not production-wired.
+
+## Remediation shape (an F10 "runnable spine" phase)
+
+The missing **driver layer**, applied uniformly:
+
+- A CLI per mutation/sync module (or genuinely executable skills) that assembles
+  inputs and emits the validated `result.yaml`:
+  `marketplace_sync`, `plan_sync`, `generator_dispatch`, and the guarded executor
+  `pen_orchestrator`.
+- Overlay wiring in the dispatcher: opt `register_claude_adapters` into
+  `healthcheck_dispatch.py` for overlay scorecards, and populate the overlay
+  `file_contents` content channel in the F0 evidence build for opted-in repos.
+- An inference hook in `gh-healthcheck-headless` (and/or the context adapter path)
+  that records whether the inference step ran; a skipped step is `unknown`, never
+  a silent `pass`.
+- Scheduler-composition entries so a trigger actually invokes the propose/mutate
+  phases (even in propose-only mode, to emit reviewable proposals).
+
+## Evidence pointers
+
+- `lib/pulse/scripts/healthcheck_dispatch.py` — `register_universal_adapters`
+  only; the CLI driver for the F1/F3 read path.
+- `lib/pulse/scripts/adapters/__init__.py` — `register_claude_adapters` exists and
+  is lazy/isolated, but has no non-test caller.
+- `skills/gh-marketplace-sync-headless/SKILL.md`, `…/gh-plan-sync-headless/…`,
+  `…/gh-generated-artifact-headless/…` — cite `module.func(...)` signatures with
+  no `uv run` driver.
+- `lib/patterns/repository-mutations.md` — the only reference to running the
+  mutation modules is a `pytest` command.
+- `hooks/heartbeat.sh` → `lib/pulse/scripts/poll.py` — trigger-and-surface only.

--- a/docs/superpowers/plans/2026-07-22-f10-runnable-spine.md
+++ b/docs/superpowers/plans/2026-07-22-f10-runnable-spine.md
@@ -1,0 +1,169 @@
+# F10: Runnable Spine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **Origin:** `docs/superpowers/audits/2026-07-22-f-series-runnable-spine-audit.md`. The audit found that F6–F9 shipped as pure libraries + prose skills with **no driver layer**, so nothing triggers them and every headless run requires an improvised driver. This plan builds the missing layer.
+
+**Goal:** Make every propose/mutate F-phase (F5 completion, F6–F9) runnable end-to-end from a real trigger to a validated `result.yaml`, with **no improvised glue** — by adding the missing **driver layer** (a `uv run` CLI per phase), wiring the F9 overlay into the dispatcher and evidence build, and composing the new runs into the scheduler.
+
+**Non-goal (explicitly out of scope):** apply-mode. Every driver here is **propose-only** and emits reviewable proposals into a validated result; none pushes, and none newly executes a Nave pen. Executing a recorded proposal through `pen_orchestrator.execute` (which needs Nave + the transformation executor on PATH in the pen checkout) remains the deferred apply-mode phase — see `docs/backlogs/2026-07-22-f1-f8-phase-deferrals.md`. F10 closes the *runnable-and-triggered* gap, not the *applies-changes* gap.
+
+**Architecture:** Each phase already owns a pure library (`marketplace_sync`, `plan_sync`, `generated_artifacts`/`generator_dispatch`, the F9 `claude_plugin` adapters) and a `SKILL.md`. F10 inserts a thin **CLI driver** between them: a PEP 723 script that assembles the phase's inputs (workspace config + a snapshot via the phase's existing `collect`, + actor), calls the pure library, validates the envelope with `validate_result.py`, and writes the phase's `*-result.yaml`. Each headless `SKILL.md` changes from *citing a function signature* to *shelling the driver* (`uv run …`) — the same pattern the F0–F5 read spine already uses (`healthcheck_dispatch.py`, `impact.py`, `impact_snapshot.py`). The F9 overlay is wired into `healthcheck_dispatch.py` (adapter registration + evidence content channel + inference hook). The scheduler maintenance template gains composition entries so a trigger invokes the propose/mutate phases.
+
+**Tech Stack:** Python 3.10+ PEP 723 scripts, PyYAML, pytest, `gh` CLI, git. (No new library dependencies — drivers only assemble and call existing pure modules.)
+
+## What already exists (verified 2026-07-22, develop head)
+
+- **Pure libraries, fully tested, with no CLI driver:**
+  - `marketplace_sync.compare(binding, releases, marketplace_doc) -> MarketplaceDrift`; `build_marketplace_proposal(drift, head_sha, actor, registry=None) -> Proposal`.
+  - `plan_sync.parse_document/patch_document/merge_field/compute/build_apply_plans/finalize`; `plan_sync_snapshot.collect(bindings, workdir, runner, gh_api) -> SyncSnapshot`.
+  - `generated_artifacts.backfill/audit/advance` + `collect(manifest, workdir, runner)`; `generator_dispatch.load_generators(data, registry)` + `dispatch(generator, binding, snapshot, actor, mutation_policy="propose") -> Proposal`.
+  - `mutation_plan.build_proposal(...)`; `pen_orchestrator.execute(...)` — propose-only, expected-SHA guarded. **No caller outside tests.**
+- **The read-spine drivers to model on:** `healthcheck_dispatch.py` (`--evidence --profiles --workspace`), `impact.py`, `impact_snapshot.py` (`default_runner`, `_valid_sha`/`_valid_branch` argv guards, fetch-then-`FETCH_HEAD`), `evidence_snapshot.py`.
+- **Result validators already registered** for every kind: `validate_result.py` kinds `marketplace-sync`, `plan-sync`, `generated-artifact`, `repo-mutation`, `impact`, `healthcheck` (+ envelope). The drivers must produce envelopes these already accept — no validator changes expected.
+- **The F9 overlay pieces, unwired:** `adapters/__init__.register_claude_adapters` (lazy, isolated, no non-test caller); the `claude-plugin-v1` scorecard in `templates/profiles.yaml.template`; `repo_claims.validate_inferred_findings` (the inference schema guard). `healthcheck_dispatch.py` registers only `register_universal_adapters`; the F0 evidence snapshot carries file paths only (no `file_contents`).
+- **Headless skills that cite signatures instead of a driver:** `gh-marketplace-sync-headless`, `gh-plan-sync-headless`, `gh-generated-artifact-headless`.
+
+## Global Constraints
+
+- Every driver is **propose-only**: it may read, compare, and emit proposal records; it MUST NOT push, apply, or newly execute a Nave pen. `mutation_policy` is always `propose`.
+- Every driver writes its `*-result.yaml` on **every exit** (including early ABORT) and self-validates via `validate_result.py`; a non-zero validator exit is a driver bug.
+- Drivers add **no new decision logic** — all classification/merge/drift rules stay in the pure libraries. A driver only assembles inputs, calls the library, and serialises the result.
+- Drivers reuse existing seams verbatim: `impact_snapshot.default_runner`, the `_valid_sha`/`_valid_branch` argv guards, the `gh_api` seam. No second runner, no second checkout mechanism.
+- The overlay remains opt-in: the dispatcher registers claude adapters and builds the content channel **only** for repositories whose reviewed profile selects an overlay scorecard. Neutral fleet behaviour stays provably unchanged (`test_dogfood_isolation.py` must still pass).
+- A skipped inference step is recorded as `unknown`, never a silent `pass`.
+- `uv run pytest -q` and `git diff --check` pass before each task closes. Every task adds neutral fixtures, not only hiivmind/plugin fixtures.
+
+---
+
+### Task 1: Marketplace-sync driver
+
+**Files:**
+- Create: `lib/pulse/scripts/marketplace_sync_run.py`
+- Create: `lib/pulse/scripts/tests/test_marketplace_sync_run.py`
+- Modify: `skills/gh-marketplace-sync-headless/SKILL.md`
+
+**Interfaces:**
+- CLI: `marketplace_sync_run.py --workspace <path> [--repo <full|short>] [--result <path>] [--mode scheduled|interactive]`.
+- Consumes: `CONFIG_DIR/marketplace-sync.yaml` bindings; per binding, the marketplace doc (via `gh api` REST, injected seam) and `gh release list --json tagName,isPrerelease,isDraft`.
+- Produces: `marketplace-sync-result.yaml` (kind `marketplace-sync`) with counts, findings, and `proposals[]` for drift/missing-entry. Never executes a pen.
+- Drives the exact Phase 1–5 flow already written in `gh-marketplace-sync-headless/SKILL.md`; the skill's `marketplace_sync.compare` / `build_marketplace_proposal` references become the driver's internals.
+
+**Steps:**
+- [ ] **Step 1: Write failing tests** — fixture bindings + injected release list / marketplace doc / HEAD SHA seams: `in_sync` → zero proposals; `drift`/`missing_entry` → one proposal each with `expected_shas`; `no stable release` → `unknown` finding, no proposal; malformed binding → `invalid_binding` finding, not counted; unresolvable `--repo` → ABORT writes a result. Assert the emitted file passes `validate_result.py --kind marketplace-sync`.
+- [ ] **Step 2: Implement** the driver as an assembler over `marketplace_sync.compare`/`build_marketplace_proposal` with a `gh` seam mirroring `impact_snapshot`'s runner injection. No decision logic in the driver.
+- [ ] **Step 3: Rewrite the skill** to shell `uv run …/marketplace_sync_run.py` with the resolved inputs; replace the function-signature contract with the command; keep the STOP/ABORT semantics.
+- [ ] **Step 4: Run tests and commit** with `feat: add runnable marketplace-sync driver`.
+
+---
+
+### Task 2: Plan-sync driver
+
+**Files:**
+- Create: `lib/pulse/scripts/plan_sync_run.py`
+- Create: `lib/pulse/scripts/tests/test_plan_sync_run.py`
+- Modify: `skills/gh-plan-sync-headless/SKILL.md`
+
+**Interfaces:**
+- CLI: `plan_sync_run.py --workspace <path> [--result <path>] [--mode …]`.
+- Consumes: bound docs from workspace config; `plan_sync_snapshot.collect` (git via `default_runner`, GitHub via `gh_api` seam).
+- Produces: `plan-sync-result.yaml` (kind `plan-sync`) with counts (`in_sync`, `doc_patches`, `github_patches`, `conflicts`, `excluded`), findings, and up to two **separate** propose-only proposals per doc (`build_apply_plans`): the doc-patch (F6 `Proposal`, recorded — not executed) and the GitHub patch (proposed action). Bases advance only on confirmed application, which never happens in propose mode.
+- Drives the skill's DISCOVER → SNAPSHOT → COMPUTE → (propose) → RECORD flow.
+
+**Steps:**
+- [ ] **Step 1: Write failing tests** — reuse `test_plan_sync_acceptance.py` fixtures: each merge outcome lands in the right count bucket; conflict withholds base; `dirty_doc`/`local_ahead` exclusion + finding; repeat run after sync is a no-op with identical counts; emitted file passes `validate_result.py --kind plan-sync`.
+- [ ] **Step 2: Implement** the assembler over `collect` + `compute` + `build_apply_plans`; propose-only, no pen exec, no `gh` writes.
+- [ ] **Step 3: Rewrite the skill** to shell the driver.
+- [ ] **Step 4: Run tests and commit** with `feat: add runnable plan-sync driver`.
+
+---
+
+### Task 3: Generated-artifact driver
+
+**Files:**
+- Create: `lib/pulse/scripts/generated_artifact_run.py`
+- Create: `lib/pulse/scripts/tests/test_generated_artifact_run.py`
+- Modify: `skills/gh-generated-artifact-headless/SKILL.md`
+
+**Interfaces:**
+- CLI: `generated_artifact_run.py --workspace <path> [--result <path>] [--mode …]`.
+- Consumes: `generated.yaml` manifest; `generated_artifacts.collect` snapshot (`git rev-parse FETCH_HEAD:<path>` tree/blob SHAs).
+- Produces: `generated-artifact-result.yaml` (kind `generated-artifact`) with `bindings_audited`, `states`, findings, and `proposals[]` — a `generator_dispatch.dispatch` F6 proposal **only** for `template-drift` bindings (recorded, not executed). `local-customization`/`conflict`/`error` produce findings and no proposal.
+- Drives the skill's SNAPSHOT → AUDIT → PROPOSE → RECORD flow.
+
+**Steps:**
+- [ ] **Step 1: Write failing tests** — fixture manifest + snapshot covering every `audit` classification cell; `template-drift` yields exactly one dispatched proposal that round-trips `pen_orchestrator.execute`'s expected-SHA guard; output outside the generator allowlist is a finding, no proposal; emitted file passes `validate_result.py --kind generated-artifact`.
+- [ ] **Step 2: Implement** the assembler over `collect` + `audit` + `generator_dispatch.dispatch`; keep it neutral (the F7 neutrality test — no `claude`/`corpus`/`plugin`/`SKILL.md` strings — extends to this driver).
+- [ ] **Step 3: Rewrite the skill** to shell the driver.
+- [ ] **Step 4: Run tests and commit** with `feat: add runnable generated-artifact driver`.
+
+---
+
+### Task 4: Wire the F9 overlay into the dispatcher
+
+**Files:**
+- Modify: `lib/pulse/scripts/healthcheck_dispatch.py`
+- Modify: `lib/pulse/scripts/evidence_snapshot.py` (or the overlay evidence build it feeds)
+- Modify: `skills/gh-healthcheck-headless/SKILL.md`
+- Modify: `lib/pulse/scripts/tests/test_healthcheck_dispatch.py`, `test_dogfood_isolation.py`
+
+**Interfaces:**
+- Dispatcher opt-in: when any profiled repo's resolved scorecard contains a `claude.*` adapter (i.e. an overlay scorecard is in play), `healthcheck_dispatch` calls `register_claude_adapters(registry)` in addition to `register_universal_adapters`. Neutral-only runs never import the overlay (the lazy import + isolation test still hold).
+- **Overlay content channel:** for a repo whose reviewed profile opts into an overlay scorecard, the evidence build populates `evidence["file_contents"]` for the overlay-relevant paths (`.claude-plugin/plugin.json`, `CLAUDE.md`, every `skills/*/SKILL.md`) — bounded, explicit, overlay-scoped. The neutral snapshot stays content-free (the F9 architecture invariant).
+- **Inference hook:** `gh-healthcheck-headless` performs the `claude.context` inference step for opted-in repos (extract candidate `stale_command`/`missing_claimed_skill`/`unsupported_evidence` claims from `CLAUDE.md`, feed as `evidence["inferred_claims"]`, schema-guarded by `repo_claims.validate_inferred_findings`) and **records whether it ran**. A skipped/failed inference step forces the `claude.context` result to `unknown`, never a silent `pass`.
+
+**Steps:**
+- [ ] **Step 1: Tests** — a fixture fleet with one overlay repo + neutral repos: overlay checks resolve to real `pass`/`fail`/`unknown` (not `unsupported`); neutral repos never load the overlay module (extend `test_dogfood_isolation.py`); a run with the inference step absent grades `claude.context` `unknown`; overlay subtotal stays in its own `by_scorecard` key.
+- [ ] **Step 2: Implement** the opt-in registration + content channel + inference-recording; keep isolation green.
+- [ ] **Step 3: Update the skill** — the "Overlay scorecards (dogfood)" subsection gains the inference-step instruction and the `unknown`-on-skip rule.
+- [ ] **Step 4: Run full suite and commit** with `feat: wire claude overlay into the dispatcher`.
+
+---
+
+### Task 5: Complete F5 scheduling and compose the propose/mutate phases into triggers
+
+**Files:**
+- Modify: `lib/pulse/scripts/poll.py` (+ `test_poll.py`)
+- Modify: the scheduler maintenance composition (`hiivmind-pulse-scheduler` `TEMPLATE-workspace-maintenance.md` — cross-repo; document the required edit here and land it in that repo)
+- Modify: `lib/patterns/run-ledger.md` / `lib/patterns/workflow-execution.md` as needed for the new run kinds
+
+**Interfaces:**
+- `poll.py` surfaces the `docs` (F8) and `branch_heads` (F5) trigger sources as due workflows the heartbeat/`gh-heartbeat` presents, and adds a periodic trigger for marketplace-sync and generated-artifact audits (mirroring the existing workflow cadence state).
+- Scheduler composition extends **status → refresh → healthcheck** with **impact-audit → generated-artifact → plan-sync → marketplace-sync** (all propose-only), each writing its validated result into the maintenance PR.
+
+**Steps:**
+- [ ] **Step 1: Tests** — `poll.py` emits due-workflow state for the new sources (mirror the `branch_heads` round-trip tests); the maintenance composition lists every propose/mutate run.
+- [ ] **Step 2: Implement** the poll sources and document the scheduler composition edit; keep triggers propose-only.
+- [ ] **Step 3: Run tests and commit** with `feat: trigger the propose/mutate phases`.
+
+---
+
+### Task 6: End-to-end acceptance and the anti-improvisation guard
+
+**Files:**
+- Create: `lib/pulse/scripts/tests/test_runnable_spine_acceptance.py`
+- Create: `lib/pulse/scripts/tests/test_skills_shell_drivers.py`
+
+**Interfaces:**
+- Acceptance: for each of marketplace-sync, plan-sync, generated-artifact, and the overlay healthcheck, a fixture-driven `trigger → driver → validated result` run (no network), asserting the result validates and the counts match the fixture's expected outcome. Compose the real public functions (the F6/F8 acceptance-test style).
+- **Anti-improvisation guard:** a test asserting that every headless `SKILL.md` that references a propose/mutate library either shells a `uv run …_run.py`/dispatcher driver or is explicitly exempt — i.e. no `SKILL.md` presents a bare `module.func(` contract as its execution path without a driver. This is the regression that keeps the runnable-spine gap from reopening.
+
+**Steps:**
+- [ ] **Step 1: Write the acceptance matrix** across all four phases.
+- [ ] **Step 2: Write the anti-improvisation guard** (grep/AST over `skills/*/SKILL.md`).
+- [ ] **Step 3: Run `uv run pytest -q` + `git diff --check` and commit** with `test: gate the runnable spine end-to-end`.
+
+---
+
+## Phase gate — after F10
+
+- Each of impact (F5), generated-artifact (F7), plan-sync (F8), and marketplace/overlay (F9) runs unattended from a trigger to a validated `result.yaml` with **zero hand-written glue**.
+- The `claude-plugin-v1` overlay scores an opted-in repo with real `pass`/`fail`/`unknown` per check (not `unsupported`); neutral fleet behaviour and the isolation proof are unchanged.
+- The `claude.context` inference step's presence is recorded; its absence grades `unknown`.
+- The scheduler composition invokes every propose/mutate phase; each emits reviewable proposals into the maintenance PR.
+- `pen_orchestrator.execute` gains its first non-test caller **only** in propose-only mode (create/validate/propose locally); pushing/applying remains deferred to the apply-mode phase.
+
+## Explicitly deferred (still gated on separate design)
+
+- **Apply-mode:** executing a recorded proposal (pen push / GitHub write / base advance). Needs Nave + the transformation executor resolvable on PATH in the pen checkout, and a review-and-apply authority model. Its own phase.
+- **F4 dependency-coherence adapters:** Pre-F4 materialised the evidence but the coherence adapter family (P1) was never built; it remains an open read-spine gap independent of F10.

--- a/docs/superpowers/specs/2026-07-22-apply-mode-design.md
+++ b/docs/superpowers/specs/2026-07-22-apply-mode-design.md
@@ -1,0 +1,82 @@
+# Apply-Mode Design: A Repository-Neutral Landing Path
+
+**Date:** 2026-07-22
+**Status:** design / scoping — pre-plan; one open decision flagged in § Design forks.
+**Scope:** The deferred "apply-mode" that F6–F9 (and F10's drivers) all stop short of. What it is, why it is blocked, and — the load-bearing question — whether it is a plugin feature or a general one.
+**Related:** `docs/superpowers/audits/2026-07-22-f-series-runnable-spine-audit.md` (the driver-layer gap), `docs/superpowers/plans/2026-07-22-f10-runnable-spine.md` (makes phases *run*; this makes them *land*), `docs/superpowers/audits/2026-07-13-fleet-scope-audit.md` (the neutral-control-plane mandate this design honors).
+
+---
+
+## 1. The headline: apply-mode is repository-neutral, and must stay that way
+
+The first question to answer, because it governs everything else: **is apply-mode geared toward plugins, or set up for any repository?** The 2026-07-13 fleet-scope audit's mandate was explicit — *"establish a neutral fleet control plane, then attach ecosystem and organization profiles, and finally run the existing plugin/corpus workflows as one dogfood profile."*
+
+Apply-mode is squarely on the neutral side of that line, and the evidence is already in the tree:
+
+- **The apply machinery has zero plugin knowledge.** A proposal is `{id, selection (owner/name…), transformation (registry id), expected_shas, mutation_policy, actor}`. The pen orchestrator, the transformation registry, the expected-SHA guard, the `propose|allow-listed|allow` policy, and the eventual push/PR flow operate on those primitives alone. None of them reads `.claude-plugin/`, `CLAUDE.md`, or `skills/`.
+- **The registry is already 5-of-7 neutral.** `format-python`, `refresh-node-lockfile`, `regenerate-docs-index`, `regenerate-from-template`, and `plan-sync-doc-patch` are repo-agnostic. Only `marketplace-entry-update` and `regenerate-corpus-navigate-skill` are plugin/corpus-specific — and both are **opt-in F9 overlay entries** (`applies_to: profile:claude-plugin`) that merely *use* the neutral apply machinery. Apply-mode does not know or care that they are plugin-related.
+- **`applies_to` is the general applicability grammar** (`always | profile:<id> | capability:<id> | evidence_path:<glob>`), the same one scorecard dispatch uses — not a plugin gate.
+
+So the design principle is inherited, not invented: **apply-mode is a neutral landing path for any registered transformation on any bound repository. Plugin-specific transformations are just registry entries behind a `profile:claude-plugin` predicate — one dogfood profile among many, exactly as the fleet-scope audit prescribed.**
+
+### The neutrality trap to avoid (the audit's real warning)
+
+The fleet-scope audit's sharpest point was not about the mechanics — those are neutral — but about **what gets demonstrated**. A green suite that only exercises the plugin's own `marketplace-entry-update` "can prove the overlay works but cannot prove general fleet behavior." Apply-mode must not fall into that: its acceptance matrix has to land at least one **neutral transformation on a non-plugin repository** (e.g. `refresh-node-lockfile` on a Node repo, `regenerate-docs-index` on a docs repo), with the two overlay transformations as a *separate* dogfood demonstration. Two suites, per the audit — `applies` for neutral repos, plus an opt-in overlay demonstration — and coverage that distinguishes "not applicable" from "not tested."
+
+This also surfaces a neutral executor concern the plugin-only view would miss: neutral transformations need the **target repo's own toolchain** present in the pen (a Python formatter for `format-python`, `npm` for `refresh-node-lockfile`, a docs generator for `regenerate-docs-index`). Apply-mode's executor-delivery story must therefore handle *arbitrary ecosystem tooling*, and treat "required tool absent in this pen" as a fail-closed `blocked`, per ecosystem — not assume a single applier.
+
+---
+
+## 2. What apply-mode is: two paths plus one trust model
+
+Today `pen_orchestrator.execute` blocks any `mutation_policy` other than `propose` before making a single Nave call. The `allow-listed` and `allow` semantics are defined but unimplemented. Apply-mode is the machinery behind them, across two independent paths:
+
+- **Path A — repository-file apply (through a Nave pen).** F7 regeneration, F8 doc patches, F9 corpus/manifest regen. A validated pen exec becomes a commit + a pushed branch + a PR.
+- **Path B — GitHub-object apply (through the `gh` API under `on_mutation`).** F5 marker updates, F8 issue/milestone patches, F9 marketplace-entry patch, F2 profile-metadata commits. A validated proposal becomes a guarded `gh` write.
+
+Both share one **trust model**: registered transformation + `expected_shas`/precondition guard + post-exec validation + `allow_scheduled` gate + attribution. Apply changes *what happens after validation succeeds*, never the gates before it.
+
+---
+
+## 3. Concrete blockers (documented, real)
+
+**B1 — Executor delivery (Path A), generalized.** A transformation's argv must run *inside the target repo's pen checkout*. `regenerate-from-template` calls the installed `nave` CLI and is fine; `plan-sync-doc-patch` runs `apply_doc_patch.py` by a **plugin-repo-relative path that does not resolve in a doc-repo pen** (per `lib/patterns/plan-sync-binding.md`). Apply needs every applier reachable on `PATH` in the checkout — a console entry point or a `nave` subcommand — and, neutrally, needs each ecosystem transformation's tool present or a clean `blocked`.
+
+**B2 — Bound-path enforcement (Path A).** The output allowlist is per-binding *dynamic* (the specific doc/output path) but the F6 registry allowlist and `validation` are *static* (`{kind: none}`), so the bound path is currently **self-attested** by the caller-authored patch descriptor. Apply needs the bound path carried as **immutable proposal metadata the orchestrator enforces**, plus a `validation: {kind: paths_changed, paths:[…]}` kind asserting exactly those paths changed — moving the guard from script-level to orchestrator-level.
+
+**B3 — Confirmation & base advancement (both paths).** F5/F8 bases advance "only after both sides confirm application." A push is not confirmation — a **merge** is. Base/marker advancement must key off the merged commit via a two-phase *propose-PR → detect-merge → advance-base* loop, using the existing run ledger (`resolve_run.py`) for the resumable cross-repo state.
+
+**B4 — Partial-failure independence.** The doc-pen path and the GitHub path fail independently; `finalize` already advances only confirmed values. Apply must preserve that and be resumable.
+
+**B5 — Result contract.** `repo-mutation` (and the object-side results) need `applied`/`pr_opened` states, the PR URL, and the pushed/merged SHA — built from the same `Proposal` that gated execution, never reconstructed.
+
+---
+
+## 4. Design forks
+
+| Fork | Options | Recommendation |
+|---|---|---|
+| **Repo-file apply granularity** | push branch + open PR (human merges) · direct push to branch · auto-merge | **PR-first** — apply = push a branch + open a PR (Path A) / `gh` write (Path B); a human or CI merges; base advances on merge detection. Keeps a review gate and closes the improvisation gap. |
+| **Scheduled auto-apply** | in v1 · deferred | **Defer** — v1 apply is interactive / PR-gated; `allow` (unattended direct push) is a bounded v2 behind `allow_scheduled: true` + a workspace apply policy. |
+| **Executor delivery** | plugin console entry points · `nave` subcommands · Nave injects the applier | **Console entry points**, preferring a `nave` subcommand where one exists (as `regenerate-from-template` already does); each ecosystem tool must be present in the pen or the run is `blocked`. |
+
+> **Open decision (flagged for the author):** the v1 boundary above assumes **PR-first, human-merges, scheduled auto-apply deferred**. That is the recommendation; if you want v1 to push directly or to include scheduled auto-apply, the confirmation model (B3) and the authority model change accordingly, and the phase below re-shapes.
+
+---
+
+## 5. Proposed phase shape — F11 apply-mode
+
+F10 makes phases *run* (propose-only, triggered); **F11 makes them *land***. Task sketch, all under the PR-first recommendation:
+
+- **T1 — Executor on PATH.** Ship plugin appliers (e.g. `apply_doc_patch`) as installed console entry points / `nave` subcommands; registry argv references the installed name, never a repo-relative path. Per-ecosystem "tool absent → `blocked`" handling.
+- **T2 — Orchestrator-enforced bound paths.** Carry `bound_paths` as immutable proposal metadata; add `validation: {kind: paths_changed}`; the orchestrator (not a script) rejects any out-of-allowlist change.
+- **T3 — `allow-listed` commit/push in `pen_orchestrator`.** Implement the reserved policy: on a validated pen, `pen_exec(commit=True, push_changes=True)` to a per-proposal branch; still fail-closed on stale/dirty/validation.
+- **T4 — PR open + merge detection + two-phase base advance.** Pulse opens the PR; a follow-up reconciliation detects the merge and advances the F5/F8 base off the merged SHA via the run ledger. Resumable; partial-application-safe.
+- **T5 — GitHub-object apply under `on_mutation`.** `allow-listed`/`allow` `gh` writes for F5 markers, F8 issue/milestone patches, F9 marketplace entry, precondition-guarded and idempotent.
+- **T6 — Result states + neutral acceptance matrix.** `applied`/`pr_opened` states; acceptance **must** include a neutral transformation on a non-plugin fixture repo, with the overlay transformations demonstrated separately (two-suite discipline). Anti-regression: a test that apply-mode carries no `claude`/`plugin`/`skills`/`SKILL.md`/`CLAUDE.md`/`marketplace` string outside the F9 overlay entries.
+
+## 6. Explicitly deferred / dependent
+
+- **`allow` (unattended direct push) and scheduled auto-apply** — v2, behind an explicit workspace apply policy.
+- **Auto-merge** — out of scope; landing is a reviewed merge.
+- **F4 dependency-coherence apply.** The richest *neutral* apply use-case — bumping a dependency across the fleet and landing the lockfile change — depends on the **unbuilt F4 dependency-coherence adapters**. `refresh-node-lockfile`/`format-python` give apply-mode neutral proof today; fleet-wide coherence apply waits on F4. This dependency is a feature of honest scope, not a blocker for F11.

--- a/docs/superpowers/specs/2026-07-22-apply-mode-design.md
+++ b/docs/superpowers/specs/2026-07-22-apply-mode-design.md
@@ -3,7 +3,7 @@
 **Date:** 2026-07-22
 **Status:** design / scoping — pre-plan; one open decision flagged in § Design forks.
 **Scope:** The deferred "apply-mode" that F6–F9 (and F10's drivers) all stop short of. What it is, why it is blocked, and — the load-bearing question — whether it is a plugin feature or a general one.
-**Related:** `docs/superpowers/audits/2026-07-22-f-series-runnable-spine-audit.md` (the driver-layer gap), `docs/superpowers/plans/2026-07-22-f10-runnable-spine.md` (makes phases *run*; this makes them *land*), `docs/superpowers/audits/2026-07-13-fleet-scope-audit.md` (the neutral-control-plane mandate this design honors).
+**Related:** `docs/backlogs/2026-07-22-f1-f8-phase-deferrals.md` § 1 (the deferrals **index** that first captured apply-mode; this doc is the design that entry points to), `docs/superpowers/audits/2026-07-22-f-series-runnable-spine-audit.md` (the driver-layer gap), `docs/superpowers/plans/2026-07-22-f10-runnable-spine.md` (makes phases *run*; this makes them *land*), `docs/superpowers/audits/2026-07-13-fleet-scope-audit.md` (the neutral-control-plane mandate this design honors).
 
 ---
 


### PR DESCRIPTION
Three cohesive F-series architecture docs, surfaced while dogfooding the F9 overlays live.

## 1. Audit — `docs/superpowers/audits/2026-07-22-f-series-runnable-spine-audit.md`
Every F-phase has three layers: **library → driver (CLI) → skill**. The read/score half (F0–F5) built all three and runs. The propose/mutate half (**F6–F9**) built library + skill but **skipped the driver** — the skills cite function signatures with no `uv run` CLI, so nothing triggers them and every headless run needs improvised glue. `pen_orchestrator.execute` has no caller outside tests.

## 2. Explainer — `docs/f-series-explained.md`
Per-phase reference for F0–F9 (and the deferred F4): what each looks at, detects, and mitigates, plus how it works (skill, Python, Nave, config, persisted evidence). The "what it does" companion to the audit's "what runs".

## 3. F10 plan — `docs/superpowers/plans/2026-07-22-f10-runnable-spine.md`
The remediation: CLI drivers for marketplace-sync / plan-sync / generated-artifact, overlay dispatcher wiring + evidence content channel + inference hook, scheduler composition, and an anti-improvisation guard test. **Propose-only**; apply-mode and the never-built **F4 dependency-coherence adapters** stay explicitly deferred.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)