### PR TITLE
F11: apply-mode — land validated proposals (Path A pen push + PR/merge, Path B object writes)

### DIFF
--- a/lib/patterns/headless-contract.md
+++ b/lib/patterns/headless-contract.md
@@ -17,6 +17,7 @@ retained for human-readable logs only — orchestrators MUST read the file.
 | repo-mutation | repo-mutation-result.yaml | `{workspace_root}/.hiivmind/github/repo-mutation-result.yaml` |
 | generated-artifact | generated-artifact-result.yaml | `{workspace_root}/.hiivmind/github/generated-artifact-result.yaml` |
 | plan-sync | plan-sync-result.yaml | `{workspace_root}/.hiivmind/github/plan-sync-result.yaml` |
+| apply-status | apply-status-result.yaml | `{workspace_root}/.hiivmind/github/apply-status-result.yaml` |
 
 Result files are per-machine transient run artifacts (never authority — see
 `workspace-detection.md` § Multi-machine topology). The workspace repo's
@@ -36,7 +37,7 @@ not kinds they were not asked to validate.
 
 ```yaml
 contract_version: 1                   # int, required
-kind: status | healthcheck | fleet-membership | refresh | workflow-run | impact | repo-mutation | generated-artifact | plan-sync
+kind: status | healthcheck | fleet-membership | refresh | workflow-run | impact | repo-mutation | apply-status | generated-artifact | plan-sync
 workspace: <login>                    # str, required — org/user login
 run_at: <ISO 8601 timestamp>          # str, required
 actor:                                # required on ALL kinds (I4)
@@ -61,6 +62,7 @@ profiles, and machines: identity-sensitive logic resolves against the
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py repo-mutation-result.yaml --kind repo-mutation
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py generated-artifact-result.yaml --kind generated-artifact
     uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py plan-sync-result.yaml --kind plan-sync
+    uv run ${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/validate_result.py apply-status-result.yaml --kind apply-status
 
 Orchestrators validate before consuming and treat exit 1/2 as a failed run
 (report, do not commit). Exit codes: 0 valid, 1 invalid (errors on stderr),
@@ -348,7 +350,35 @@ apply later, never performed by the run itself. `reason` is required
 (non-null) whenever `state` is `blocked` or `failed`, and optional (may be
 null) when `state` is `proposed`.
 
+### apply-status-result.yaml (written by apply reconcile loop, F11)
+
+Carries the persisted apply lifecycle status for a proposal branch.
+
+```yaml
+contract_version: 1
+kind: apply-status
+workspace: <login>
+run_at: <ISO 8601>
+actor: { gh_login: <str>, machine: <str>, mode: <enum> }
+state: pushed | pr_opened | applied | rejected  # required enum — apply lifecycle state
+proposal_id: <str>                  # required — the proposal id
+selection: [<owner/name>, ...]      # list of str, required — targeted repos
+branch: <str>                       # required — branch name (pulse/apply/{proposal_id})
+pushed_sha: <str or null>           # required key, nullable — branch head SHA (required for pushed/pr_opened/applied)
+pr_url: <str or null>               # required key, nullable — pull request URL (required for pr_opened/applied)
+merged_sha: <str or null>           # required key, nullable — merge commit SHA (required for applied)
+reason: <str or null>               # required key, nullable — rejection reason (required for rejected)
+errors: []
+```
+
+Lifecycle states and required fields:
+- `pushed`: branch pushed to remote, no PR open yet. Requires `pushed_sha`. `pr_url` and `merged_sha` are null.
+- `pr_opened`: pull request created. Requires `pushed_sha` and `pr_url`. `merged_sha` is null.
+- `applied`: PR merged into default branch. Requires `pushed_sha`, `pr_url`, and `merged_sha`.
+- `rejected`: PR closed unmerged. Requires `reason` (non-null). `merged_sha` is null.
+
 ### generated-artifact-result.yaml (written by the generation audit, F7)
+
 
 Reports the drift state of committed generated-artifact bindings
 (`templates/generated.yaml.template`). For each binding the audit compares the

--- a/lib/patterns/plan-sync-binding.md
+++ b/lib/patterns/plan-sync-binding.md
@@ -47,19 +47,9 @@ V1 does not synchronize GitHub Projects custom fields, labels, or comments.
 
 F8 is **propose-only** end to end (see the plan's Global Constraints): the doc
 path is proposed as an F6 `plan-sync-doc-patch` repo mutation and the GitHub
-path as a Pulse proposed action, and **neither is ever applied**. One aspect of
-the doc transformation is defined but not yet execution-safe, and
-must be closed before any apply-mode consumer runs `plan-sync-doc-patch`:
+path as a Pulse proposed action, and **neither is ever applied**.
 
-- **Bound-path enforcement.** The transformation's output allowlist is the
-  *per-binding dynamic* document path, but the F6 registry allowlist and
-  `validation` are static — the entry carries `validation: {kind: none}`, and
-  the bound path is currently self-attested by the (caller-authored) patch
-  descriptor. Apply mode needs the bound path carried as immutable proposal
-  metadata that the F6 orchestrator enforces, plus a "this exact path changed"
-  validation kind. `apply_doc_patch.py` already verifies the base-blob match and
-  rejects path escapes, but that is script-level, not orchestrator-level.
-
-These are backlogged as an F6/apply-mode enhancement; they do not affect
-propose-mode correctness (the argv is recorded, never executed; no validation
-runs).
+- **Bound-path enforcement (closed in F11 Task 2).** `plan-sync-doc-patch`
+  proposals carry `bound_paths: {repo: [doc_path]}` as immutable proposal
+  metadata, enforced by `pen_orchestrator.py` via `validation: {kind: paths_changed}`.
+  `apply_doc_patch.py` also verifies base-blob match and rejects path escapes.

--- a/lib/patterns/plan-sync-binding.md
+++ b/lib/patterns/plan-sync-binding.md
@@ -47,15 +47,10 @@ V1 does not synchronize GitHub Projects custom fields, labels, or comments.
 
 F8 is **propose-only** end to end (see the plan's Global Constraints): the doc
 path is proposed as an F6 `plan-sync-doc-patch` repo mutation and the GitHub
-path as a Pulse proposed action, and **neither is ever applied**. Two aspects of
-the doc transformation are therefore defined but not yet execution-safe, and
+path as a Pulse proposed action, and **neither is ever applied**. One aspect of
+the doc transformation is defined but not yet execution-safe, and
 must be closed before any apply-mode consumer runs `plan-sync-doc-patch`:
 
-- **Executor path.** The registered argv runs `apply_doc_patch.py` by a
-  plugin-repo-relative path, which does not resolve inside a doc-repo pen
-  checkout (unlike F7's `regenerate-from-template`, which calls the installed
-  `nave` CLI). Apply mode needs the patch applier reachable on `PATH` in the
-  checkout (an installed console entry point or a `nave` subcommand).
 - **Bound-path enforcement.** The transformation's output allowlist is the
   *per-binding dynamic* document path, but the F6 registry allowlist and
   `validation` are static — the entry carries `validation: {kind: none}`, and

--- a/lib/patterns/repository-mutations.md
+++ b/lib/patterns/repository-mutations.md
@@ -59,11 +59,11 @@ mutations are not a separate policy dialect from GitHub-object mutations:
   other gate below (still requires a registered transformation; still
   blocks on a stale/dirty pen or a validation failure).
 
-> **Current implementation status:** the F6 orchestrator
-> (`pen_orchestrator.execute`) is propose-only — it blocks any policy other
-> than `propose` before making a single Nave call. `allow-listed` and
-> `allow` describe the semantics reserved for a later apply step; until that
-> lands, setting either yields a `blocked` result, never a push.
+> **Current implementation status:** `pen_orchestrator.execute` supports `propose`
+> (propose-only, terminal state `proposed`) and `allow-listed` (Path A apply mode:
+> provision per-proposal branch `pulse/apply/{id}` -> exec -> validate -> commit-all -> push-all ->
+> terminal state `pushed`). `allow` policy remains reserved and blocked in v1.
+
 
 ## The transformation registry
 

--- a/lib/patterns/repository-mutations.md
+++ b/lib/patterns/repository-mutations.md
@@ -133,6 +133,39 @@ and each repo's exec outcome (from `pen_status --json`) into the
 Nothing in that attribution record is inferred or reconstructed after the
 fact — it is built from the same `Proposal` that gated execution.
 
+## Per-proposal branch targeting invariant (C1)
+
+Before any apply step commits or pushes changes, each selected repo clone is
+provisioned onto a dedicated per-proposal branch named `pulse/apply/{proposal_id}`,
+created off its guarded base SHA (`expected_shas[repo]`).
+
+- **Implementation:** `nave_adapter.provision_apply_branch(clone_paths, branch, base_shas)`
+  executes `git -C <clone> checkout -b pulse/apply/{proposal_id} <base_sha>` for each
+  selected repo clone.
+- **Invariant:** Every apply push targets `pulse/apply/{proposal_id}`, never a default
+  or base branch.
+- **Fail-closed:** If branch provisioning fails on any selected repo (e.g. if the branch
+  already exists locally from a previous run or a base SHA is missing), the per-repo status
+  reports `"failed"` with the explicit reason so execution blocks before any push.
+
+## Pen clone reader & clone-root contract (C2)
+
+The `pen_clone_reader` module (`lib/pulse/scripts/pen_clone_reader.py`) exposes real git and
+filesystem readers over local pen clones to satisfy `pen_orchestrator`'s injectable seams:
+- `read_repo_head(repo)` -> SHA string via `git rev-parse HEAD`
+- `read_repo_file(repo, path)` -> file content bytes
+- `read_repo_changed_paths(repo)` -> repo-relative changed paths tuple (modified, added, deleted, untracked)
+
+### Clone-root contract
+- **Source Resolution:** Resolved in priority order via explicit `clone_root` factory argument
+  or the `PULSE_PEN_ROOT` environment variable.
+- **Per-repo Layout:** Selected repo `owner/name` lives at `{clone_root}/{owner}/{name}`.
+- **Fail-closed:** `make_pen_clone_reader(clone_root, selection)` validates the clone root
+  and every selected repo's checkout up front. If `clone_root` is unset or missing, or if any
+  selected repo's checkout path is absent or not a git worktree, `make_pen_clone_reader`
+  raises `PenCloneReaderError` immediately.
+
+
 ## Validation
 
 ```text

--- a/lib/patterns/repository-mutations.md
+++ b/lib/patterns/repository-mutations.md
@@ -28,7 +28,7 @@ subprocess calls, no filesystem writes, no Nave interaction.
 `mutation_plan.build_proposal(...)` constructs and validates a `Proposal`:
 
 ```text
-{id, selection, transformation, expected_shas, mutation_policy, actor}
+{id, selection, transformation, expected_shas, mutation_policy, actor, bound_paths}
 ```
 
 | Field | Shape | Meaning |
@@ -39,6 +39,7 @@ subprocess calls, no filesystem writes, no Nave interaction.
 | `expected_shas` | dict `owner/name -> sha` | The expected-base guard: keys must be **exactly** `selection`, no more, no fewer. The orchestrator (Task 3) compares this against each repo's current SHA before executing and blocks on any mismatch — a stale base is never silently mutated. Since no Nave surface exposes a per-repo SHA, this comparison runs through an injectable `read_repo_head` reader `execute` accepts (same seam pattern as `read_repo_file`); with `expected_shas` non-empty and no reader supplied, verification fails closed. |
 | `mutation_policy` | one of `propose`, `allow-listed`, `allow` | See below. Default: `propose`. |
 | `actor` | `{gh_login, machine, mode}` | Same shape as the headless result contract's `actor:` block (`lib/patterns/headless-contract.md`); `mode` is `interactive` or `scheduled`. |
+| `bound_paths` | dict `owner/name -> tuple[str, ...]` | Immutable proposal metadata: per-repo allowlist of exact repo-relative paths or globs (`*`, `**`) this proposal is permitted to change. When the transformation's validation kind is `paths_changed`, keys must cover `selection` exactly (no uncovered repo, no extra repo). |
 
 ### `mutation_policy` values
 
@@ -79,7 +80,7 @@ mutations are not a separate policy dialect from GitHub-object mutations:
 | `id` | string, must match its registry key | The transformation ID proposals reference. |
 | `command_argv` | non-empty list of plain strings | The **exact** argv passed to `nave_adapter.pen_exec` after `--`. No nested structures (lists/dicts as elements are rejected), no booleans. |
 | `applies_to` | non-empty list of predicates | OR-matched repository eligibility, in the same grammar `profile_dispatch.py` uses for scorecard-check applicability: `always`, `profile:<id>`, `capability:<id>`, `evidence_path:<glob>`. `mutation_plan.transformation_applies(entry, profiles, capabilities, evidence_paths)` evaluates it. |
-| `validation` | `{kind: none \| json_schema, ...}` | Post-execution check the orchestrator runs after `pen_exec` succeeds. `kind: none` takes no extra fields. `kind: json_schema` requires `path` (repo-relative file the transformation is expected to produce/modify) and `schema` (inline JSON Schema mapping the file's parsed content must satisfy). A validation failure is a `blocked`/`failed` outcome, never a silent pass. |
+| `validation` | `{kind: none \| json_schema \| paths_changed, ...}` | Post-execution check the orchestrator runs after `pen_exec` succeeds. `kind: none` and `kind: paths_changed` take no extra fields in the registry (`paths_changed` bounds live on the proposal's `bound_paths`). `kind: json_schema` requires `path` and `schema`. `kind: paths_changed` asserts post-exec that the set of changed paths in each repo matches that repo's `bound_paths` (every changed path must match an exact/glob bound entry, every exact bound entry must change, and changed set must be non-empty). |
 | `allow_scheduled` | boolean | Whether this transformation may run under `actor.mode: scheduled`. Interactive-only transformations (destructive, judgment-requiring, or simply not yet trusted unattended) set this `false`. |
 
 ### No shell strings, ever

--- a/lib/patterns/run-ledger.md
+++ b/lib/patterns/run-ledger.md
@@ -96,9 +96,18 @@ state. `check-gate` is for gates a registered evaluator can compute
 deterministically from an already-validated result file — e.g.
 `binding_edges_current` (F5) reads an `impact-result.yaml` and is satisfied
 only when it validates as kind `impact` with `edges_stale == 0` and no edge
-in state `unknown`. New evaluators register by name in `resolve_run.py`'s
-`GATE_EVALUATORS`; `--gate-type` naming an evaluator that isn't registered is
-a usage error (exit 1), never silently treated as satisfied.
+in state `unknown`; `merge_detected` (F11) reads an `apply-status` file and is
+satisfied only when it validates as kind `apply-status`, state is `applied`,
+and `merged_sha` is present.
+
+If a PR is observed `CLOSED` without merging during reconcile, the apply-status
+file is written at state `rejected`, the step status is marked `failed` (I3),
+and the remote branch is deleted; the overall run transitions to `failed` rather
+than blocking forever on gate.
+
+New evaluators register by name in `resolve_run.py`'s `GATE_EVALUATORS`;
+`--gate-type` naming an evaluator that isn't registered is a usage error
+(exit 1), never silently treated as satisfied.
 
 Exit codes: 0 ok, 1 validation/state error, 2 file missing/unparseable,
 3 lease actively held by someone else.

--- a/lib/pulse/scripts/apply_doc_patch_entry.py
+++ b/lib/pulse/scripts/apply_doc_patch_entry.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["ruamel.yaml>=0.18.0"]
+# ///
+"""Console entry point for pulse-apply-doc-patch.
+
+Wraps lib.pulse.scripts.apply_doc_patch so the applier can be installed on PATH
+and executed regardless of the target checkout directory.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+# Ensure plugin root is in sys.path when invoked directly or via entry point
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+from lib.pulse.scripts.apply_doc_patch import main as _apply_doc_patch_main  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> int:
+    return _apply_doc_patch_main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/pulse/scripts/apply_marketplace_entry.py
+++ b/lib/pulse/scripts/apply_marketplace_entry.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["ruamel.yaml>=0.18.0"]
+# ///
+"""Apply one guarded marketplace entry patch from a pen checkout.
+
+The variable patch content lives in a well-known file rather than command
+arguments.  This script only writes after the target's Git blob hash matches
+the patch's recorded base, so a stale checkout cannot overwrite newer work.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+from ruamel.yaml import YAML
+
+
+_PLUGIN_ROOT = Path(__file__).resolve().parents[3]
+if str(_PLUGIN_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PLUGIN_ROOT))
+
+
+def _blob_sha(content: bytes) -> str:
+    return hashlib.sha1(f"blob {len(content)}\0".encode() + content).hexdigest()
+
+
+def _relative_path(value: Any, label: str) -> Path:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{label} must be a non-empty relative path")
+    path = Path(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{label} must be a safe relative path")
+    return path
+
+
+def _mapping(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a mapping")
+    return value
+
+
+def apply_marketplace_patch_file(patch_file: Path, checkout: Path) -> None:
+    yaml = YAML(typ="safe")
+    try:
+        patch = _mapping(yaml.load(patch_file.read_text()), "patch")
+    except FileNotFoundError as exc:
+        raise ValueError(f"patch file not found: {patch_file}") from exc
+
+    path = _relative_path(patch.get("path"), "patch.path")
+    output_paths = patch.get("output_paths")
+    if not isinstance(output_paths, list) or not output_paths:
+        raise ValueError("patch.output_paths must be a non-empty list")
+    allowed_paths = {
+        str(_relative_path(output_path, "patch.output_paths entry"))
+        for output_path in output_paths
+    }
+    if str(path) not in allowed_paths:
+        raise ValueError(f"document is outside the output allowlist: {path}")
+
+    target = (checkout / path).resolve()
+    try:
+        target.relative_to(checkout.resolve())
+    except ValueError as exc:
+        raise ValueError("patch.path escapes the checkout") from exc
+    if not target.is_file():
+        raise ValueError(f"document not found: {path}")
+
+    base_blob = patch.get("base_blob")
+    if not isinstance(base_blob, str) or not base_blob:
+        raise ValueError("patch.base_blob must be a non-empty string")
+    original_bytes = target.read_bytes()
+    if _blob_sha(original_bytes) != base_blob:
+        raise ValueError(f"base blob mismatch for document: {path}")
+
+    try:
+        original_text = original_bytes.decode()
+    except UnicodeDecodeError as exc:
+        raise ValueError(f"document is not UTF-8: {path}") from exc
+
+    if "content" in patch:
+        new_content = str(patch["content"])
+    elif "entry_patch" in patch or "plugin_patch" in patch:
+        entry_patch = patch.get("entry_patch") or patch.get("plugin_patch")
+        if not isinstance(entry_patch, dict):
+            raise ValueError("patch.entry_patch must be a mapping")
+
+        # Handle JSON or YAML target document
+        try:
+            doc_data = json.loads(original_text)
+        except json.JSONDecodeError:
+            doc_data = yaml.load(original_text)
+
+        plugin_name = entry_patch.get("name") or entry_patch.get("plugin_id")
+        if not plugin_name:
+            raise ValueError("entry_patch must contain 'name' or 'plugin_id'")
+
+        if isinstance(doc_data, dict) and isinstance(doc_data.get("plugins"), list):
+            found = False
+            for plugin in doc_data["plugins"]:
+                if isinstance(plugin, dict) and plugin.get("name") == plugin_name:
+                    plugin.update({k: v for k, v in entry_patch.items() if k not in ("plugin_id",)})
+                    found = True
+                    break
+            if not found:
+                doc_data["plugins"].append({k: v for k, v in entry_patch.items() if k not in ("plugin_id",)})
+        else:
+            raise ValueError("target document structure does not match marketplace schema")
+
+        if path.name.endswith(".json"):
+            new_content = json.dumps(doc_data, indent=2) + "\n"
+        else:
+            stream = io.StringIO()
+            yaml.dump(doc_data, stream)
+            new_content = stream.getvalue()
+    else:
+        raise ValueError("patch must contain 'content' or 'entry_patch'")
+
+    target.write_text(new_content)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--patch", default=".hiivmind/marketplace-entry-patch.yaml")
+    args = parser.parse_args(argv)
+    checkout = Path.cwd().resolve()
+    try:
+        apply_marketplace_patch_file(checkout / _relative_path(args.patch, "--patch"), checkout)
+    except (OSError, UnicodeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/pulse/scripts/apply_marketplace_entry.py
+++ b/lib/pulse/scripts/apply_marketplace_entry.py
@@ -46,6 +46,12 @@ def _mapping(value: Any, label: str) -> dict[str, Any]:
     return value
 
 
+def _string(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value
+
+
 def apply_marketplace_patch_file(patch_file: Path, checkout: Path) -> None:
     yaml = YAML(typ="safe")
     try:
@@ -86,30 +92,24 @@ def apply_marketplace_patch_file(patch_file: Path, checkout: Path) -> None:
 
     if "content" in patch:
         new_content = str(patch["content"])
-    elif "entry_patch" in patch or "plugin_patch" in patch:
-        entry_patch = patch.get("entry_patch") or patch.get("plugin_patch")
-        if not isinstance(entry_patch, dict):
-            raise ValueError("patch.entry_patch must be a mapping")
+    elif "entry_patch" in patch:
+        entry_patch = _mapping(patch.get("entry_patch"), "patch.entry_patch")
+        plugin_name = _string(entry_patch.get("name"), "entry_patch.name")
 
-        # Handle JSON or YAML target document
         try:
             doc_data = json.loads(original_text)
         except json.JSONDecodeError:
             doc_data = yaml.load(original_text)
 
-        plugin_name = entry_patch.get("name") or entry_patch.get("plugin_id")
-        if not plugin_name:
-            raise ValueError("entry_patch must contain 'name' or 'plugin_id'")
-
         if isinstance(doc_data, dict) and isinstance(doc_data.get("plugins"), list):
             found = False
             for plugin in doc_data["plugins"]:
                 if isinstance(plugin, dict) and plugin.get("name") == plugin_name:
-                    plugin.update({k: v for k, v in entry_patch.items() if k not in ("plugin_id",)})
+                    plugin.update(entry_patch)
                     found = True
                     break
             if not found:
-                doc_data["plugins"].append({k: v for k, v in entry_patch.items() if k not in ("plugin_id",)})
+                doc_data["plugins"].append(dict(entry_patch))
         else:
             raise ValueError("target document structure does not match marketplace schema")
 

--- a/lib/pulse/scripts/apply_reconcile.py
+++ b/lib/pulse/scripts/apply_reconcile.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Resumable reconcile loop turning a pushed branch into a landed change (F11 Task 6).
+
+Open PR -> detect merge -> advance base.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+import yaml
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from lib.pulse.scripts import resolve_run  # noqa: E402
+from lib.pulse.scripts import validate_result  # noqa: E402
+
+
+class GhOps:
+    """Interface for GitHub CLI operations (injected for testing)."""
+
+    def create_or_get_pr(
+        self, repo: str, branch: str, base: str, title: str, body: str
+    ) -> dict:
+        """Return {"url": str, "created": bool}."""
+        raise NotImplementedError
+
+    def view_pr(self, repo: str, branch: str) -> dict:
+        """Return {"state": "OPEN"|"MERGED"|"CLOSED", "merged": bool, "merge_commit_sha": str|None, "url": str}."""
+        raise NotImplementedError
+
+    def delete_remote_branch(self, repo: str, branch: str) -> dict:
+        """Return {"state": "ok"|"failed", "reason": str|None}."""
+        raise NotImplementedError
+
+
+class GhCliOps(GhOps):
+    """Production implementation of GhOps calling `gh` CLI."""
+
+    def __init__(self, gh_binary: str = "gh") -> None:
+        self.gh_binary = gh_binary
+
+    def create_or_get_pr(
+        self, repo: str, branch: str, base: str, title: str, body: str
+    ) -> dict:
+        existing = self.view_pr(repo, branch)
+        if existing.get("url") and existing.get("state") == "OPEN":
+            return {"url": existing["url"], "created": False}
+
+        cmd = [
+            self.gh_binary,
+            "pr",
+            "create",
+            "-R",
+            repo,
+            "--head",
+            branch,
+            "--base",
+            base,
+            "--title",
+            title,
+            "--body",
+            body,
+        ]
+        res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if res.returncode == 0:
+            url = res.stdout.strip()
+            return {"url": url, "created": True}
+
+        existing = self.view_pr(repo, branch)
+        if existing.get("url"):
+            return {"url": existing["url"], "created": False}
+        raise RuntimeError(
+            f"gh pr create failed for {repo} {branch}: {res.stderr.strip()}"
+        )
+
+    def view_pr(self, repo: str, branch: str) -> dict:
+        cmd = [
+            self.gh_binary,
+            "pr",
+            "view",
+            branch,
+            "-R",
+            repo,
+            "--json",
+            "state,mergedAt,mergeCommit,url",
+        ]
+        res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if res.returncode != 0:
+            return {
+                "state": "CLOSED",
+                "merged": False,
+                "merge_commit_sha": None,
+                "url": "",
+            }
+        try:
+            data = json.loads(res.stdout)
+        except json.JSONDecodeError:
+            return {
+                "state": "CLOSED",
+                "merged": False,
+                "merge_commit_sha": None,
+                "url": "",
+            }
+        state = data.get("state", "CLOSED").upper()
+        merged_at = data.get("mergedAt")
+        merge_commit = data.get("mergeCommit")
+        merge_commit_sha = (
+            merge_commit.get("oid")
+            if isinstance(merge_commit, dict)
+            else (merge_commit if isinstance(merge_commit, str) else None)
+        )
+        merged = bool(merged_at) or state == "MERGED"
+        return {
+            "state": "MERGED" if merged else state,
+            "merged": merged,
+            "merge_commit_sha": merge_commit_sha if merged else None,
+            "url": data.get("url", ""),
+        }
+
+    def delete_remote_branch(self, repo: str, branch: str) -> dict:
+        cmd = [
+            self.gh_binary,
+            "api",
+            "-X",
+            "DELETE",
+            f"repos/{repo}/git/refs/heads/{branch}",
+        ]
+        res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if res.returncode == 0:
+            return {"state": "ok"}
+        return {"state": "failed", "reason": res.stderr.strip()}
+
+
+def load_apply_status(path: str | Path) -> dict | None:
+    p = Path(path)
+    if not p.exists():
+        return None
+    try:
+        data = yaml.safe_load(p.read_text())
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        pass
+    return None
+
+
+def write_apply_status(
+    path: str | Path,
+    *,
+    proposal_id: str,
+    repo: str,
+    branch: str,
+    state: str,
+    pushed_sha: str | None = None,
+    pr_url: str | None = None,
+    merged_sha: str | None = None,
+    reason: str | None = None,
+    workspace: str = "unknown",
+    actor: dict | None = None,
+    errors: list[str] | None = None,
+) -> dict:
+    if actor is None:
+        actor = {"gh_login": "unknown", "machine": "unknown", "mode": "interactive"}
+    doc = {
+        "contract_version": 1,
+        "kind": "apply-status",
+        "workspace": workspace,
+        "run_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "actor": actor,
+        "errors": errors or [],
+        "proposal_id": proposal_id,
+        "selection": [repo],
+        "branch": branch,
+        "state": state,
+        "pushed_sha": pushed_sha,
+        "pr_url": pr_url,
+        "merged_sha": merged_sha,
+        "reason": reason,
+    }
+    validation_errors = validate_result.validate(doc, "apply-status")
+    if validation_errors:
+        raise ValueError(
+            f"Invalid apply-status document: {'; '.join(validation_errors)}"
+        )
+
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(yaml.safe_dump(doc, sort_keys=False))
+    return doc
+
+
+def open_apply_pr(
+    *,
+    ledger_path: str | Path,
+    step_id: str,
+    proposal_id: str,
+    repo: str,
+    branch: str,
+    base: str,
+    pushed_sha: str,
+    title: str,
+    body: str,
+    result_path: str | Path,
+    gh_ops: GhOps,
+    actor_id: str = "octocat@mba-m4",
+    workspace: str = "unknown",
+) -> dict:
+    resolve_run.acquire_lease(ledger_path, step_id, actor_id)
+
+    existing = load_apply_status(result_path)
+    if existing and existing.get("state") in {"pr_opened", "applied", "rejected"}:
+        return existing
+
+    pr_info = gh_ops.create_or_get_pr(
+        repo=repo, branch=branch, base=base, title=title, body=body
+    )
+    pr_url = pr_info["url"]
+
+    actor_parts = actor_id.split("@", 1)
+    login = actor_parts[0]
+    machine = actor_parts[1] if len(actor_parts) > 1 else ""
+    actor_doc = {"gh_login": login, "machine": machine, "mode": "interactive"}
+
+    doc = write_apply_status(
+        result_path,
+        proposal_id=proposal_id,
+        repo=repo,
+        branch=branch,
+        state="pr_opened",
+        pushed_sha=pushed_sha,
+        pr_url=pr_url,
+        workspace=workspace,
+        actor=actor_doc,
+    )
+
+    ledger_doc = resolve_run.load(ledger_path)
+    step = resolve_run.find_step(ledger_doc, step_id)
+    step["status"] = "blocked-on-gate"
+    step["notes"].append(f"{resolve_run.now_iso()} PR opened: {pr_url}")
+    resolve_run.recompute_status(ledger_doc)
+    resolve_run.save(ledger_path, ledger_doc)
+
+    return doc
+
+
+def reconcile_apply(
+    *,
+    ledger_path: str | Path,
+    step_id: str,
+    proposal_id: str,
+    repo: str,
+    branch: str,
+    result_path: str | Path,
+    gh_ops: GhOps,
+    advance_base: Callable[[str, str], dict] | None = None,
+    actor_id: str = "octocat@mba-m4",
+    workspace: str = "unknown",
+) -> dict:
+    resolve_run.acquire_lease(ledger_path, step_id, actor_id)
+
+    existing = load_apply_status(result_path)
+    if existing:
+        ex_state = existing.get("state")
+        if ex_state == "applied":
+            ledger_doc = resolve_run.load(ledger_path)
+            step = resolve_run.find_step(ledger_doc, step_id)
+            if step["status"] != "done":
+                step["status"] = "done"
+                resolve_run.recompute_status(ledger_doc)
+                resolve_run.save(ledger_path, ledger_doc)
+            return existing
+        elif ex_state == "rejected":
+            ledger_doc = resolve_run.load(ledger_path)
+            step = resolve_run.find_step(ledger_doc, step_id)
+            if step["status"] != "failed":
+                step["status"] = "failed"
+                resolve_run.recompute_status(ledger_doc)
+                resolve_run.save(ledger_path, ledger_doc)
+            return existing
+
+    pr_info = gh_ops.view_pr(repo=repo, branch=branch)
+    actor_parts = actor_id.split("@", 1)
+    login = actor_parts[0]
+    machine = actor_parts[1] if len(actor_parts) > 1 else ""
+    actor_doc = {"gh_login": login, "machine": machine, "mode": "interactive"}
+
+    pushed_sha = existing.get("pushed_sha") if existing else None
+    pr_url = pr_info.get("url") or (existing.get("pr_url") if existing else None)
+
+    if pr_info.get("merged") and pr_info.get("merge_commit_sha"):
+        merged_sha = pr_info["merge_commit_sha"]
+        doc = write_apply_status(
+            result_path,
+            proposal_id=proposal_id,
+            repo=repo,
+            branch=branch,
+            state="applied",
+            pushed_sha=pushed_sha or "unknown",
+            pr_url=pr_url or "",
+            merged_sha=merged_sha,
+            workspace=workspace,
+            actor=actor_doc,
+        )
+
+        satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
+        if satisfied:
+            if advance_base is not None:
+                advance_base(repo, merged_sha)
+
+            ledger_doc = resolve_run.load(ledger_path)
+            step = resolve_run.find_step(ledger_doc, step_id)
+            resolve_run._apply_gate_result(step, True, detail)
+            step["status"] = "done"
+            resolve_run.recompute_status(ledger_doc)
+            resolve_run.save(ledger_path, ledger_doc)
+
+        return doc
+
+    elif pr_info.get("state") == "CLOSED" and not pr_info.get("merged"):
+        reason = "PR closed without merging"
+        doc = write_apply_status(
+            result_path,
+            proposal_id=proposal_id,
+            repo=repo,
+            branch=branch,
+            state="rejected",
+            pushed_sha=pushed_sha,
+            pr_url=pr_url,
+            reason=reason,
+            workspace=workspace,
+            actor=actor_doc,
+        )
+
+        gh_ops.delete_remote_branch(repo, branch)
+
+        ledger_doc = resolve_run.load(ledger_path)
+        step = resolve_run.find_step(ledger_doc, step_id)
+        step["status"] = "failed"
+        step["notes"].append(f"{resolve_run.now_iso()} {reason}; deleted branch {branch}")
+        resolve_run.recompute_status(ledger_doc)
+        resolve_run.save(ledger_path, ledger_doc)
+
+        return doc
+
+    else:
+        ledger_doc = resolve_run.load(ledger_path)
+        step = resolve_run.find_step(ledger_doc, step_id)
+        step["status"] = "blocked-on-gate"
+        resolve_run.recompute_status(ledger_doc)
+        resolve_run.save(ledger_path, ledger_doc)
+
+        if existing:
+            return existing
+        else:
+            return write_apply_status(
+                result_path,
+                proposal_id=proposal_id,
+                repo=repo,
+                branch=branch,
+                state="pr_opened",
+                pushed_sha=pushed_sha or "unknown",
+                pr_url=pr_url or "",
+                workspace=workspace,
+                actor=actor_doc,
+            )
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Apply reconcile operations")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    o = sub.add_parser("open-pr")
+    o.add_argument("--ledger", required=True)
+    o.add_argument("--step", required=True)
+    o.add_argument("--proposal-id", required=True)
+    o.add_argument("--repo", required=True)
+    o.add_argument("--branch", required=True)
+    o.add_argument("--base", default="main")
+    o.add_argument("--pushed-sha", required=True)
+    o.add_argument("--title", required=True)
+    o.add_argument("--body", default="")
+    o.add_argument("--result", required=True)
+    o.add_argument("--actor", default="unknown@unknown")
+    o.add_argument("--workspace", default="unknown")
+
+    r = sub.add_parser("reconcile")
+    r.add_argument("--ledger", required=True)
+    r.add_argument("--step", required=True)
+    r.add_argument("--proposal-id", required=True)
+    r.add_argument("--repo", required=True)
+    r.add_argument("--branch", required=True)
+    r.add_argument("--result", required=True)
+    r.add_argument("--actor", default="unknown@unknown")
+    r.add_argument("--workspace", default="unknown")
+
+    args = parser.parse_args()
+    gh_ops = GhCliOps()
+
+    if args.cmd == "open-pr":
+        doc = open_apply_pr(
+            ledger_path=args.ledger,
+            step_id=args.step,
+            proposal_id=args.proposal_id,
+            repo=args.repo,
+            branch=args.branch,
+            base=args.base,
+            pushed_sha=args.pushed_sha,
+            title=args.title,
+            body=args.body,
+            result_path=args.result,
+            gh_ops=gh_ops,
+            actor_id=args.actor,
+            workspace=args.workspace,
+        )
+        print(json.dumps(doc))
+
+    elif args.cmd == "reconcile":
+        doc = reconcile_apply(
+            ledger_path=args.ledger,
+            step_id=args.step,
+            proposal_id=args.proposal_id,
+            repo=args.repo,
+            branch=args.branch,
+            result_path=args.result,
+            gh_ops=gh_ops,
+            actor_id=args.actor,
+            workspace=args.workspace,
+        )
+        print(json.dumps(doc))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/pulse/scripts/apply_reconcile.py
+++ b/lib/pulse/scripts/apply_reconcile.py
@@ -36,7 +36,7 @@ class GhOps:
         raise NotImplementedError
 
     def view_pr(self, repo: str, branch: str) -> dict:
-        """Return {"state": "OPEN"|"MERGED"|"CLOSED", "merged": bool, "merge_commit_sha": str|None, "url": str}."""
+        """Return {"state": "OPEN"|"MERGED"|"CLOSED"|"ERROR", "merged": bool, "merge_commit_sha": str|None, "url": str, "error"?: str}."""
         raise NotImplementedError
 
     def delete_remote_branch(self, repo: str, branch: str) -> dict:
@@ -98,19 +98,21 @@ class GhCliOps(GhOps):
         res = subprocess.run(cmd, capture_output=True, text=True, check=False)
         if res.returncode != 0:
             return {
-                "state": "CLOSED",
+                "state": "ERROR",
                 "merged": False,
                 "merge_commit_sha": None,
                 "url": "",
+                "error": res.stderr.strip() or f"gh pr view exit code {res.returncode}",
             }
         try:
             data = json.loads(res.stdout)
-        except json.JSONDecodeError:
+        except json.JSONDecodeError as exc:
             return {
-                "state": "CLOSED",
+                "state": "ERROR",
                 "merged": False,
                 "merge_commit_sha": None,
                 "url": "",
+                "error": f"unparseable JSON from gh pr view: {exc.msg}",
             }
         state = data.get("state", "CLOSED").upper()
         merged_at = data.get("mergedAt")
@@ -267,6 +269,14 @@ def reconcile_apply(
     actor_id: str = "octocat@mba-m4",
     workspace: str = "unknown",
 ) -> dict:
+    """Reconcile a pushed apply branch against remote PR state and advance base off merged SHA.
+
+    Note on bare CLI vs Python API: When advance_base is None (e.g. bare CLI execution
+    via main()), base advancement is deferred to the caller driver, and reconcile_apply
+    marks the step done once merge is detected. When advance_base is provided, base
+    advancement must be idempotent, and the step is marked done ONLY after advance_base
+    returns {"state": "ok"}.
+    """
     resolve_run.acquire_lease(ledger_path, step_id, actor_id)
 
     existing = load_apply_status(result_path)
@@ -275,11 +285,9 @@ def reconcile_apply(
         if ex_state == "applied":
             ledger_doc = resolve_run.load(ledger_path)
             step = resolve_run.find_step(ledger_doc, step_id)
-            if step["status"] != "done":
-                step["status"] = "done"
-                resolve_run.recompute_status(ledger_doc)
-                resolve_run.save(ledger_path, ledger_doc)
-            return existing
+            if step["status"] == "done":
+                return existing
+            # If step is NOT done, fall through to re-run advancement path below.
         elif ex_state == "rejected":
             ledger_doc = resolve_run.load(ledger_path)
             step = resolve_run.find_step(ledger_doc, step_id)
@@ -289,7 +297,16 @@ def reconcile_apply(
                 resolve_run.save(ledger_path, ledger_doc)
             return existing
 
-    pr_info = gh_ops.view_pr(repo=repo, branch=branch)
+    if existing and existing.get("state") == "applied":
+        pr_info = {
+            "state": "MERGED",
+            "merged": True,
+            "merge_commit_sha": existing.get("merged_sha"),
+            "url": existing.get("pr_url", ""),
+        }
+    else:
+        pr_info = gh_ops.view_pr(repo=repo, branch=branch)
+
     actor_parts = actor_id.split("@", 1)
     login = actor_parts[0]
     machine = actor_parts[1] if len(actor_parts) > 1 else ""
@@ -300,30 +317,55 @@ def reconcile_apply(
 
     if pr_info.get("merged") and pr_info.get("merge_commit_sha"):
         merged_sha = pr_info["merge_commit_sha"]
-        doc = write_apply_status(
-            result_path,
-            proposal_id=proposal_id,
-            repo=repo,
-            branch=branch,
-            state="applied",
-            pushed_sha=pushed_sha or "unknown",
-            pr_url=pr_url or "",
-            merged_sha=merged_sha,
-            workspace=workspace,
-            actor=actor_doc,
-        )
+        if not (existing and existing.get("state") == "applied"):
+            doc = write_apply_status(
+                result_path,
+                proposal_id=proposal_id,
+                repo=repo,
+                branch=branch,
+                state="applied",
+                pushed_sha=pushed_sha or "unknown",
+                pr_url=pr_url or "",
+                merged_sha=merged_sha,
+                workspace=workspace,
+                actor=actor_doc,
+            )
+        else:
+            doc = existing
 
         satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
         if satisfied:
-            if advance_base is not None:
-                advance_base(repo, merged_sha)
-
-            ledger_doc = resolve_run.load(ledger_path)
-            step = resolve_run.find_step(ledger_doc, step_id)
-            resolve_run._apply_gate_result(step, True, detail)
-            step["status"] = "done"
-            resolve_run.recompute_status(ledger_doc)
-            resolve_run.save(ledger_path, ledger_doc)
+            if advance_base is None:
+                ledger_doc = resolve_run.load(ledger_path)
+                step = resolve_run.find_step(ledger_doc, step_id)
+                resolve_run._apply_gate_result(step, True, detail)
+                step["status"] = "done"
+                step["notes"].append(
+                    f"{resolve_run.now_iso()} Merge detected; base advance deferred to caller driver"
+                )
+                resolve_run.recompute_status(ledger_doc)
+                resolve_run.save(ledger_path, ledger_doc)
+            else:
+                adv_res = advance_base(repo, merged_sha)
+                ledger_doc = resolve_run.load(ledger_path)
+                step = resolve_run.find_step(ledger_doc, step_id)
+                if isinstance(adv_res, dict) and adv_res.get("state") == "ok":
+                    resolve_run._apply_gate_result(step, True, detail)
+                    step["status"] = "done"
+                    resolve_run.recompute_status(ledger_doc)
+                    resolve_run.save(ledger_path, ledger_doc)
+                else:
+                    reason = (
+                        adv_res.get("reason", "unknown error")
+                        if isinstance(adv_res, dict)
+                        else "unknown error"
+                    )
+                    step["status"] = "blocked-on-gate"
+                    step["notes"].append(
+                        f"{resolve_run.now_iso()} base advance failed: {reason}"
+                    )
+                    resolve_run.recompute_status(ledger_doc)
+                    resolve_run.save(ledger_path, ledger_doc)
 
         return doc
 
@@ -347,7 +389,9 @@ def reconcile_apply(
         ledger_doc = resolve_run.load(ledger_path)
         step = resolve_run.find_step(ledger_doc, step_id)
         step["status"] = "failed"
-        step["notes"].append(f"{resolve_run.now_iso()} {reason}; deleted branch {branch}")
+        step["notes"].append(
+            f"{resolve_run.now_iso()} {reason}; deleted branch {branch}"
+        )
         resolve_run.recompute_status(ledger_doc)
         resolve_run.save(ledger_path, ledger_doc)
 
@@ -357,6 +401,11 @@ def reconcile_apply(
         ledger_doc = resolve_run.load(ledger_path)
         step = resolve_run.find_step(ledger_doc, step_id)
         step["status"] = "blocked-on-gate"
+        if pr_info.get("state") == "ERROR":
+            err_detail = pr_info.get("error", "unknown gh error")
+            step["notes"].append(
+                f"{resolve_run.now_iso()} gh view_pr error: {err_detail}"
+            )
         resolve_run.recompute_status(ledger_doc)
         resolve_run.save(ledger_path, ledger_doc)
 

--- a/lib/pulse/scripts/executor_probe.py
+++ b/lib/pulse/scripts/executor_probe.py
@@ -1,0 +1,70 @@
+"""Executor on PATH probe helper and command_argv safety linter."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from typing import Any
+
+from lib.pulse.scripts.mutation_plan import MutationPlanError
+
+
+KNOWN_CONSOLE_SCRIPTS = {
+    "pulse-apply-doc-patch",
+    "pulse-apply-marketplace-entry",
+}
+
+ECOSYSTEM_MAP = {
+    "ruff": "python",
+    "npm": "nodejs",
+    "mkdocs": "docs",
+    "nave": "nave",
+    "pulse-apply-doc-patch": "plan-sync",
+    "pulse-apply-marketplace-entry": "marketplace",
+}
+
+
+def validate_command_argv(command_argv: tuple[str, ...] | list[str], entry_id: str = "") -> None:
+    """Scan every element of command_argv for repo-relative script paths.
+
+    Every element must be resolvable on PATH or a bare argument/command.
+    Repo-relative script paths (e.g. `lib/pulse/scripts/apply_doc_patch.py` or
+    `foo/bar.py`) are rejected at any position.
+    """
+    prefix = f"transformation {entry_id}." if entry_id else ""
+    for index, arg in enumerate(command_argv):
+        if not isinstance(arg, str):
+            continue
+        # Flag any element that is a repo-relative python script path
+        if arg.endswith(".py") or (("lib/" in arg or "scripts/" in arg or "/" in arg) and arg.endswith(".py")):
+            raise MutationPlanError(
+                f"{prefix}command_argv[{index}] is a repo-relative script path, not reachable on PATH: {arg!r}"
+            )
+
+
+def probe_required_tool(tool: str, ecosystem: str | None = None, path_env: str | None = None) -> dict[str, Any]:
+    """Probe presence of a required executable tool on PATH before execution.
+
+    If absent, returns a fail-closed `blocked`-shaped dictionary naming the
+    missing tool and ecosystem.
+    """
+    resolved_ecosystem = ecosystem or ECOSYSTEM_MAP.get(tool, "unknown")
+    # Check PATH using shutil.which
+    found = shutil.which(tool, path=path_env)
+    if not found and tool in KNOWN_CONSOLE_SCRIPTS:
+        # Also check if installed in Python environment's bin/scripts dir
+        bin_dir = sys.exec_prefix + "/bin"
+        found = shutil.which(tool, path=bin_dir) or shutil.which(tool, path=path_env)
+
+    if not found:
+        return {
+            "state": "blocked",
+            "reason": f"required tool {tool!r} for ecosystem {resolved_ecosystem!r} is absent from PATH",
+            "missing_tool": tool,
+            "ecosystem": resolved_ecosystem,
+        }
+    return {
+        "state": "ok",
+        "tool": tool,
+        "ecosystem": resolved_ecosystem,
+    }

--- a/lib/pulse/scripts/executor_probe.py
+++ b/lib/pulse/scripts/executor_probe.py
@@ -3,10 +3,8 @@
 from __future__ import annotations
 
 import shutil
-import sys
+import sysconfig
 from typing import Any
-
-from lib.pulse.scripts.mutation_plan import MutationPlanError
 
 
 KNOWN_CONSOLE_SCRIPTS = {
@@ -33,11 +31,8 @@ def validate_command_argv(command_argv: tuple[str, ...] | list[str], entry_id: s
     """
     prefix = f"transformation {entry_id}." if entry_id else ""
     for index, arg in enumerate(command_argv):
-        if not isinstance(arg, str):
-            continue
-        # Flag any element that is a repo-relative python script path
-        if arg.endswith(".py") or (("lib/" in arg or "scripts/" in arg or "/" in arg) and arg.endswith(".py")):
-            raise MutationPlanError(
+        if isinstance(arg, str) and arg.endswith(".py"):
+            raise ValueError(
                 f"{prefix}command_argv[{index}] is a repo-relative script path, not reachable on PATH: {arg!r}"
             )
 
@@ -49,12 +44,11 @@ def probe_required_tool(tool: str, ecosystem: str | None = None, path_env: str |
     missing tool and ecosystem.
     """
     resolved_ecosystem = ecosystem or ECOSYSTEM_MAP.get(tool, "unknown")
-    # Check PATH using shutil.which
     found = shutil.which(tool, path=path_env)
-    if not found and tool in KNOWN_CONSOLE_SCRIPTS:
-        # Also check if installed in Python environment's bin/scripts dir
-        bin_dir = sys.exec_prefix + "/bin"
-        found = shutil.which(tool, path=bin_dir) or shutil.which(tool, path=path_env)
+    if not found and path_env is None and tool in KNOWN_CONSOLE_SCRIPTS:
+        scripts_dir = sysconfig.get_path("scripts")
+        if scripts_dir:
+            found = shutil.which(tool, path=scripts_dir)
 
     if not found:
         return {

--- a/lib/pulse/scripts/mutation_plan.py
+++ b/lib/pulse/scripts/mutation_plan.py
@@ -14,7 +14,7 @@ for the normative contract this module implements.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Any
@@ -26,7 +26,7 @@ from lib.pulse.scripts.executor_probe import validate_command_argv
 
 ACTOR_MODES = {"interactive", "scheduled"}
 MUTATION_POLICIES = {"propose", "allow-listed", "allow"}
-VALIDATION_KINDS = {"none", "json_schema"}
+VALIDATION_KINDS = {"none", "json_schema", "paths_changed"}
 
 
 class MutationPlanError(ValueError):
@@ -121,12 +121,12 @@ def _load_validation(raw: Any, entry_id: str) -> ValidationSpec:
         raise MutationPlanError(
             f"transformation {entry_id}.validation.kind invalid: {kind}"
         )
-    if kind == "none":
+    if kind in ("none", "paths_changed"):
         if "path" in item or "schema" in item:
             raise MutationPlanError(
-                f"transformation {entry_id}.validation: kind 'none' takes no path/schema"
+                f"transformation {entry_id}.validation: kind '{kind}' takes no path/schema"
             )
-        return ValidationSpec(kind="none")
+        return ValidationSpec(kind=kind)
     # kind == "json_schema"
     path = _string(item.get("path"), f"transformation {entry_id}.validation.path")
     schema = _mapping(item.get("schema"), f"transformation {entry_id}.validation.schema")
@@ -293,6 +293,7 @@ class Proposal:
     expected_shas: dict[str, str]
     mutation_policy: str
     actor: Actor
+    bound_paths: dict[str, tuple[str, ...]] = field(default_factory=dict)
 
 
 def _repo_name(value: Any, label: str) -> str:
@@ -321,6 +322,7 @@ def build_proposal(
     expected_shas: dict[str, str],
     actor: dict[str, Any] | Actor,
     mutation_policy: str = "propose",
+    bound_paths: dict[str, list[str] | tuple[str, ...]] | None = None,
     registry: TransformationRegistry | None = None,
 ) -> Proposal:
     """Construct and validate a `Proposal`.
@@ -362,6 +364,20 @@ def build_proposal(
 
     actor_block = actor if isinstance(actor, Actor) else _load_actor(actor)
 
+    normalized_bound_paths: dict[str, tuple[str, ...]] = {}
+    if bound_paths is not None:
+        b_map = _mapping(bound_paths, "proposal.bound_paths")
+        for repo, paths in b_map.items():
+            repo_key = _repo_name(repo, "proposal.bound_paths key")
+            if repo_key not in repos:
+                raise MutationPlanError(
+                    f"proposal.bound_paths has entry outside selection: {repo_key}"
+                )
+            path_list = _list(list(paths), f"proposal.bound_paths[{repo_key}]")
+            normalized_bound_paths[repo_key] = tuple(
+                _string(p, f"proposal.bound_paths[{repo_key}] entry") for p in path_list
+            )
+
     proposal = Proposal(
         id=proposal_id,
         selection=repos,
@@ -369,6 +385,7 @@ def build_proposal(
         expected_shas=normalized_shas,
         mutation_policy=policy,
         actor=actor_block,
+        bound_paths=normalized_bound_paths,
     )
 
     if registry is not None:
@@ -389,3 +406,14 @@ def validate_proposal(proposal: Proposal, registry: TransformationRegistry) -> N
         raise MutationPlanError(
             f"transformation not allowed in scheduled mode: {proposal.transformation}"
         )
+    if entry.validation.kind == "paths_changed":
+        missing = set(proposal.selection) - set(proposal.bound_paths)
+        if missing:
+            raise MutationPlanError(
+                f"proposal.bound_paths missing entry for: {sorted(missing)[0]}"
+            )
+        extra = set(proposal.bound_paths) - set(proposal.selection)
+        if extra:
+            raise MutationPlanError(
+                f"proposal.bound_paths has entry outside selection: {sorted(extra)[0]}"
+            )

--- a/lib/pulse/scripts/mutation_plan.py
+++ b/lib/pulse/scripts/mutation_plan.py
@@ -21,6 +21,8 @@ from typing import Any
 
 import yaml
 
+from lib.pulse.scripts.executor_probe import validate_command_argv
+
 
 ACTOR_MODES = {"interactive", "scheduled"}
 MUTATION_POLICIES = {"propose", "allow-listed", "allow"}
@@ -167,9 +169,10 @@ def _load_transformation(raw: Any, entry_id: str) -> TransformationEntry:
             f"transformation {entry_id}.id must match its registry key: {declared_id}"
         )
     command_argv = _argv(item.get("command_argv"), f"transformation {entry_id}.command_argv")
-    from lib.pulse.scripts.executor_probe import validate_command_argv
-
-    validate_command_argv(command_argv, entry_id)
+    try:
+        validate_command_argv(command_argv, entry_id)
+    except ValueError as exc:
+        raise MutationPlanError(str(exc)) from exc
     applies_to_raw = _list(item.get("applies_to"), f"transformation {entry_id}.applies_to")
     if not applies_to_raw:
         raise MutationPlanError(f"transformation {entry_id}.applies_to must be non-empty")

--- a/lib/pulse/scripts/mutation_plan.py
+++ b/lib/pulse/scripts/mutation_plan.py
@@ -167,6 +167,9 @@ def _load_transformation(raw: Any, entry_id: str) -> TransformationEntry:
             f"transformation {entry_id}.id must match its registry key: {declared_id}"
         )
     command_argv = _argv(item.get("command_argv"), f"transformation {entry_id}.command_argv")
+    from lib.pulse.scripts.executor_probe import validate_command_argv
+
+    validate_command_argv(command_argv, entry_id)
     applies_to_raw = _list(item.get("applies_to"), f"transformation {entry_id}.applies_to")
     if not applies_to_raw:
         raise MutationPlanError(f"transformation {entry_id}.applies_to must be non-empty")

--- a/lib/pulse/scripts/nave_adapter.py
+++ b/lib/pulse/scripts/nave_adapter.py
@@ -535,6 +535,88 @@ def provision_apply_branch(
     return results
 
 
+def commit_apply_clones(
+    clone_paths: dict[str, str | Path],
+    message: str,
+) -> dict[str, dict[str, str]]:
+    """Commit uncommitted changes in each repo clone with the attributed message.
+
+    Operates directly on local repository clones via `git -C <clone> add -A` then
+    `git -C <clone> commit -m <message>`. A repo with nothing to commit fails.
+
+    Returns a dict mapping repo identifier (`owner/name`) to a result dict:
+      `{"state": "ok"}` or `{"state": "failed", "reason": "..."}`.
+    """
+    results: dict[str, dict[str, str]] = {}
+    for repo, clone_path in clone_paths.items():
+        add_res = subprocess.run(
+            ["git", "-C", str(clone_path), "add", "-A"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if add_res.returncode != 0:
+            reason = add_res.stderr.strip() or add_res.stdout.strip() or "git add failed"
+            results[repo] = {"state": "failed", "reason": reason}
+            continue
+
+        status_res = subprocess.run(
+            ["git", "-C", str(clone_path), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if status_res.returncode == 0 and not status_res.stdout.strip():
+            results[repo] = {
+                "state": "failed",
+                "reason": f"nothing to commit in {repo}",
+            }
+            continue
+
+        res = subprocess.run(
+            ["git", "-C", str(clone_path), "commit", "-m", message],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if res.returncode == 0:
+            results[repo] = {"state": "ok"}
+        else:
+            reason = res.stderr.strip() or res.stdout.strip() or "git commit failed"
+            results[repo] = {"state": "failed", "reason": reason}
+
+    return results
+
+
+def push_apply_clones(
+    clone_paths: dict[str, str | Path],
+    branch: str,
+) -> dict[str, dict[str, str]]:
+    """Push each clone's apply branch to origin.
+
+    Operates directly on local repository clones via `git -C <clone> push origin <branch>`.
+
+    Returns a dict mapping repo identifier (`owner/name`) to a result dict:
+      `{"state": "ok"}` or `{"state": "failed", "reason": "..."}`.
+    """
+    results: dict[str, dict[str, str]] = {}
+    for repo, clone_path in clone_paths.items():
+        res = subprocess.run(
+            ["git", "-C", str(clone_path), "push", "origin", branch],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if res.returncode == 0:
+            results[repo] = {"state": "ok"}
+        else:
+            reason = res.stderr.strip() or res.stdout.strip() or "git push failed"
+            results[repo] = {"state": "failed", "reason": reason}
+
+    return results
+
+
+
 def _materialize_summary(report: dict) -> dict:
     """Build a content-free per-repo, per-state artifact summary.
 

--- a/lib/pulse/scripts/nave_adapter.py
+++ b/lib/pulse/scripts/nave_adapter.py
@@ -497,6 +497,44 @@ def pen_exec(
     }
 
 
+def provision_apply_branch(
+    clone_paths: dict[str, str | Path],
+    branch: str,
+    base_shas: dict[str, str],
+) -> dict[str, dict[str, str]]:
+    """Provision a per-proposal branch off the guarded base SHA in each repo clone.
+
+    Operates directly on local repository clones via `git checkout -b <branch> <base_sha>`.
+    This is a git operation on local clones, not a Nave CLI subcommand.
+
+    Returns a dict mapping repo identifier (`owner/name`) to a result dict:
+      `{"state": "ok"}` or `{"state": "failed", "reason": "..."}`.
+    """
+    results: dict[str, dict[str, str]] = {}
+    for repo, clone_path in clone_paths.items():
+        base_sha = base_shas.get(repo)
+        if not base_sha:
+            results[repo] = {
+                "state": "failed",
+                "reason": f"missing base SHA for repo {repo}",
+            }
+            continue
+
+        res = subprocess.run(
+            ["git", "-C", str(clone_path), "checkout", "-b", branch, base_sha],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if res.returncode == 0:
+            results[repo] = {"state": "ok"}
+        else:
+            reason = res.stderr.strip() or res.stdout.strip() or "git checkout -b failed"
+            results[repo] = {"state": "failed", "reason": reason}
+
+    return results
+
+
 def _materialize_summary(report: dict) -> dict:
     """Build a content-free per-repo, per-state artifact summary.
 

--- a/lib/pulse/scripts/object_apply.py
+++ b/lib/pulse/scripts/object_apply.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Precondition-guarded, idempotent Path B GitHub object writes under on_mutation policy (F11 Task 7).
+
+Independence Notice (B4):
+-------------------------
+Path B (GitHub-object apply) is completely independent of Path A (doc-pen apply).
+``object_apply`` knows nothing about pens, branches, or PRs. A Path A doc-pen push
+failure does not block an object write, and vice-versa.
+
+Emitter Integration Points:
+---------------------------
+1. F8 Issue Field Patch (Concrete Demonstrator):
+   Use ``apply_issue_field_patch(issue_repo, issue_number, field, target_value, expected_value, ...)``
+   or construct ``ObjectWrite(verb="update-field", target=f"{issue_repo}#{issue_number}", payload=..., precondition=Precondition(target=f"{issue_repo}#{issue_number}", field=field, expected=expected_value))``.
+
+2. F5 Marker Advancement (Documented Integration Point):
+   To advance a dependency marker on GitHub under Path B:
+   - Construct ``Precondition(target=f"{repo}:{marker_id}", field="sha", expected=current_marker_sha)``.
+   - Construct ``ObjectWrite(verb="marker-advance", target=f"{repo}:{marker_id}", payload={"marker": marker_id, "sha": target_marker_sha}, precondition=precondition)``.
+   - Call ``apply_object_write(write, policy=policy, mutation_allowlist=mutation_allowlist, gh_ops=gh_ops)``.
+
+3. F9 Marketplace Entry Update (Documented Integration Point):
+   To land a marketplace version patch on GitHub under Path B:
+   - Construct ``Precondition(target=f"{marketplace_repo}:{file_path}", field="version", expected=current_version)``.
+   - Construct ``ObjectWrite(verb="marketplace-entry", target=f"{marketplace_repo}:{file_path}", payload={"plugin_id": plugin_id, "version": new_version}, precondition=precondition)``.
+   - Call ``apply_object_write(write, policy=policy, mutation_allowlist=mutation_allowlist, gh_ops=gh_ops)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Sequence
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+
+BLOCKED_VERBS: set[str] = {
+    "delete",
+    "transfer",
+    "archive",
+    "delete-default",
+    "delete-all",
+    "remove-all-members",
+    "delete-repo",
+    "delete-org",
+}
+
+
+@dataclass(frozen=True)
+class Precondition:
+    """Descriptor naming an object's expected current state (Path B expected_shas equivalent)."""
+
+    target: str
+    field: str
+    expected: Any
+
+
+@dataclass(frozen=True)
+class ObjectWrite:
+    """Descriptor for a typed GitHub object write operation."""
+
+    verb: str
+    target: str
+    payload: dict[str, Any]
+    precondition: Precondition
+    desired: Any = None
+
+
+class GhExecutionError(Exception):
+    """Raised when a gh CLI operation fails or produces unparseable output."""
+
+    pass
+
+
+class ObjectGhOps:
+    """Interface for GitHub object CLI operations (injected for testing)."""
+
+    def get_state(self, precondition: Precondition) -> Any:
+        """Return current live state for precondition checking.
+
+        Raises GhExecutionError on gh execution or parsing failure.
+        """
+        raise NotImplementedError
+
+    def apply_write(self, write: ObjectWrite) -> dict[str, Any]:
+        """Execute the object write against GitHub API / CLI.
+
+        Returns result dict e.g. {"state": "applied", "detail": ...}.
+        Raises GhExecutionError on execution failure.
+        """
+        raise NotImplementedError
+
+
+class ObjectGhCliOps(ObjectGhOps):
+    """Production implementation of ObjectGhOps shelling `gh` CLI."""
+
+    def __init__(self, gh_binary: str = "gh") -> None:
+        self.gh_binary = gh_binary
+
+    def get_state(self, precondition: Precondition) -> Any:
+        target = precondition.target
+        if "#" in target:
+            repo, num = target.split("#", 1)
+            cmd = [
+                self.gh_binary,
+                "issue",
+                "view",
+                num,
+                "-R",
+                repo,
+                "--json",
+                precondition.field,
+            ]
+            res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            if res.returncode != 0:
+                raise GhExecutionError(
+                    f"gh issue view exit code {res.returncode}: {res.stderr.strip()}"
+                )
+            try:
+                data = json.loads(res.stdout)
+                return data.get(precondition.field)
+            except Exception as exc:
+                raise GhExecutionError(f"Failed to parse gh issue view JSON: {exc}")
+
+        cmd = [self.gh_binary, "api", target]
+        res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if res.returncode != 0:
+            raise GhExecutionError(
+                f"gh api exit code {res.returncode}: {res.stderr.strip()}"
+            )
+        try:
+            data = json.loads(res.stdout)
+            if isinstance(data, dict):
+                return data.get(precondition.field)
+            return data
+        except Exception as exc:
+            raise GhExecutionError(f"Failed to parse gh api response: {exc}")
+
+    def apply_write(self, write: ObjectWrite) -> dict[str, Any]:
+        if write.verb in {"update-field", "issue-patch"} and "#" in write.target:
+            repo, num = write.target.split("#", 1)
+            field = write.payload.get("field") or write.precondition.field
+            val = write.desired if write.desired is not None else write.payload.get("value")
+            cmd = [
+                self.gh_binary,
+                "issue",
+                "edit",
+                num,
+                "-R",
+                repo,
+                f"--{field}",
+                str(val),
+            ]
+            res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+            if res.returncode != 0:
+                raise GhExecutionError(
+                    f"gh issue edit exit code {res.returncode}: {res.stderr.strip()}"
+                )
+            return {
+                "state": "applied",
+                "target": write.target,
+                "field": field,
+                "value": val,
+            }
+
+        cmd = [
+            self.gh_binary,
+            "api",
+            "-X",
+            "POST",
+            write.target,
+            "-f",
+            json.dumps(write.payload),
+        ]
+        res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        if res.returncode != 0:
+            raise GhExecutionError(
+                f"gh api write exit code {res.returncode}: {res.stderr.strip()}"
+            )
+        return {"state": "applied", "target": write.target}
+
+
+def is_verb_blocked(verb: str) -> bool:
+    v = verb.lower().strip()
+    return v in BLOCKED_VERBS or any(
+        b in v for b in ("delete", "transfer", "archive")
+    )
+
+
+def apply_object_write(
+    write: ObjectWrite,
+    *,
+    policy: str,
+    mutation_allowlist: Sequence[str] | set[str] | None = None,
+    gh_ops: ObjectGhOps,
+) -> dict[str, Any]:
+    """Execute a guarded, idempotent Path-B GitHub object write under on_mutation policy."""
+    # 1. Unconditional Blocklist Check
+    if is_verb_blocked(write.verb):
+        return {
+            "state": "blocked",
+            "reason": f"blocked: operation '{write.verb}' is in operation blocklist",
+        }
+
+    # 2. Policy: propose
+    if policy == "propose":
+        return {"state": "proposed", "action": f"{write.verb} {write.target}"}
+
+    # 3. Policy: allow (reserved / blocked in v1)
+    if policy == "allow":
+        return {"state": "blocked", "reason": "allow is reserved and blocked in v1"}
+
+    # 4. Policy: allow-listed
+    if policy == "allow-listed":
+        allowlist = set(mutation_allowlist or ())
+        if write.verb not in allowlist:
+            return {"state": "proposed", "action": f"{write.verb} {write.target}"}
+
+        # Verb is in allowlist -> check precondition live state
+        try:
+            current_state = gh_ops.get_state(write.precondition)
+        except (GhExecutionError, Exception) as exc:
+            return {
+                "state": "blocked",
+                "reason": f"precondition unconfirmable: {exc}",
+            }
+
+        # Determine desired end state
+        desired = write.desired
+        if desired is None:
+            if write.precondition.field in write.payload:
+                desired = write.payload[write.precondition.field]
+            elif "value" in write.payload:
+                desired = write.payload["value"]
+            elif "patch" in write.payload and isinstance(write.payload["patch"], dict):
+                desired = write.payload["patch"].get(write.precondition.field)
+
+        # Idempotency check: if object is already in desired end state -> no-op
+        if desired is not None and current_state == desired:
+            return {"state": "applied", "noop": True}
+
+        # Precondition check: must match expected state
+        if current_state != write.precondition.expected:
+            return {
+                "state": "blocked",
+                "reason": (
+                    f"precondition mismatch: expected {write.precondition.expected!r}, "
+                    f"got {current_state!r}"
+                ),
+            }
+
+        # Apply write
+        try:
+            res = gh_ops.apply_write(write)
+            if isinstance(res, dict):
+                result = dict(res)
+                result.setdefault("state", "applied")
+                result["noop"] = False
+                return result
+            return {"state": "applied", "noop": False, "result": res}
+        except (GhExecutionError, Exception) as exc:
+            return {"state": "failed", "reason": str(exc)}
+
+    return {"state": "blocked", "reason": f"unrecognized policy: {policy}"}
+
+
+def apply_issue_field_patch(
+    *,
+    issue_repo: str,
+    issue_number: int,
+    field: str,
+    target_value: Any,
+    expected_value: Any,
+    policy: str,
+    mutation_allowlist: Sequence[str] | set[str] | None = None,
+    gh_ops: ObjectGhOps,
+) -> dict[str, Any]:
+    """Demonstrator wiring for F8 issue/milestone field patch under Path B."""
+    target = f"{issue_repo}#{issue_number}"
+    precondition = Precondition(target=target, field=field, expected=expected_value)
+    write = ObjectWrite(
+        verb="update-field",
+        target=target,
+        payload={
+            "repo": issue_repo,
+            "number": issue_number,
+            "field": field,
+            "value": target_value,
+        },
+        precondition=precondition,
+        desired=target_value,
+    )
+    return apply_object_write(
+        write,
+        policy=policy,
+        mutation_allowlist=mutation_allowlist,
+        gh_ops=gh_ops,
+    )

--- a/lib/pulse/scripts/object_apply.py
+++ b/lib/pulse/scripts/object_apply.py
@@ -44,14 +44,7 @@ if __package__ in {None, ""}:
 
 
 BLOCKED_VERBS: set[str] = {
-    "delete",
-    "transfer",
-    "archive",
-    "delete-default",
-    "delete-all",
     "remove-all-members",
-    "delete-repo",
-    "delete-org",
 }
 
 
@@ -81,6 +74,14 @@ class GhExecutionError(Exception):
     pass
 
 
+OPERATIONAL_ERRORS = (
+    GhExecutionError,
+    subprocess.SubprocessError,
+    OSError,
+    json.JSONDecodeError,
+)
+
+
 class ObjectGhOps:
     """Interface for GitHub object CLI operations (injected for testing)."""
 
@@ -98,6 +99,16 @@ class ObjectGhOps:
         Raises GhExecutionError on execution failure.
         """
         raise NotImplementedError
+
+
+def build_gh_api_post_args(
+    target: str, payload: dict[str, Any], gh_binary: str = "gh"
+) -> list[str]:
+    """Construct `gh api -X POST` command args with `-f key=value` flags."""
+    cmd = [gh_binary, "api", "-X", "POST", target]
+    for k, v in payload.items():
+        cmd.extend(["-f", f"{k}={v}"])
+    return cmd
 
 
 class ObjectGhCliOps(ObjectGhOps):
@@ -172,15 +183,7 @@ class ObjectGhCliOps(ObjectGhOps):
                 "value": val,
             }
 
-        cmd = [
-            self.gh_binary,
-            "api",
-            "-X",
-            "POST",
-            write.target,
-            "-f",
-            json.dumps(write.payload),
-        ]
+        cmd = build_gh_api_post_args(write.target, write.payload, self.gh_binary)
         res = subprocess.run(cmd, capture_output=True, text=True, check=False)
         if res.returncode != 0:
             raise GhExecutionError(
@@ -228,7 +231,7 @@ def apply_object_write(
         # Verb is in allowlist -> check precondition live state
         try:
             current_state = gh_ops.get_state(write.precondition)
-        except (GhExecutionError, Exception) as exc:
+        except OPERATIONAL_ERRORS as exc:
             return {
                 "state": "blocked",
                 "reason": f"precondition unconfirmable: {exc}",
@@ -267,7 +270,7 @@ def apply_object_write(
                 result["noop"] = False
                 return result
             return {"state": "applied", "noop": False, "result": res}
-        except (GhExecutionError, Exception) as exc:
+        except OPERATIONAL_ERRORS as exc:
             return {"state": "failed", "reason": str(exc)}
 
     return {"state": "blocked", "reason": f"unrecognized policy: {policy}"}

--- a/lib/pulse/scripts/pen_clone_reader.py
+++ b/lib/pulse/scripts/pen_clone_reader.py
@@ -150,9 +150,12 @@ def make_pen_clone_reader(
             rel_path = part[3:].decode("utf-8", errors="replace")
             changed_paths.add(rel_path)
 
-            if status_code.startswith(("R", "C")):
+            if "R" in status_code or "C" in status_code:
                 if idx < len(parts):
+                    orig_path = parts[idx].decode("utf-8", errors="replace")
                     idx += 1
+                    if orig_path:
+                        changed_paths.add(orig_path)
 
         return tuple(sorted(changed_paths))
 

--- a/lib/pulse/scripts/pen_clone_reader.py
+++ b/lib/pulse/scripts/pen_clone_reader.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = []
+# ///
+"""Reader over a pen's local repo clones driven by a defined clone-root source.
+
+Implements the three injectable reader seams consumed by `pen_orchestrator.execute`:
+- `read_repo_head(repo)` -> SHA string via `git rev-parse HEAD`
+- `read_repo_file(repo, path)` -> file content bytes
+- `read_repo_changed_paths(repo)` -> repo-relative changed paths tuple (modified, added, deleted, untracked)
+
+The clone-root contract resolves clone root from:
+1. `clone_root` argument if provided to `make_pen_clone_reader`
+2. `PULSE_PEN_ROOT` environment variable
+Per-repo layout is expected at `{clone_root}/{owner}/{name}` for repo `owner/name`.
+Fails closed loudly with `PenCloneReaderError` if clone_root is unset, missing, or if any selected repo's checkout is absent/not a git worktree.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+class PenCloneReaderError(ValueError):
+    """Raised when clone root or repo clone validation fails."""
+
+
+@dataclass(frozen=True)
+class PenCloneReaders:
+    """Container holding the three reader seams for pen_orchestrator.execute."""
+
+    read_repo_head: Callable[[str], str]
+    read_repo_file: Callable[[str, str], bytes]
+    read_repo_changed_paths: Callable[[str], tuple[str, ...]]
+
+
+def make_pen_clone_reader(
+    clone_root: str | Path | None = None,
+    selection: Sequence[str] = (),
+) -> PenCloneReaders:
+    """Validate clone root and selected repos up front, returning the 3 reader callables.
+
+    Raises PenCloneReaderError if:
+    - clone_root is unset and PULSE_PEN_ROOT environment variable is not set
+    - resolved clone root directory does not exist
+    - any repo in selection is invalid, missing, or not a git worktree
+    """
+    if clone_root is not None:
+        root_path = Path(clone_root)
+    elif "PULSE_PEN_ROOT" in os.environ:
+        root_path = Path(os.environ["PULSE_PEN_ROOT"])
+    else:
+        raise PenCloneReaderError(
+            "clone_root was not provided and PULSE_PEN_ROOT environment variable is not set"
+        )
+
+    if not root_path.exists() or not root_path.is_dir():
+        raise PenCloneReaderError(
+            f"clone_root directory does not exist or is not a directory: {root_path}"
+        )
+
+    clone_paths: dict[str, Path] = {}
+    for repo in selection:
+        parts = repo.split("/")
+        if len(parts) != 2 or not parts[0] or not parts[1]:
+            raise PenCloneReaderError(f"Invalid repo format {repo!r}; expected 'owner/name'")
+        owner, name = parts
+        repo_dir = root_path / owner / name
+        if not repo_dir.exists() or not repo_dir.is_dir():
+            raise PenCloneReaderError(
+                f"Repo clone for {repo!r} not found at {repo_dir}"
+            )
+        git_dir = repo_dir / ".git"
+        if not git_dir.exists():
+            raise PenCloneReaderError(
+                f"Repo clone for {repo!r} at {repo_dir} is not a git worktree (missing .git)"
+            )
+        clone_paths[repo] = repo_dir
+
+    def read_repo_head(repo: str) -> str:
+        if repo not in clone_paths:
+            raise KeyError(f"Unknown or unvalidated repo {repo!r}")
+        repo_dir = clone_paths[repo]
+        res = subprocess.run(
+            ["git", "-C", str(repo_dir), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if res.returncode != 0:
+            raise FileNotFoundError(
+                f"Could not read HEAD for repo {repo!r}: {res.stderr.strip()}"
+            )
+        return res.stdout.strip()
+
+    def read_repo_file(repo: str, path: str) -> bytes:
+        if repo not in clone_paths:
+            raise KeyError(f"Unknown or unvalidated repo {repo!r}")
+        repo_dir = clone_paths[repo]
+        target_path = (repo_dir / path).resolve()
+        resolved_repo_dir = repo_dir.resolve()
+        try:
+            target_path.relative_to(resolved_repo_dir)
+        except ValueError:
+            raise FileNotFoundError(
+                f"Path {path!r} traverses outside repo directory for {repo!r}"
+            )
+        if not target_path.exists() or not target_path.is_file():
+            raise FileNotFoundError(f"File {path!r} not found in repo {repo!r}")
+        return target_path.read_bytes()
+
+    def read_repo_changed_paths(repo: str) -> tuple[str, ...]:
+        if repo not in clone_paths:
+            raise KeyError(f"Unknown or unvalidated repo {repo!r}")
+        repo_dir = clone_paths[repo]
+        res = subprocess.run(
+            [
+                "git",
+                "-C",
+                str(repo_dir),
+                "status",
+                "--porcelain=v1",
+                "--untracked-files=all",
+                "-z",
+            ],
+            capture_output=True,
+            check=False,
+        )
+        if res.returncode != 0:
+            raise RuntimeError(
+                f"Could not read status for repo {repo!r}: {res.stderr.decode('utf-8', errors='replace').strip()}"
+            )
+
+        changed_paths: set[str] = set()
+        parts = res.stdout.split(b"\x00")
+        idx = 0
+        while idx < len(parts):
+            part = parts[idx]
+            idx += 1
+            if not part:
+                continue
+            if len(part) < 3:
+                continue
+            status_code = part[:2].decode("utf-8", errors="replace")
+            rel_path = part[3:].decode("utf-8", errors="replace")
+            changed_paths.add(rel_path)
+
+            if status_code.startswith(("R", "C")):
+                if idx < len(parts):
+                    idx += 1
+
+        return tuple(sorted(changed_paths))
+
+    return PenCloneReaders(
+        read_repo_head=read_repo_head,
+        read_repo_file=read_repo_file,
+        read_repo_changed_paths=read_repo_changed_paths,
+    )

--- a/lib/pulse/scripts/pen_orchestrator.py
+++ b/lib/pulse/scripts/pen_orchestrator.py
@@ -68,6 +68,16 @@ check runs after pen creation and the freshness/cleanliness preflight
 (a pen must exist, and have a resolvable HEAD, before it can be checked)
 and strictly before `pen exec`.
 
+## `validation.kind == "paths_changed"`: injectable changed-paths reader
+
+`mutation_plan.ValidationSpec` declares a `paths_changed` kind that asserts
+the set of changed paths in each repo matches exactly that repo's `bound_paths`
+on the `Proposal`. `execute` accepts an injectable
+`read_repo_changed_paths: Callable[[str], tuple[str, ...]] | None` seam (repo
+`owner/name` -> repo-relative paths that changed in that repo's pen clone).
+With no reader supplied and `kind == "paths_changed"`, validation fails closed
+as `blocked` with a message explaining that a reader is required.
+
 ## NEEDS_CONTEXT: per-repo command-failure attribution
 
 `nave_pen::ops::exec_pen` (verified against
@@ -87,6 +97,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
+from fnmatch import fnmatchcase
 from typing import Any, Callable
 
 from lib.pulse.scripts import nave_adapter
@@ -239,37 +250,108 @@ def _validate_repo_output(spec: ValidationSpec, read_repo_file, repo: str) -> st
     return None
 
 
+def _match_bound_path(pattern: str, path: str) -> bool:
+    if "*" in pattern:
+        return fnmatchcase(path, pattern)
+    return path == pattern
+
+
+def _validate_repo_paths_changed(
+    bound_patterns: tuple[str, ...],
+    read_repo_changed_paths: Callable[[str], tuple[str, ...]],
+    repo: str,
+) -> str | None:
+    try:
+        changed_raw = read_repo_changed_paths(repo)
+    except Exception as exc:
+        return f"{repo}: could not read changed paths: {exc}"
+
+    changed = set(changed_raw)
+    if not changed:
+        return f"{repo}: no paths changed (expected changes in bound_paths)"
+
+    unmatched = [
+        p for p in sorted(changed) if not any(_match_bound_path(pat, p) for pat in bound_patterns)
+    ]
+    if unmatched:
+        return f"{repo}: path changed outside bound_paths allowlist: {', '.join(unmatched)}"
+
+    missing_exact = [
+        pat for pat in bound_patterns if "*" not in pat and pat not in changed
+    ]
+    if missing_exact:
+        return f"{repo}: bound_paths exact path did not change: {', '.join(sorted(missing_exact))}"
+
+    return None
+
+
 def _validate(
-    spec: ValidationSpec, read_repo_file, selection: tuple[str, ...]
-) -> tuple[dict[str, str], str] | None:
+    spec: ValidationSpec,
+    read_repo_file: Callable[[str, str], bytes] | None,
+    read_repo_changed_paths: Callable[[str], tuple[str, ...]] | None,
+    bound_paths: dict[str, tuple[str, ...]],
+    selection: tuple[str, ...],
+) -> tuple[dict[str, str], str, str] | None:
     """Run the post-exec check `spec` declares across `selection`; return
-    `None` on success, or `(repo_outcomes, reason)` on failure. `kind ==
-    "none"` always passes. `kind == "json_schema"` with no `read_repo_file`
-    fails closed uniformly (see module docstring); with a reader, each repo
+    `None` on success, or `(repo_outcomes, reason, state)` on failure. `kind ==
+    "none"` always passes. `kind == "json_schema"` or `"paths_changed"` with no
+    reader fails closed uniformly (see module docstring); with a reader, each repo
     is checked independently so failure is attributed per repo."""
     if spec.kind == "none":
         return None
-    if read_repo_file is None:
-        reason = (
-            f"validation kind 'json_schema' (path={spec.path!r}) requires a "
-            "read_repo_file callable to read the pen's local output file "
-            "content — none was provided to execute(); pen show/status "
-            "carry no clone path, pen exec stdout/stderr are opaque by "
-            "contract, and `materialize` fetches committed GitHub content, "
-            "not a pen's local working tree, so pen_orchestrator cannot "
-            "read repo files on its own"
-        )
-        return ({repo: "failed" for repo in selection}, reason)
-    errors = {
-        repo: error
-        for repo in selection
-        if (error := _validate_repo_output(spec, read_repo_file, repo)) is not None
-    }
-    if not errors:
-        return None
-    repo_outcomes = {repo: ("failed" if repo in errors else "ok") for repo in selection}
-    reason = "; ".join(errors[repo] for repo in selection if repo in errors)
-    return (repo_outcomes, reason)
+
+    if spec.kind == "json_schema":
+        if read_repo_file is None:
+            reason = (
+                f"validation kind 'json_schema' (path={spec.path!r}) requires a "
+                "read_repo_file callable to read the pen's local output file "
+                "content — none was provided to execute(); pen show/status "
+                "carry no clone path, pen exec stdout/stderr are opaque by "
+                "contract, and `materialize` fetches committed GitHub content, "
+                "not a pen's local working tree, so pen_orchestrator cannot "
+                "read repo files on its own"
+            )
+            return ({repo: "failed" for repo in selection}, reason, "failed")
+        errors = {
+            repo: error
+            for repo in selection
+            if (error := _validate_repo_output(spec, read_repo_file, repo)) is not None
+        }
+        if not errors:
+            return None
+        repo_outcomes = {repo: ("failed" if repo in errors else "ok") for repo in selection}
+        reason = "; ".join(errors[repo] for repo in selection if repo in errors)
+        return (repo_outcomes, reason, "failed")
+
+    if spec.kind == "paths_changed":
+        if read_repo_changed_paths is None:
+            reason = (
+                "validation kind 'paths_changed' requires a "
+                "read_repo_changed_paths callable to read the pen's changed "
+                "paths — none was provided to execute(); pen show/status "
+                "carry no clone path, pen exec stdout/stderr are opaque by "
+                "contract, and `materialize` fetches committed GitHub content, "
+                "not a pen's local working tree, so pen_orchestrator cannot "
+                "read repo changed paths on its own"
+            )
+            return ({repo: "blocked" for repo in selection}, reason, "blocked")
+        errors = {
+            repo: error
+            for repo in selection
+            if (
+                error := _validate_repo_paths_changed(
+                    bound_paths.get(repo, ()), read_repo_changed_paths, repo
+                )
+            )
+            is not None
+        }
+        if not errors:
+            return None
+        repo_outcomes = {repo: ("failed" if repo in errors else "ok") for repo in selection}
+        reason = "; ".join(errors[repo] for repo in selection if repo in errors)
+        return (repo_outcomes, reason, "failed")
+
+    return None
 
 
 def execute(
@@ -278,6 +360,7 @@ def execute(
     *,
     read_repo_file: Callable[[str, str], bytes] | None = None,
     read_repo_head: Callable[[str], str] | None = None,
+    read_repo_changed_paths: Callable[[str], tuple[str, ...]] | None = None,
 ) -> PenRunResult:
     """Drive `plan` through the pen state machine using `nave_adapter_runner`.
 
@@ -468,10 +551,16 @@ def execute(
         )
 
     # --- validated -----------------------------------------------------------
-    validation_failure = _validate(entry.validation, read_repo_file, selection)
+    validation_failure = _validate(
+        entry.validation,
+        read_repo_file,
+        read_repo_changed_paths,
+        proposal.bound_paths,
+        selection,
+    )
     if validation_failure is not None:
-        repo_outcomes, reason = validation_failure
-        return _result(plan, "failed", version, repo_outcomes, reason)
+        repo_outcomes, reason, state = validation_failure
+        return _result(plan, state, version, repo_outcomes, reason)
 
     # --- proposed: terminal success, propose-only, never pushed -------------
     return _result(

--- a/lib/pulse/scripts/pen_orchestrator.py
+++ b/lib/pulse/scripts/pen_orchestrator.py
@@ -493,16 +493,23 @@ def execute(
         if state is None:
             reasons.append(f"{repo}: missing from pen status")
         elif state.get("working_tree") != "clean":
+            # Fail closed on partial/malformed status entries too: anything
+            # other than an explicit "clean" blocks, not just "dirty".
             reasons.append(
                 f"{repo}: working tree not clean before run "
                 f"(working_tree={state.get('working_tree')!r})"
             )
+        # Freshness must be explicitly "fresh" and divergence explicitly
+        # "up-to-date"; any other value — including a missing field on a
+        # partial status entry — is staleness, fail closed.
         elif state.get("freshness") != "fresh" or state.get("divergence") != "up-to-date":
             reasons.append(
                 f"{repo}: stale pen (freshness={state.get('freshness')}, "
                 f"divergence={state.get('divergence')})"
             )
     if reasons:
+        # Fail closed: a stale or dirty repo blocks the *whole* run, never
+        # just itself — nothing gets executed anywhere.
         return _result(
             plan,
             "blocked",
@@ -512,6 +519,14 @@ def execute(
         )
 
     # --- created -> executed: expected-SHA guard (stale-base block) ------
+    # See module docstring "expected-SHA guard" section: Nave exposes no
+    # per-repo SHA on its own, so verification requires an injected reader.
+    # Runs after the pen exists and preflight passed, strictly before exec.
+    # Fail closed on coverage, not just mismatch: `execute` cannot assume the
+    # Proposal came through build_proposal, so a selected repo missing from
+    # expected_shas (or an entirely empty dict) blocks rather than skipping
+    # the guard — an unguarded repo is exactly the stale-base mutation this
+    # gate exists to prevent.
     expected_shas = proposal.expected_shas
     if selection:
         if read_repo_head is None:
@@ -566,16 +581,23 @@ def execute(
     apply_branch = f"pulse/apply/{proposal.id}"
     if proposal.mutation_policy == "allow-listed":
         prov_results = apply_ops.provision_branch(apply_branch, expected_shas)
-        prov_failures = [
-            f"{repo}: {res.get('reason', 'provision failed')}"
-            for repo, res in prov_results.items()
-            if res.get("state") != "ok"
-        ]
+        if not isinstance(prov_results, dict):
+            prov_results = {}
+        prov_failures: list[str] = []
+        prov_outcomes: dict[str, str] = {}
+        for repo in selection:
+            res = prov_results.get(repo)
+            if not isinstance(res, dict) or res.get("state") != "ok":
+                reason = (
+                    res.get("reason", "provision failed")
+                    if isinstance(res, dict)
+                    else "missing provision result"
+                )
+                prov_failures.append(f"{repo}: {reason}")
+                prov_outcomes[repo] = "blocked"
+            else:
+                prov_outcomes[repo] = "ok"
         if prov_failures:
-            prov_outcomes = {
-                repo: ("blocked" if prov_results.get(repo, {}).get("state") != "ok" else "ok")
-                for repo in selection
-            }
             return _result(
                 plan,
                 "blocked",
@@ -620,16 +642,23 @@ def execute(
     if proposal.mutation_policy == "allow-listed":
         message = f"pulse-apply {proposal.id} by {proposal.actor.gh_login}@{proposal.actor.machine}"
         commit_results = apply_ops.commit_repos(message)
-        commit_failures = [
-            f"{repo}: {res.get('reason', 'commit failed')}"
-            for repo, res in commit_results.items()
-            if res.get("state") != "ok"
-        ]
+        if not isinstance(commit_results, dict):
+            commit_results = {}
+        commit_failures: list[str] = []
+        commit_outcomes: dict[str, str] = {}
+        for repo in selection:
+            res = commit_results.get(repo)
+            if not isinstance(res, dict) or res.get("state") != "ok":
+                reason = (
+                    res.get("reason", "commit failed")
+                    if isinstance(res, dict)
+                    else "missing commit result"
+                )
+                commit_failures.append(f"{repo}: {reason}")
+                commit_outcomes[repo] = "failed"
+            else:
+                commit_outcomes[repo] = "ok"
         if commit_failures:
-            commit_outcomes = {
-                repo: ("failed" if commit_results.get(repo, {}).get("state") != "ok" else "ok")
-                for repo in selection
-            }
             return _result(
                 plan,
                 "failed",
@@ -639,16 +668,23 @@ def execute(
             )
 
         push_results = apply_ops.push_repos(apply_branch)
-        push_failures = [
-            f"{repo}: {res.get('reason', 'push failed')}"
-            for repo, res in push_results.items()
-            if res.get("state") != "ok"
-        ]
+        if not isinstance(push_results, dict):
+            push_results = {}
+        push_failures: list[str] = []
+        push_outcomes: dict[str, str] = {}
+        for repo in selection:
+            res = push_results.get(repo)
+            if not isinstance(res, dict) or res.get("state") != "ok":
+                reason = (
+                    res.get("reason", "push failed")
+                    if isinstance(res, dict)
+                    else "missing push result"
+                )
+                push_failures.append(f"{repo}: {reason}")
+                push_outcomes[repo] = "failed"
+            else:
+                push_outcomes[repo] = "ok"
         if push_failures:
-            push_outcomes = {
-                repo: ("failed" if push_results.get(repo, {}).get("state") != "ok" else "ok")
-                for repo in selection
-            }
             return _result(
                 plan,
                 "failed",
@@ -673,4 +709,5 @@ def execute(
         {repo: "ok" for repo in selection},
         None,
     )
+
 

--- a/lib/pulse/scripts/pen_orchestrator.py
+++ b/lib/pulse/scripts/pen_orchestrator.py
@@ -98,7 +98,7 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from fnmatch import fnmatchcase
-from typing import Any, Callable
+from typing import Any, Callable, Protocol
 
 from lib.pulse.scripts import nave_adapter
 from lib.pulse.scripts.mutation_plan import (
@@ -110,7 +110,23 @@ from lib.pulse.scripts.mutation_plan import (
 )
 
 
+class ApplyOps(Protocol):
+    """Abstract protocol for git-on-clones operations during allow-listed apply mode."""
+
+    def provision_branch(
+        self, branch: str, base_shas: dict[str, str]
+    ) -> dict[str, dict[str, str]]:
+        ...
+
+    def commit_repos(self, message: str) -> dict[str, dict[str, str]]:
+        ...
+
+    def push_repos(self, branch: str) -> dict[str, dict[str, str]]:
+        ...
+
+
 class PenOrchestratorError(ValueError):
+
     """Raised for a structurally invalid `PenPlan` — a caller/programmer
     bug (e.g. a mismatched resolved transformation), never a runtime
     gating outcome. Runtime gating outcomes are always reported via a
@@ -361,6 +377,7 @@ def execute(
     read_repo_file: Callable[[str, str], bytes] | None = None,
     read_repo_head: Callable[[str], str] | None = None,
     read_repo_changed_paths: Callable[[str], tuple[str, ...]] | None = None,
+    apply_ops: ApplyOps | Any | None = None,
 ) -> PenRunResult:
     """Drive `plan` through the pen state machine using `nave_adapter_runner`.
 
@@ -376,8 +393,11 @@ def execute(
     `read_repo_head`, if supplied, is called as `read_repo_head(repo) ->
     str` (raising `FileNotFoundError` or `KeyError` when `repo` is unknown)
     to satisfy `proposal.expected_shas` verification — see the module
-    docstring's "expected-SHA guard" section. These two callables are the
-    only filesystem seams this module accepts.
+    docstring's "expected-SHA guard" section.
+
+    `apply_ops`, if supplied, is an object/dataclass exposing
+    `provision_branch(branch, base_shas)`, `commit_repos(message)`, and
+    `push_repos(branch)` for allow-listed apply mode.
     """
     proposal = plan.proposal
     entry = plan.entry
@@ -391,16 +411,42 @@ def execute(
     version = _probe_version(runner)
     selection = proposal.selection
 
-    # --- forbidden push: checked before any Nave call --------------------
-    if plan.request_push or proposal.mutation_policy != "propose":
+    # --- policy gating check ----------------------------------------------
+    if proposal.mutation_policy == "propose":
+        if plan.request_push:
+            return _result(
+                plan,
+                "blocked",
+                version,
+                {repo: "blocked" for repo in selection},
+                "push forbidden: pen_orchestrator is propose-only and never "
+                f"commits or pushes; got mutation_policy={proposal.mutation_policy!r} "
+                f"request_push={plan.request_push!r}",
+            )
+    elif proposal.mutation_policy == "allow-listed":
+        if apply_ops is None:
+            return _result(
+                plan,
+                "blocked",
+                version,
+                {repo: "blocked" for repo in selection},
+                "mutation_policy 'allow-listed' requires apply_ops to be supplied to execute()",
+            )
+    elif proposal.mutation_policy == "allow":
         return _result(
             plan,
             "blocked",
             version,
             {repo: "blocked" for repo in selection},
-            "push forbidden: pen_orchestrator is propose-only and never "
-            f"commits or pushes; got mutation_policy={proposal.mutation_policy!r} "
-            f"request_push={plan.request_push!r}",
+            "push forbidden: mutation policy 'allow' is reserved and blocked in v1",
+        )
+    else:
+        return _result(
+            plan,
+            "blocked",
+            version,
+            {repo: "blocked" for repo in selection},
+            f"push forbidden: unsupported mutation_policy={proposal.mutation_policy!r}",
         )
 
     # --- planned -> created ------------------------------------------------
@@ -447,23 +493,16 @@ def execute(
         if state is None:
             reasons.append(f"{repo}: missing from pen status")
         elif state.get("working_tree") != "clean":
-            # Fail closed on partial/malformed status entries too: anything
-            # other than an explicit "clean" blocks, not just "dirty".
             reasons.append(
                 f"{repo}: working tree not clean before run "
                 f"(working_tree={state.get('working_tree')!r})"
             )
-        # Freshness must be explicitly "fresh" and divergence explicitly
-        # "up-to-date"; any other value — including a missing field on a
-        # partial status entry — is staleness, fail closed.
         elif state.get("freshness") != "fresh" or state.get("divergence") != "up-to-date":
             reasons.append(
                 f"{repo}: stale pen (freshness={state.get('freshness')}, "
                 f"divergence={state.get('divergence')})"
             )
     if reasons:
-        # Fail closed: a stale or dirty repo blocks the *whole* run, never
-        # just itself — nothing gets executed anywhere.
         return _result(
             plan,
             "blocked",
@@ -473,14 +512,6 @@ def execute(
         )
 
     # --- created -> executed: expected-SHA guard (stale-base block) ------
-    # See module docstring "expected-SHA guard" section: Nave exposes no
-    # per-repo SHA on its own, so verification requires an injected reader.
-    # Runs after the pen exists and preflight passed, strictly before exec.
-    # Fail closed on coverage, not just mismatch: `execute` cannot assume the
-    # Proposal came through build_proposal, so a selected repo missing from
-    # expected_shas (or an entirely empty dict) blocks rather than skipping
-    # the guard — an unguarded repo is exactly the stale-base mutation this
-    # gate exists to prevent.
     expected_shas = proposal.expected_shas
     if selection:
         if read_repo_head is None:
@@ -520,12 +551,37 @@ def execute(
             else:
                 sha_outcomes[repo] = "ok"
         if sha_reasons:
+            reason = "; ".join(sha_reasons)
+            if proposal.mutation_policy == "allow-listed":
+                reason += " (stale base: recovery is rebuild expected_shas off current HEAD and re-propose)"
             return _result(
                 plan,
                 "blocked",
                 version,
                 sha_outcomes,
-                "; ".join(sha_reasons),
+                reason,
+            )
+
+    # --- provision apply branch (allow-listed mode) -----------------------
+    apply_branch = f"pulse/apply/{proposal.id}"
+    if proposal.mutation_policy == "allow-listed":
+        prov_results = apply_ops.provision_branch(apply_branch, expected_shas)
+        prov_failures = [
+            f"{repo}: {res.get('reason', 'provision failed')}"
+            for repo, res in prov_results.items()
+            if res.get("state") != "ok"
+        ]
+        if prov_failures:
+            prov_outcomes = {
+                repo: ("blocked" if prov_results.get(repo, {}).get("state") != "ok" else "ok")
+                for repo in selection
+            }
+            return _result(
+                plan,
+                "blocked",
+                version,
+                prov_outcomes,
+                f"provision apply branch failed: {'; '.join(prov_failures)}",
             )
 
     # --- executed -----------------------------------------------------------
@@ -540,8 +596,6 @@ def execute(
         message=None,
     )
     if exec_result.get("adapter_state") == "error":
-        # See module NEEDS_CONTEXT note: no per-repo attribution is
-        # possible, so the whole run fails and every repo is "failed".
         return _result(
             plan,
             "failed",
@@ -562,6 +616,55 @@ def execute(
         repo_outcomes, reason, state = validation_failure
         return _result(plan, state, version, repo_outcomes, reason)
 
+    # --- landing (allow-listed mode: commit-all then push-all) --------------
+    if proposal.mutation_policy == "allow-listed":
+        message = f"pulse-apply {proposal.id} by {proposal.actor.gh_login}@{proposal.actor.machine}"
+        commit_results = apply_ops.commit_repos(message)
+        commit_failures = [
+            f"{repo}: {res.get('reason', 'commit failed')}"
+            for repo, res in commit_results.items()
+            if res.get("state") != "ok"
+        ]
+        if commit_failures:
+            commit_outcomes = {
+                repo: ("failed" if commit_results.get(repo, {}).get("state") != "ok" else "ok")
+                for repo in selection
+            }
+            return _result(
+                plan,
+                "failed",
+                version,
+                commit_outcomes,
+                f"commit failed: {'; '.join(commit_failures)}",
+            )
+
+        push_results = apply_ops.push_repos(apply_branch)
+        push_failures = [
+            f"{repo}: {res.get('reason', 'push failed')}"
+            for repo, res in push_results.items()
+            if res.get("state") != "ok"
+        ]
+        if push_failures:
+            push_outcomes = {
+                repo: ("failed" if push_results.get(repo, {}).get("state") != "ok" else "ok")
+                for repo in selection
+            }
+            return _result(
+                plan,
+                "failed",
+                version,
+                push_outcomes,
+                f"push failed: {'; '.join(push_failures)}",
+            )
+
+        return _result(
+            plan,
+            "pushed",
+            version,
+            {repo: "ok" for repo in selection},
+            None,
+        )
+
     # --- proposed: terminal success, propose-only, never pushed -------------
     return _result(
         plan,
@@ -570,3 +673,4 @@ def execute(
         {repo: "ok" for repo in selection},
         None,
     )
+

--- a/lib/pulse/scripts/plan_sync.py
+++ b/lib/pulse/scripts/plan_sync.py
@@ -271,6 +271,7 @@ def build_apply_plans(
             expected_shas={repo: head},
             actor=actor,
             mutation_policy="propose",
+            bound_paths={repo: [path]},
         )
         doc_patch = {
             "path": path,

--- a/lib/pulse/scripts/resolve_run.py
+++ b/lib/pulse/scripts/resolve_run.py
@@ -292,8 +292,25 @@ def evaluate_binding_edges_gate(result_path):
     return True, f"{len(edges)} edge(s) current"
 
 
+def evaluate_merge_detected_gate(result_path):
+    """`merge_detected` — fail-closed gate over an apply-status result (F11).
+    Satisfied ONLY when the result file is present, validates cleanly as
+    kind `apply-status`, state is `applied`, and `merged_sha` is a
+    non-empty string."""
+    data, errors = _load_result_kind(result_path, "apply-status")
+    if data is None:
+        return False, "; ".join(errors) or "invalid apply-status result"
+    if data.get("state") != "applied":
+        return False, f"apply-status state is {data.get('state')!r}, expected 'applied'"
+    merged_sha = data.get("merged_sha")
+    if not merged_sha or not isinstance(merged_sha, str):
+        return False, "merged_sha missing or empty"
+    return True, f"merge detected: {merged_sha}"
+
+
 GATE_EVALUATORS = {
     "binding_edges_current": evaluate_binding_edges_gate,
+    "merge_detected": evaluate_merge_detected_gate,
 }
 
 
@@ -313,20 +330,34 @@ def cmd_check_gate(args):
     print(json.dumps({"satisfied": satisfied, "detail": detail}))
 
 
-def cmd_lease(args):
-    doc = load(args.file)
-    step = find_step(doc, args.step)
+class LeaseError(Exception):
+    pass
+
+
+def acquire_lease(file_path, step_id, by, ttl_minutes=120):
+    doc = load(file_path)
+    step = find_step(doc, step_id)
     lease = step.get("lease")
-    ttl = timedelta(minutes=args.ttl_minutes)
-    if lease and lease.get("leased_by") != args.by:
+    ttl = timedelta(minutes=ttl_minutes)
+    if lease and lease.get("leased_by") != by:
         age = datetime.now(timezone.utc) - parse_ts(lease["leased_at"])
         if age < ttl:
-            print(f"error: lease held by {lease['leased_by']} "
-                  f"({int(age.total_seconds() // 60)} min old)", file=sys.stderr)
-            sys.exit(3)
-    step["lease"] = {"leased_by": args.by, "leased_at": now_iso()}
-    save(args.file, doc)
-    print(json.dumps(step["lease"]))
+            raise LeaseError(
+                f"lease held by {lease['leased_by']} "
+                f"({int(age.total_seconds() // 60)} min old)"
+            )
+    step["lease"] = {"leased_by": by, "leased_at": now_iso()}
+    save(file_path, doc)
+    return step["lease"]
+
+
+def cmd_lease(args):
+    try:
+        lease = acquire_lease(args.file, args.step, args.by, args.ttl_minutes)
+        print(json.dumps(lease))
+    except LeaseError as e:
+        print(f"error: {e}", file=sys.stderr)
+        sys.exit(3)
 
 
 def main():

--- a/lib/pulse/scripts/tests/fixtures/apply-status-invalid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/apply-status-invalid.yaml
@@ -1,0 +1,13 @@
+contract_version: 1
+kind: apply-status
+workspace: testorg
+run_at: "2026-07-29T15:00:00Z"
+state: pr_opened
+proposal_id: bump-lockfile-2026-07-10
+selection: [testorg/widget, testorg/core]
+branch: pulse/apply/bump-lockfile-2026-07-10
+pushed_sha: "1234567890abcdef1234567890abcdef12345678"
+pr_url: null
+merged_sha: null
+reason: null
+errors: []

--- a/lib/pulse/scripts/tests/fixtures/apply-status-valid.yaml
+++ b/lib/pulse/scripts/tests/fixtures/apply-status-valid.yaml
@@ -1,0 +1,17 @@
+contract_version: 1
+kind: apply-status
+workspace: testorg
+run_at: "2026-07-29T15:00:00Z"
+actor:
+  gh_login: octocat
+  machine: mba-m4
+  mode: scheduled
+state: pr_opened
+proposal_id: bump-lockfile-2026-07-10
+selection: [testorg/widget, testorg/core]
+branch: pulse/apply/bump-lockfile-2026-07-10
+pushed_sha: "1234567890abcdef1234567890abcdef12345678"
+pr_url: "https://github.com/testorg/widget/pull/42"
+merged_sha: null
+reason: null
+errors: []

--- a/lib/pulse/scripts/tests/fixtures/neutral_repos/docs_repo/.generated/docs/index.html
+++ b/lib/pulse/scripts/tests/fixtures/neutral_repos/docs_repo/.generated/docs/index.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html>
+  <head><title>Docs Index</title></head>
+  <body><h1>Docs Index</h1></body>
+</html>

--- a/lib/pulse/scripts/tests/fixtures/neutral_repos/docs_repo/mkdocs.yml
+++ b/lib/pulse/scripts/tests/fixtures/neutral_repos/docs_repo/mkdocs.yml
@@ -1,0 +1,1 @@
+site_name: Sample Docs Index

--- a/lib/pulse/scripts/tests/fixtures/neutral_repos/node_repo/package-lock.json
+++ b/lib/pulse/scripts/tests/fixtures/neutral_repos/node_repo/package-lock.json
@@ -1,0 +1,7 @@
+{
+  "name": "sample-node-app",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/lib/pulse/scripts/tests/fixtures/neutral_repos/node_repo/package.json
+++ b/lib/pulse/scripts/tests/fixtures/neutral_repos/node_repo/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sample-node-app",
+  "version": "1.0.0",
+  "description": "Neutral node repo fixture"
+}

--- a/lib/pulse/scripts/tests/test_apply_acceptance.py
+++ b/lib/pulse/scripts/tests/test_apply_acceptance.py
@@ -1,0 +1,716 @@
+"""Neutral end-to-end acceptance suite and overlay dogfood suite (F11 Task 8 capstone).
+
+Composes real public entry points across F11 Tasks 1-7:
+- `pen_orchestrator.execute` (allow-listed apply landing)
+- `apply_reconcile.open_apply_pr` and `reconcile_apply` (PR open -> merge detect -> base advance)
+- `resolve_run.evaluate_merge_detected_gate` (gate evaluation)
+- `object_apply.apply_object_write` (Path B GitHub object writes)
+
+All tests run without network access, injecting explicit fake seams for CLI/remote calls.
+Known coverage boundaries are explicitly documented in test docstrings and assertions.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import pytest
+import yaml
+
+from lib.pulse.scripts import (
+    apply_reconcile,
+    mutation_plan,
+    nave_adapter,
+    object_apply,
+    pen_orchestrator,
+    resolve_run,
+    validate_result,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "neutral_repos"
+
+
+# --- Fakes & Test Helpers --------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _stub_probe(monkeypatch):
+    """Stub nave_adapter.probe to fixed available response avoiding extra CLI probe calls."""
+    monkeypatch.setattr(
+        pen_orchestrator.nave_adapter,
+        "probe",
+        lambda _runner: {"available": True, "version": "0.0.8", "protocol": 1},
+    )
+
+
+class QueuedRunner:
+    """Fake Nave runner returning pre-queued Completed instances.
+
+    KNOWN COVERAGE BOUNDARY: Nave CLI (`pen create`, `pen status`, `pen exec`)
+    execution is stubbed here. Status: not_applicable in unit test suite.
+    """
+
+    def __init__(self, results: list[nave_adapter.Completed]) -> None:
+        self.calls: list[list[str]] = []
+        self._results = list(results)
+
+    def run(self, args: list[str]) -> nave_adapter.Completed:
+        self.calls.append(args)
+        return self._results.pop(0)
+
+
+class RecordingApplyOps:
+    """Fake apply_ops recording branch provisioning, commit, and push operations.
+
+    KNOWN COVERAGE BOUNDARY: Pen clone git branch creation, committing, and remote
+    pushing are recorded in-memory. Status: not_applicable in unit test suite.
+    """
+
+    def __init__(
+        self,
+        prov_results: dict[str, dict[str, str]] | None = None,
+        commit_results: dict[str, dict[str, str]] | None = None,
+        push_results: dict[str, dict[str, str]] | None = None,
+    ) -> None:
+        self.calls: list[tuple[str, ...]] = []
+        self.prov_results = prov_results
+        self.commit_results = commit_results
+        self.push_results = push_results
+
+    def provision_branch(self, branch: str, base_shas: dict[str, str]) -> dict[str, dict[str, str]]:
+        self.calls.append(("provision_branch", branch, base_shas))
+        if self.prov_results is not None:
+            return self.prov_results
+        return {repo: {"state": "ok"} for repo in base_shas}
+
+    def commit_repos(self, message: str) -> dict[str, dict[str, str]]:
+        self.calls.append(("commit_repos", message))
+        if self.commit_results is not None:
+            return self.commit_results
+        return {"acme/docs-repo": {"state": "ok"}, "acme/node-repo": {"state": "ok"}, "acme/plugin-repo": {"state": "ok"}}
+
+    def push_repos(self, branch: str) -> dict[str, dict[str, str]]:
+        self.calls.append(("push_repos", branch))
+        if self.push_results is not None:
+            return self.push_results
+        return {"acme/docs-repo": {"state": "ok"}, "acme/node-repo": {"state": "ok"}, "acme/plugin-repo": {"state": "ok"}}
+
+
+class FakeGhOps(apply_reconcile.GhOps):
+    """Fake GitHub CLI operations for PR management and reconciliation.
+
+    KNOWN COVERAGE BOUNDARY: GitHub PR creation, viewing, and branch deletion
+    via `gh` CLI are stubbed in-memory. Status: not_applicable in unit test suite.
+    """
+
+    def __init__(self) -> None:
+        self.prs: dict[tuple[str, str], dict[str, object]] = {}
+        self.deleted_branches: list[tuple[str, str]] = []
+        self.create_calls = 0
+
+    def create_or_get_pr(
+        self, repo: str, branch: str, base: str, title: str, body: str
+    ) -> dict[str, object]:
+        key = (repo, branch)
+        if key in self.prs and self.prs[key]["state"] == "OPEN":
+            return {"url": str(self.prs[key]["url"]), "created": False}
+        self.create_calls += 1
+        url = f"https://github.com/{repo}/pull/{self.create_calls}"
+        self.prs[key] = {
+            "url": url,
+            "state": "OPEN",
+            "merged": False,
+            "merge_commit_sha": None,
+            "base": base,
+            "title": title,
+            "body": body,
+        }
+        return {"url": url, "created": True}
+
+    def view_pr(self, repo: str, branch: str) -> dict[str, object]:
+        key = (repo, branch)
+        if key not in self.prs:
+            return {
+                "state": "CLOSED",
+                "merged": False,
+                "merge_commit_sha": None,
+                "url": "",
+            }
+        pr = self.prs[key]
+        return {
+            "state": pr["state"],
+            "merged": pr["merged"],
+            "merge_commit_sha": pr["merge_commit_sha"],
+            "url": pr["url"],
+        }
+
+    def delete_remote_branch(self, repo: str, branch: str) -> dict[str, object]:
+        self.deleted_branches.append((repo, branch))
+        return {"state": "ok"}
+
+
+class FakeObjectGhOps(object_apply.ObjectGhOps):
+    """Fake GitHub object API operations for Path B writes.
+
+    KNOWN COVERAGE BOUNDARY: GitHub GraphQL/REST object writes are stubbed in-memory.
+    Status: not_applicable in unit test suite.
+    """
+
+    def __init__(self, initial_state: dict[str, dict[str, object]] | None = None) -> None:
+        self.state: dict[str, dict[str, object]] = initial_state or {}
+        self.writes: list[object_apply.ObjectWrite] = []
+
+    def get_state(self, precondition: object_apply.Precondition) -> object:
+        target_state = self.state.get(precondition.target, {})
+        if precondition.field not in target_state:
+            raise object_apply.GhExecutionError(
+                f"field {precondition.field} not found for {precondition.target}"
+            )
+        return target_state[precondition.field]
+
+    def apply_write(self, write: object_apply.ObjectWrite) -> dict[str, object]:
+        self.writes.append(write)
+        target = write.target
+        if target not in self.state:
+            self.state[target] = {}
+
+        field = write.payload.get("field") or write.precondition.field
+        val = write.desired if write.desired is not None else write.payload.get("value")
+        self.state[target][field] = val
+        return {"state": "applied", "target": target, "field": field, "value": val}
+
+
+def _pen_show_completed(repos: list[tuple[str, str]]) -> nave_adapter.Completed:
+    payload = {
+        "name": "nave/acceptance",
+        "created_at": "2026-07-29T10:00:00Z",
+        "branch": "nave/acceptance",
+        "filter": {"terms": []},
+        "repos": [
+            {
+                "owner": o,
+                "name": n,
+                "default_branch": "main",
+                "clone_url": "x",
+                "synced_at": "2026-07-29T10:00:00Z",
+            }
+            for o, n in repos
+        ],
+        "ops": [],
+    }
+    return nave_adapter.Completed(0, json.dumps(payload), "")
+
+
+def _pen_status_completed(entries: list[dict[str, object]]) -> nave_adapter.Completed:
+    return nave_adapter.Completed(0, json.dumps(entries), "")
+
+
+def _exec_ok_sequence(repos: list[tuple[str, str]]) -> list[nave_adapter.Completed]:
+    status_entries = [
+        {
+            "owner": o,
+            "repo": n,
+            "working_tree": "clean",
+            "freshness": "fresh",
+            "run_state": "not-run",
+            "divergence": "up-to-date",
+            "ahead": 0,
+            "behind": 0,
+        }
+        for o, n in repos
+    ]
+    return [
+        nave_adapter.Completed(0, "created\n", ""),
+        _pen_show_completed(repos),
+        _pen_status_completed(status_entries),
+        _pen_status_completed(status_entries),
+        nave_adapter.Completed(0, "exec ok\n", ""),
+    ]
+
+
+def _create_test_ledger(tmp_path: Path, run_id: str, step_id: str, repo: str) -> Path:
+    steps = json.dumps([
+        {
+            "id": step_id,
+            "repo": repo,
+            "gate": "merge_detected",
+            "has_workflow": True,
+        }
+    ])
+    resolve_run.cmd_create(
+        type(
+            "Args",
+            (),
+            {
+                "runs_dir": str(tmp_path),
+                "workflow": "apply-reconcile",
+                "run_id": run_id,
+                "actor_login": "octocat",
+                "actor_machine": "laptop",
+                "mode": "interactive",
+                "params": "{}",
+                "repos": repo,
+                "steps": steps,
+                "local": True,
+            },
+        )()
+    )
+    return tmp_path / "local" / f"apply-reconcile-{run_id}.yaml"
+
+
+# --- Neutral Acceptance Suite -----------------------------------------------
+
+class TestNeutralApplyAcceptanceSuite:
+    """Suite 1: Fixture-driven NEUTRAL end-to-end acceptance tests.
+
+    Tests non-plugin transformations (`regenerate-docs-index`, `refresh-node-lockfile`)
+    through the full lifecycle:
+    propose -> allow-listed apply -> branch -> push -> PR -> merge-detect -> base-advance.
+    """
+
+    def test_docs_index_neutral_lifecycle_success(self, tmp_path: Path) -> None:
+        """Full lifecycle for neutral transformation `regenerate-docs-index`."""
+        # 1. Proposal setup for neutral transformation
+        proposal = mutation_plan.build_proposal(
+            id="prop-docs-100",
+            selection=["acme/docs-repo"],
+            transformation="regenerate-docs-index",
+            expected_shas={"acme/docs-repo": "pushed_sha_base_100"},
+            actor={"gh_login": "octocat", "machine": "laptop", "mode": "interactive"},
+            mutation_policy="allow-listed",
+            bound_paths={"acme/docs-repo": [".generated/docs/**"]},
+        )
+        registry = mutation_plan.load_registry({
+            "transformations": {
+                "regenerate-docs-index": {
+                    "id": "regenerate-docs-index",
+                    "command_argv": ["mkdocs", "build", "--site-dir", ".generated/docs"],
+                    "applies_to": ["evidence_path:mkdocs.yml"],
+                    "validation": {"kind": "paths_changed"},
+                    "allow_scheduled": True,
+                }
+            }
+        })
+        plan = pen_orchestrator.PenPlan(
+            proposal=proposal,
+            entry=registry.get("regenerate-docs-index"),
+            pen_name="nave/acceptance",
+            query=nave_adapter.PenQuery(terms=[]),
+        )
+
+        runner = QueuedRunner(_exec_ok_sequence([("acme", "docs-repo")]))
+        apply_ops = RecordingApplyOps()
+
+        def read_repo_head(repo: str) -> str:
+            return "pushed_sha_base_100"
+
+        def read_repo_changed_paths(repo: str) -> tuple[str, ...]:
+            return (".generated/docs/index.html",)
+
+        # 2. Execute allow-listed apply
+        exec_res = pen_orchestrator.execute(
+            plan,
+            runner,
+            read_repo_head=read_repo_head,
+            read_repo_changed_paths=read_repo_changed_paths,
+            apply_ops=apply_ops,
+        )
+
+        # Assert: reaches state "pushed" and push targeted pulse/apply/{id}, NEVER main/base
+        assert exec_res.state == "pushed"
+        assert exec_res.repo_outcomes == {"acme/docs-repo": "ok"}
+
+        assert len(apply_ops.calls) == 3
+        prov_call, commit_call, push_call = apply_ops.calls
+        assert prov_call == (
+            "provision_branch",
+            "pulse/apply/prop-docs-100",
+            {"acme/docs-repo": "pushed_sha_base_100"},
+        )
+        assert push_call == ("push_repos", "pulse/apply/prop-docs-100")
+        assert "main" not in push_call[1]
+        assert "master" not in push_call[1]
+
+        # 3. PR Open phase
+        ledger_path = _create_test_ledger(tmp_path, "run-docs-100", "step-docs", "acme/docs-repo")
+        result_path = tmp_path / "apply-status-docs.yaml"
+        gh_ops = FakeGhOps()
+
+        doc_pr = apply_reconcile.open_apply_pr(
+            ledger_path=ledger_path,
+            step_id="step-docs",
+            proposal_id="prop-docs-100",
+            repo="acme/docs-repo",
+            branch="pulse/apply/prop-docs-100",
+            base="main",
+            pushed_sha="pushed_sha_base_100",
+            title="Apply regenerate-docs-index prop-docs-100",
+            body="Automated neutral apply PR",
+            result_path=result_path,
+            gh_ops=gh_ops,
+            actor_id="octocat@laptop",
+            workspace="acme",
+        )
+
+        assert doc_pr["state"] == "pr_opened"
+        assert doc_pr["pushed_sha"] == "pushed_sha_base_100"
+        assert validate_result.validate(doc_pr, "apply-status") == []
+
+        # Gate check before merge: merge-detected gate is NOT satisfied
+        satisfied_before, _ = resolve_run.evaluate_merge_detected_gate(str(result_path))
+        assert satisfied_before is False
+
+        # Injected base advancement stub
+        advance_calls: list[tuple[str, str]] = []
+
+        def advance_base_fake(repo: str, merged_sha: str) -> dict[str, str]:
+            advance_calls.append((repo, merged_sha))
+            return {"state": "ok"}
+
+        # First reconcile pass while PR is OPEN: base does NOT advance
+        doc_reconcile_open = apply_reconcile.reconcile_apply(
+            ledger_path=ledger_path,
+            step_id="step-docs",
+            proposal_id="prop-docs-100",
+            repo="acme/docs-repo",
+            branch="pulse/apply/prop-docs-100",
+            result_path=result_path,
+            gh_ops=gh_ops,
+            advance_base=advance_base_fake,
+            actor_id="octocat@laptop",
+            workspace="acme",
+        )
+        assert doc_reconcile_open["state"] == "pr_opened"
+        assert advance_calls == [], "Base advancement must NOT occur while PR is OPEN"
+
+        # 4. Simulate PR MERGED in GitHub
+        gh_ops.prs[("acme/docs-repo", "pulse/apply/prop-docs-100")]["state"] = "MERGED"
+        gh_ops.prs[("acme/docs-repo", "pulse/apply/prop-docs-100")]["merged"] = True
+        gh_ops.prs[("acme/docs-repo", "pulse/apply/prop-docs-100")]["merge_commit_sha"] = "merged_sha_docs_999"
+
+        doc_reconcile_merged = apply_reconcile.reconcile_apply(
+            ledger_path=ledger_path,
+            step_id="step-docs",
+            proposal_id="prop-docs-100",
+            repo="acme/docs-repo",
+            branch="pulse/apply/prop-docs-100",
+            result_path=result_path,
+            gh_ops=gh_ops,
+            advance_base=advance_base_fake,
+            actor_id="octocat@laptop",
+            workspace="acme",
+        )
+
+        # Assert: state is "applied", validates schema, merged SHA is set
+        assert doc_reconcile_merged["state"] == "applied"
+        assert doc_reconcile_merged["merged_sha"] == "merged_sha_docs_999"
+        assert validate_result.validate(doc_reconcile_merged, "apply-status") == []
+
+        # Gate check after merge: gate IS satisfied
+        satisfied_after, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
+        assert satisfied_after is True
+        assert "merged_sha_docs_999" in detail
+
+        # Assert: base advancement happened ONLY on detected merge with MERGED sha (never pushed sha)
+        assert advance_calls == [("acme/docs-repo", "merged_sha_docs_999")]
+        assert advance_calls[0][1] != "pushed_sha_base_100"
+
+    def test_neutral_bound_path_guard_fires_on_violation(self) -> None:
+        """Bound-path guard (I7) fires on neutral transformation when changed paths violate bound_paths."""
+        proposal = mutation_plan.build_proposal(
+            id="prop-docs-101",
+            selection=["acme/docs-repo"],
+            transformation="regenerate-docs-index",
+            expected_shas={"acme/docs-repo": "deadbeef"},
+            actor={"gh_login": "octocat", "machine": "laptop", "mode": "interactive"},
+            mutation_policy="allow-listed",
+            bound_paths={"acme/docs-repo": [".generated/docs/**"]},
+        )
+        registry = mutation_plan.load_registry({
+            "transformations": {
+                "regenerate-docs-index": {
+                    "id": "regenerate-docs-index",
+                    "command_argv": ["mkdocs", "build"],
+                    "applies_to": ["always"],
+                    "validation": {"kind": "paths_changed"},
+                    "allow_scheduled": True,
+                }
+            }
+        })
+        plan = pen_orchestrator.PenPlan(
+            proposal=proposal,
+            entry=registry.get("regenerate-docs-index"),
+            pen_name="nave/acceptance",
+            query=nave_adapter.PenQuery(terms=[]),
+        )
+
+        runner = QueuedRunner(_exec_ok_sequence([("acme", "docs-repo")]))
+        apply_ops = RecordingApplyOps()
+
+        def read_repo_head(repo: str) -> str:
+            return "deadbeef"
+
+        # Violating path outside .generated/docs/**
+        def read_repo_changed_paths_violating(repo: str) -> tuple[str, ...]:
+            return (".generated/docs/index.html", "src/unauthorized_code.py")
+
+        exec_res = pen_orchestrator.execute(
+            plan,
+            runner,
+            read_repo_head=read_repo_head,
+            read_repo_changed_paths=read_repo_changed_paths_violating,
+            apply_ops=apply_ops,
+        )
+
+        # Assert: fails closed with blocked or failed (NOT pushed)
+        assert exec_res.state in ("blocked", "failed")
+        assert exec_res.state != "pushed"
+        assert "bound_paths" in (exec_res.reason or "") or "out-of-bounds" in (exec_res.reason or "") or "validation" in (exec_res.reason or "")
+
+        # Assert: no push was executed
+        assert not any(call[0] == "push_repos" for call in apply_ops.calls)
+
+    def test_node_lockfile_neutral_lifecycle_success(self, tmp_path: Path) -> None:
+        """Full lifecycle for neutral transformation `refresh-node-lockfile` with json_schema validation."""
+        node_fixture_lockfile = (FIXTURES_DIR / "node_repo" / "package-lock.json").read_bytes()
+
+        proposal = mutation_plan.build_proposal(
+            id="prop-node-200",
+            selection=["acme/node-repo"],
+            transformation="refresh-node-lockfile",
+            expected_shas={"acme/node-repo": "sha_node_base_200"},
+            actor={"gh_login": "octocat", "machine": "laptop", "mode": "interactive"},
+            mutation_policy="allow-listed",
+        )
+        registry = mutation_plan.load_registry({
+            "transformations": {
+                "refresh-node-lockfile": {
+                    "id": "refresh-node-lockfile",
+                    "command_argv": ["npm", "install", "--package-lock-only"],
+                    "applies_to": ["profile:nodejs"],
+                    "validation": {
+                        "kind": "json_schema",
+                        "path": "package-lock.json",
+                        "schema": {"type": "object", "required": ["lockfileVersion"]},
+                    },
+                    "allow_scheduled": False,
+                }
+            }
+        })
+        plan = pen_orchestrator.PenPlan(
+            proposal=proposal,
+            entry=registry.get("refresh-node-lockfile"),
+            pen_name="nave/acceptance",
+            query=nave_adapter.PenQuery(terms=[]),
+        )
+
+        runner = QueuedRunner(_exec_ok_sequence([("acme", "node-repo")]))
+        apply_ops = RecordingApplyOps()
+
+        def read_repo_head(repo: str) -> str:
+            return "sha_node_base_200"
+
+        def read_repo_file(repo: str, path: str) -> bytes:
+            if repo == "acme/node-repo" and path == "package-lock.json":
+                return node_fixture_lockfile
+            raise FileNotFoundError(f"not found: {path}")
+
+        exec_res = pen_orchestrator.execute(
+            plan,
+            runner,
+            read_repo_head=read_repo_head,
+            read_repo_file=read_repo_file,
+            apply_ops=apply_ops,
+        )
+
+        assert exec_res.state == "pushed"
+        assert [c[0] for c in apply_ops.calls] == ["provision_branch", "commit_repos", "push_repos"]
+
+        # Reconcile PR & Merge
+        ledger_path = _create_test_ledger(tmp_path, "run-node-200", "step-node", "acme/node-repo")
+        result_path = tmp_path / "apply-status-node.yaml"
+        gh_ops = FakeGhOps()
+
+        apply_reconcile.open_apply_pr(
+            ledger_path=ledger_path,
+            step_id="step-node",
+            proposal_id="prop-node-200",
+            repo="acme/node-repo",
+            branch="pulse/apply/prop-node-200",
+            base="main",
+            pushed_sha="sha_node_base_200",
+            title="Apply refresh-node-lockfile prop-node-200",
+            body="Automated node lockfile PR",
+            result_path=result_path,
+            gh_ops=gh_ops,
+            actor_id="octocat@laptop",
+            workspace="acme",
+        )
+
+        gh_ops.prs[("acme/node-repo", "pulse/apply/prop-node-200")]["state"] = "MERGED"
+        gh_ops.prs[("acme/node-repo", "pulse/apply/prop-node-200")]["merged"] = True
+        gh_ops.prs[("acme/node-repo", "pulse/apply/prop-node-200")]["merge_commit_sha"] = "merged_sha_node_888"
+
+        advance_calls: list[tuple[str, str]] = []
+
+        def advance_base_fake(repo: str, merged_sha: str) -> dict[str, str]:
+            advance_calls.append((repo, merged_sha))
+            return {"state": "ok"}
+
+        doc_final = apply_reconcile.reconcile_apply(
+            ledger_path=ledger_path,
+            step_id="step-node",
+            proposal_id="prop-node-200",
+            repo="acme/node-repo",
+            branch="pulse/apply/prop-node-200",
+            result_path=result_path,
+            gh_ops=gh_ops,
+            advance_base=advance_base_fake,
+            actor_id="octocat@laptop",
+            workspace="acme",
+        )
+
+        assert doc_final["state"] == "applied"
+        assert doc_final["merged_sha"] == "merged_sha_node_888"
+        assert validate_result.validate(doc_final, "apply-status") == []
+        assert advance_calls == [("acme/node-repo", "merged_sha_node_888")]
+
+
+# --- Overlay Dogfood Suite --------------------------------------------------
+
+class TestOverlayApplySuite:
+    """Suite 2: Overlay dogfood transformations (`marketplace-entry-update`, Path B writes).
+
+    Demonstrates that overlay transformations land through the EXACT SAME neutral
+    machinery (`pen_orchestrator.execute`, `apply_reconcile`, `object_apply.apply_object_write`),
+    maintaining strict two-suite discipline.
+    """
+
+    def test_overlay_marketplace_entry_update_path_a_lifecycle(self, tmp_path: Path) -> None:
+        """Path A overlay transformation `marketplace-entry-update` lands via neutral apply machinery."""
+        proposal = mutation_plan.build_proposal(
+            id="prop-mkt-300",
+            selection=["acme/plugin-repo"],
+            transformation="marketplace-entry-update",
+            expected_shas={"acme/plugin-repo": "sha_plugin_base_300"},
+            actor={"gh_login": "octocat", "machine": "laptop", "mode": "interactive"},
+            mutation_policy="allow-listed",
+        )
+        registry = mutation_plan.load_registry({
+            "transformations": {
+                "marketplace-entry-update": {
+                    "id": "marketplace-entry-update",
+                    "command_argv": ["pulse-apply-marketplace-entry", "--patch", ".hiivmind/marketplace-entry-patch.yaml"],
+                    "applies_to": ["profile:claude-plugin"],
+                    "validation": {"kind": "none"},
+                    "allow_scheduled": False,
+                }
+            }
+        })
+        plan = pen_orchestrator.PenPlan(
+            proposal=proposal,
+            entry=registry.get("marketplace-entry-update"),
+            pen_name="nave/acceptance",
+            query=nave_adapter.PenQuery(terms=[]),
+        )
+
+        runner = QueuedRunner(_exec_ok_sequence([("acme", "plugin-repo")]))
+        apply_ops = RecordingApplyOps()
+
+        def read_repo_head(repo: str) -> str:
+            return "sha_plugin_base_300"
+
+        exec_res = pen_orchestrator.execute(
+            plan,
+            runner,
+            read_repo_head=read_repo_head,
+            apply_ops=apply_ops,
+        )
+
+        assert exec_res.state == "pushed"
+        assert apply_ops.calls[2] == ("push_repos", "pulse/apply/prop-mkt-300")
+
+        # PR & Reconcile through same neutral machinery
+        ledger_path = _create_test_ledger(tmp_path, "run-mkt-300", "step-mkt", "acme/plugin-repo")
+        result_path = tmp_path / "apply-status-mkt.yaml"
+        gh_ops = FakeGhOps()
+
+        apply_reconcile.open_apply_pr(
+            ledger_path=ledger_path,
+            step_id="step-mkt",
+            proposal_id="prop-mkt-300",
+            repo="acme/plugin-repo",
+            branch="pulse/apply/prop-mkt-300",
+            base="main",
+            pushed_sha="sha_plugin_base_300",
+            title="Apply marketplace-entry-update prop-mkt-300",
+            body="Automated marketplace entry PR",
+            result_path=result_path,
+            gh_ops=gh_ops,
+            actor_id="octocat@laptop",
+            workspace="acme",
+        )
+
+        gh_ops.prs[("acme/plugin-repo", "pulse/apply/prop-mkt-300")]["state"] = "MERGED"
+        gh_ops.prs[("acme/plugin-repo", "pulse/apply/prop-mkt-300")]["merged"] = True
+        gh_ops.prs[("acme/plugin-repo", "pulse/apply/prop-mkt-300")]["merge_commit_sha"] = "merged_sha_mkt_777"
+
+        advance_calls: list[tuple[str, str]] = []
+
+        def advance_base_fake(repo: str, merged_sha: str) -> dict[str, str]:
+            advance_calls.append((repo, merged_sha))
+            return {"state": "ok"}
+
+        doc_final = apply_reconcile.reconcile_apply(
+            ledger_path=ledger_path,
+            step_id="step-mkt",
+            proposal_id="prop-mkt-300",
+            repo="acme/plugin-repo",
+            branch="pulse/apply/prop-mkt-300",
+            result_path=result_path,
+            gh_ops=gh_ops,
+            advance_base=advance_base_fake,
+            actor_id="octocat@laptop",
+            workspace="acme",
+        )
+
+        assert doc_final["state"] == "applied"
+        assert doc_final["merged_sha"] == "merged_sha_mkt_777"
+        assert validate_result.validate(doc_final, "apply-status") == []
+        assert advance_calls == [("acme/plugin-repo", "merged_sha_mkt_777")]
+
+    def test_overlay_marketplace_entry_path_b_object_write(self) -> None:
+        """Path B object write for marketplace entry lands through neutral object_apply."""
+        gh_ops = FakeObjectGhOps({"acme/plugin-repo#mkt": {"status": "pending"}})
+        precondition = object_apply.Precondition(
+            target="acme/plugin-repo#mkt", field="status", expected="pending"
+        )
+        write = object_apply.ObjectWrite(
+            verb="update-field",
+            target="acme/plugin-repo#mkt",
+            payload={"field": "status", "value": "active"},
+            precondition=precondition,
+            desired="active",
+        )
+
+        # First execution applies write
+        res1 = object_apply.apply_object_write(
+            write,
+            policy="allow-listed",
+            mutation_allowlist=["update-field"],
+            gh_ops=gh_ops,
+        )
+        assert res1["state"] == "applied"
+        assert res1.get("noop") is False
+        assert len(gh_ops.writes) == 1
+        assert gh_ops.state["acme/plugin-repo#mkt"]["status"] == "active"
+
+        # Repeat execution is idempotent no-op
+        res2 = object_apply.apply_object_write(
+            write,
+            policy="allow-listed",
+            mutation_allowlist=["update-field"],
+            gh_ops=gh_ops,
+        )
+        assert res2["state"] == "applied"
+        assert res2.get("noop") is True
+        assert len(gh_ops.writes) == 1

--- a/lib/pulse/scripts/tests/test_apply_neutrality.py
+++ b/lib/pulse/scripts/tests/test_apply_neutrality.py
@@ -47,7 +47,7 @@ FORBIDDEN_OVERLAY_MODULES_AND_SYMBOLS = (
 
 
 def _collect_all_ast_imports(source: str) -> set[str]:
-    """Parse source and return all imported names anywhere in the AST (top-level or inside functions)."""
+    """Parse source and return all imported names anywhere in the AST (top-level, inside functions, absolute and relative)."""
     tree = ast.parse(source)
     imported: set[str] = set()
     for node in ast.walk(tree):
@@ -55,14 +55,76 @@ def _collect_all_ast_imports(source: str) -> set[str]:
             for alias in node.names:
                 imported.add(alias.name)
         elif isinstance(node, ast.ImportFrom):
-            if node.level:
-                continue
             module = node.module or ""
             if module:
                 imported.add(module)
             for alias in node.names:
-                imported.add(f"{module}.{alias.name}" if module else alias.name)
+                alias_name = alias.name
+                imported.add(alias_name)
+                if module:
+                    imported.add(f"{module}.{alias_name}")
     return imported
+
+
+def _scan_line_for_unwhitelisted_overlay_tokens(
+    line: str, in_docstring: bool
+) -> tuple[bool, bool]:
+    """Inspect line for forbidden overlay tokens.
+
+    Returns (is_flagged, new_in_docstring_state). Whitelists apply ONLY to pure
+    comment lines (# ...) or docstring prose — code before inline comments is
+    never exempted by a comment whitelist.
+    """
+    flag_patterns = [
+        re.compile(r"\bprofile_dispatch\b"),
+        re.compile(r"\bclaude_plugin\b"),
+        re.compile(r"\bregister_claude_adapters\b"),
+        re.compile(r"\bprofile:claude-plugin\b"),
+        re.compile(r"\bcorpus_generator_overlay\b"),
+    ]
+
+    whitelist_patterns = [
+        r"#.*F6 plan",
+        r"#.*F11 plan",
+        r'""".*F6 plan',
+        r"'''.*F6 plan",
+    ]
+
+    stripped = line.strip()
+
+    num_triple_double = line.count('"""')
+    num_triple_single = line.count("'''")
+    docstring_toggle = (num_triple_double % 2 == 1) or (num_triple_single % 2 == 1)
+
+    current_is_docstring = in_docstring or stripped.startswith('"""') or stripped.startswith("'''")
+    new_in_docstring = in_docstring ^ docstring_toggle
+
+    # Case 1: Pure comment line or inside docstring
+    if current_is_docstring or stripped.startswith("#"):
+        if any(re.search(pat, line) for pat in whitelist_patterns):
+            return False, new_in_docstring
+        for pat in flag_patterns:
+            if pat.search(line):
+                return True, new_in_docstring
+        return False, new_in_docstring
+
+    # Case 2: Code line (possibly with an inline comment after #)
+    parts = line.split("#", 1)
+    code_part = parts[0]
+    comment_part = f"# {parts[1]}" if len(parts) > 1 else ""
+
+    # Code before # is NEVER whitelisted by an inline comment
+    for pat in flag_patterns:
+        if pat.search(code_part):
+            return True, new_in_docstring
+
+    if comment_part:
+        if not any(re.search(pat, comment_part) for pat in whitelist_patterns):
+            for pat in flag_patterns:
+                if pat.search(comment_part):
+                    return True, new_in_docstring
+
+    return False, new_in_docstring
 
 
 @pytest.mark.parametrize("module_path", APPLY_MODULE_PATHS)
@@ -76,7 +138,12 @@ def test_apply_module_imports_no_overlay_modules_structural_ast(module_path: str
     forbidden_hits: list[str] = []
     for imp in imported:
         for forbidden in FORBIDDEN_OVERLAY_MODULES_AND_SYMBOLS:
-            if imp == forbidden or imp.startswith(forbidden + ".") or imp.endswith("." + forbidden):
+            if (
+                imp == forbidden
+                or imp.startswith(forbidden + ".")
+                or imp.endswith("." + forbidden)
+                or f".{forbidden}." in f".{imp}."
+            ):
                 forbidden_hits.append(imp)
 
     assert forbidden_hits == [], (
@@ -111,30 +178,46 @@ def test_apply_module_secondary_whitelisted_lexical_heuristic(module_path: str) 
     full_path = REPO_ROOT / module_path
     source = full_path.read_text()
 
-    flag_patterns = [
-        re.compile(r"\bclaude_plugin\b"),
-        re.compile(r"\bregister_claude_adapters\b"),
-        re.compile(r"\bprofile:claude-plugin\b"),
-        re.compile(r"\bcorpus_generator_overlay\b"),
-    ]
-
-    whitelist_patterns = [
-        r"#.*F6 plan",
-        r"#.*F11 plan",
-        r'""".*F6 plan',
-    ]
-
     lines = source.splitlines()
     unwhitelisted_hits: list[tuple[int, str]] = []
+    in_docstring = False
 
     for idx, line in enumerate(lines, 1):
-        if any(re.search(pat, line) for pat in whitelist_patterns):
-            continue
-        for pat in flag_patterns:
-            if pat.search(line):
-                unwhitelisted_hits.append((idx, line.strip()))
+        flagged, in_docstring = _scan_line_for_unwhitelisted_overlay_tokens(line, in_docstring)
+        if flagged:
+            unwhitelisted_hits.append((idx, line.strip()))
 
     assert unwhitelisted_hits == [], (
         f"Secondary lexical scan found unwhitelisted overlay references in {module_path}: "
         f"{unwhitelisted_hits}"
     )
+
+
+def test_relative_import_detection_in_ast_guard() -> None:
+    """Unit test for Important 1: Proves relative imports of forbidden overlay modules are caught."""
+    synthetic_sources = [
+        "from .profile_dispatch import foo",
+        "from . import profile_dispatch",
+        "from ..adapters.claude_plugin import bar",
+        "from .marketplace_sync import sync",
+    ]
+    for src in synthetic_sources:
+        imported = _collect_all_ast_imports(src)
+        hits = []
+        for imp in imported:
+            for forbidden in FORBIDDEN_OVERLAY_MODULES_AND_SYMBOLS:
+                if (
+                    imp == forbidden
+                    or imp.startswith(forbidden + ".")
+                    or imp.endswith("." + forbidden)
+                    or f".{forbidden}." in f".{imp}."
+                ):
+                    hits.append(imp)
+        assert hits != [], f"Relative import not detected as forbidden in source: {src}"
+
+
+def test_inline_comment_not_whitelisted_in_secondary_scan() -> None:
+    """Unit test for Important 2: Proves inline comments do NOT whitelist code on the same line."""
+    synthetic_line = "import profile_dispatch  # F6 plan"
+    flagged, _ = _scan_line_for_unwhitelisted_overlay_tokens(synthetic_line, in_docstring=False)
+    assert flagged is True, "Inline comment must NOT whitelist forbidden code before #"

--- a/lib/pulse/scripts/tests/test_apply_neutrality.py
+++ b/lib/pulse/scripts/tests/test_apply_neutrality.py
@@ -1,0 +1,140 @@
+"""Structural neutrality guard for apply-mode modules (F11 Task 8).
+
+Guarantees that apply-mode modules carry NO plugin/overlay knowledge:
+1. AST / Import-Graph Guard (PRIMARY): Ensures pen_orchestrator, apply_reconcile,
+   object_apply, pen_clone_reader, and nave_adapter import NO plugin/overlay modules
+   or overlay registration functions (top-level or inside functions).
+2. Predicate Evaluation Guard: Asserts no `profile:claude-plugin` predicate logic
+   is evaluated in the apply code paths.
+3. Secondary Whitelisted Lexical Heuristic: A string-grep scanner with an explicit
+   whitelist for legitimate prose references.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+import re
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+APPLY_MODULE_PATHS = (
+    "lib/pulse/scripts/pen_orchestrator.py",
+    "lib/pulse/scripts/apply_reconcile.py",
+    "lib/pulse/scripts/object_apply.py",
+    "lib/pulse/scripts/pen_clone_reader.py",
+    "lib/pulse/scripts/nave_adapter.py",
+)
+
+FORBIDDEN_OVERLAY_MODULES_AND_SYMBOLS = (
+    "profile_dispatch",
+    "lib.pulse.scripts.profile_dispatch",
+    "claude_plugin",
+    "lib.pulse.scripts.adapters.claude_plugin",
+    "register_claude_adapters",
+    "marketplace_sync",
+    "lib.pulse.scripts.marketplace_sync",
+    "repo_claims",
+    "lib.pulse.scripts.repo_claims",
+    "apply_marketplace_entry",
+    "lib.pulse.scripts.apply_marketplace_entry",
+    "apply_doc_patch",
+    "lib.pulse.scripts.apply_doc_patch",
+    "corpus_generator_overlay",
+    "skills_path_resolver",
+)
+
+
+def _collect_all_ast_imports(source: str) -> set[str]:
+    """Parse source and return all imported names anywhere in the AST (top-level or inside functions)."""
+    tree = ast.parse(source)
+    imported: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                imported.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                continue
+            module = node.module or ""
+            if module:
+                imported.add(module)
+            for alias in node.names:
+                imported.add(f"{module}.{alias.name}" if module else alias.name)
+    return imported
+
+
+@pytest.mark.parametrize("module_path", APPLY_MODULE_PATHS)
+def test_apply_module_imports_no_overlay_modules_structural_ast(module_path: str) -> None:
+    """PRIMARY AST GUARD: Assert apply module imports zero plugin/overlay modules or functions."""
+    full_path = REPO_ROOT / module_path
+    assert full_path.exists(), f"module file not found: {module_path}"
+    source = full_path.read_text()
+    imported = _collect_all_ast_imports(source)
+
+    forbidden_hits: list[str] = []
+    for imp in imported:
+        for forbidden in FORBIDDEN_OVERLAY_MODULES_AND_SYMBOLS:
+            if imp == forbidden or imp.startswith(forbidden + ".") or imp.endswith("." + forbidden):
+                forbidden_hits.append(imp)
+
+    assert forbidden_hits == [], (
+        f"Apply module {module_path} imports plugin/overlay symbol(s): {forbidden_hits}. "
+        "Apply-mode modules must be strictly neutral and carry no plugin/overlay imports."
+    )
+
+
+@pytest.mark.parametrize("module_path", APPLY_MODULE_PATHS)
+def test_apply_module_evaluates_no_claude_plugin_predicates_ast(module_path: str) -> None:
+    """AST PREDICATE GUARD: Assert apply module code path evaluates no profile:claude-plugin predicates."""
+    full_path = REPO_ROOT / module_path
+    source = full_path.read_text()
+    tree = ast.parse(source)
+
+    claude_pred_hits: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            val = node.value
+            if "profile:claude-plugin" in val:
+                claude_pred_hits.append(val)
+
+    assert claude_pred_hits == [], (
+        f"Apply module {module_path} hardcodes or evaluates `profile:claude-plugin` predicate logic: "
+        f"{claude_pred_hits}. Neutral apply paths must evaluate no overlay-specific predicates."
+    )
+
+
+@pytest.mark.parametrize("module_path", APPLY_MODULE_PATHS)
+def test_apply_module_secondary_whitelisted_lexical_heuristic(module_path: str) -> None:
+    """SECONDARY HEURISTIC: Lexical scan with whitelist for legitimate prose cross-references."""
+    full_path = REPO_ROOT / module_path
+    source = full_path.read_text()
+
+    flag_patterns = [
+        re.compile(r"\bclaude_plugin\b"),
+        re.compile(r"\bregister_claude_adapters\b"),
+        re.compile(r"\bprofile:claude-plugin\b"),
+        re.compile(r"\bcorpus_generator_overlay\b"),
+    ]
+
+    whitelist_patterns = [
+        r"#.*F6 plan",
+        r"#.*F11 plan",
+        r'""".*F6 plan',
+    ]
+
+    lines = source.splitlines()
+    unwhitelisted_hits: list[tuple[int, str]] = []
+
+    for idx, line in enumerate(lines, 1):
+        if any(re.search(pat, line) for pat in whitelist_patterns):
+            continue
+        for pat in flag_patterns:
+            if pat.search(line):
+                unwhitelisted_hits.append((idx, line.strip()))
+
+    assert unwhitelisted_hits == [], (
+        f"Secondary lexical scan found unwhitelisted overlay references in {module_path}: "
+        f"{unwhitelisted_hits}"
+    )

--- a/lib/pulse/scripts/tests/test_apply_reconcile.py
+++ b/lib/pulse/scripts/tests/test_apply_reconcile.py
@@ -1,0 +1,444 @@
+"""Tests for apply_reconcile.py — resumable PR open, merge detection, and base advance (F11 Task 6)."""
+
+import json
+import pytest
+import yaml
+
+from lib.pulse.scripts import apply_reconcile
+from lib.pulse.scripts import resolve_run
+from lib.pulse.scripts import validate_result
+
+
+class FakeGhOps(apply_reconcile.GhOps):
+
+    def __init__(self):
+        self.prs = {}
+        self.deleted_branches = []
+        self.create_calls = 0
+
+    def create_or_get_pr(
+        self, repo: str, branch: str, base: str, title: str, body: str
+    ) -> dict:
+        key = (repo, branch)
+        if key in self.prs and self.prs[key]["state"] == "OPEN":
+            return {"url": self.prs[key]["url"], "created": False}
+        self.create_calls += 1
+        url = f"https://github.com/{repo}/pull/{self.create_calls}"
+        self.prs[key] = {
+            "url": url,
+            "state": "OPEN",
+            "merged": False,
+            "merge_commit_sha": None,
+            "base": base,
+            "title": title,
+            "body": body,
+        }
+        return {"url": url, "created": True}
+
+    def view_pr(self, repo: str, branch: str) -> dict:
+        key = (repo, branch)
+        if key not in self.prs:
+            return {
+                "state": "CLOSED",
+                "merged": False,
+                "merge_commit_sha": None,
+                "url": "",
+            }
+        pr = self.prs[key]
+        return {
+            "state": pr["state"],
+            "merged": pr["merged"],
+            "merge_commit_sha": pr["merge_commit_sha"],
+            "url": pr["url"],
+        }
+
+    def delete_remote_branch(self, repo: str, branch: str) -> dict:
+        self.deleted_branches.append((repo, branch))
+        return {"state": "ok"}
+
+
+def create_test_ledger(tmp_path, step_id="reconcile-repo1"):
+    steps = json.dumps([
+        {
+            "id": step_id,
+            "repo": "testorg/repo1",
+            "gate": "merge_detected",
+            "has_workflow": True,
+        }
+    ])
+    r = resolve_run.cmd_create(
+        type(
+            "Args",
+            (),
+            {
+                "runs_dir": str(tmp_path),
+                "workflow": "apply-reconcile",
+                "run_id": "2026-07-29-octocat-120000",
+                "actor_login": "octocat",
+                "actor_machine": "mba-m4",
+                "mode": "interactive",
+                "params": "{}",
+                "repos": "testorg/repo1",
+                "steps": steps,
+                "local": True,
+            },
+        )()
+    )
+    return tmp_path / "local" / "apply-reconcile-2026-07-29-octocat-120000.yaml"
+
+
+def test_open_apply_pr_creates_and_reuses_pr(tmp_path):
+    ledger_path = create_test_ledger(tmp_path)
+    result_path = tmp_path / "apply-status-repo1.yaml"
+    gh_ops = FakeGhOps()
+
+    doc = apply_reconcile.open_apply_pr(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        base="main",
+        pushed_sha="pushed_sha_111",
+        title="Apply proposal prop-101",
+        body="Automated apply PR",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    assert doc["state"] == "pr_opened"
+    assert doc["pushed_sha"] == "pushed_sha_111"
+    assert doc["pr_url"] == "https://github.com/testorg/repo1/pull/1"
+    assert validate_result.validate(doc, "apply-status") == []
+    assert gh_ops.create_calls == 1
+
+    # Second pass reuses PR without creating duplicate
+    doc2 = apply_reconcile.open_apply_pr(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        base="main",
+        pushed_sha="pushed_sha_111",
+        title="Apply proposal prop-101",
+        body="Automated apply PR",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    assert doc2["pr_url"] == doc["pr_url"]
+    assert gh_ops.create_calls == 1
+
+    ledger_doc = resolve_run.load(ledger_path)
+    step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
+    assert step["status"] == "blocked-on-gate"
+
+
+def test_reconcile_open_pr_withholds_base(tmp_path):
+    ledger_path = create_test_ledger(tmp_path)
+    result_path = tmp_path / "apply-status-repo1.yaml"
+    gh_ops = FakeGhOps()
+
+    apply_reconcile.open_apply_pr(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        base="main",
+        pushed_sha="pushed_sha_111",
+        title="Apply proposal prop-101",
+        body="Automated apply PR",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    advance_calls = []
+    doc = apply_reconcile.reconcile_apply(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        advance_base=lambda repo, sha: advance_calls.append((repo, sha)),
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    assert doc["state"] == "pr_opened"
+    assert advance_calls == []
+
+    satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
+    assert satisfied is False
+
+    ledger_doc = resolve_run.load(ledger_path)
+    step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
+    assert step["status"] == "blocked-on-gate"
+
+
+def test_reconcile_merged_pr_advances_base_off_merged_sha(tmp_path):
+    ledger_path = create_test_ledger(tmp_path)
+    result_path = tmp_path / "apply-status-repo1.yaml"
+    gh_ops = FakeGhOps()
+
+    apply_reconcile.open_apply_pr(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        base="main",
+        pushed_sha="pushed_sha_111",
+        title="Apply proposal prop-101",
+        body="Automated apply PR",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    # Mark PR merged in fake
+    gh_ops.prs[("testorg/repo1", "pulse/apply/prop-101")] = {
+        "url": "https://github.com/testorg/repo1/pull/1",
+        "state": "MERGED",
+        "merged": True,
+        "merge_commit_sha": "merged_commit_sha_999",
+        "base": "main",
+        "title": "Apply proposal prop-101",
+        "body": "Automated apply PR",
+    }
+
+    advance_calls = []
+    doc = apply_reconcile.reconcile_apply(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        advance_base=lambda repo, sha: advance_calls.append((repo, sha)),
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    assert doc["state"] == "applied"
+    assert doc["merged_sha"] == "merged_commit_sha_999"
+    assert validate_result.validate(doc, "apply-status") == []
+
+    satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
+    assert satisfied is True
+    assert "merged_commit_sha_999" in detail
+
+    assert advance_calls == [("testorg/repo1", "merged_commit_sha_999")]
+
+    ledger_doc = resolve_run.load(ledger_path)
+    step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
+    assert step["status"] == "done"
+
+
+def test_reconcile_closed_unmerged_pr_rejects_and_deletes_branch(tmp_path):
+    ledger_path = create_test_ledger(tmp_path)
+    result_path = tmp_path / "apply-status-repo1.yaml"
+    gh_ops = FakeGhOps()
+
+    apply_reconcile.open_apply_pr(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        base="main",
+        pushed_sha="pushed_sha_111",
+        title="Apply proposal prop-101",
+        body="Automated apply PR",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    # Mark PR closed unmerged
+    gh_ops.prs[("testorg/repo1", "pulse/apply/prop-101")]["state"] = "CLOSED"
+    gh_ops.prs[("testorg/repo1", "pulse/apply/prop-101")]["merged"] = False
+
+    advance_calls = []
+    doc = apply_reconcile.reconcile_apply(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        advance_base=lambda repo, sha: advance_calls.append((repo, sha)),
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    assert doc["state"] == "rejected"
+    assert doc["reason"] is not None
+    assert validate_result.validate(doc, "apply-status") == []
+    assert advance_calls == []
+    assert gh_ops.deleted_branches == [("testorg/repo1", "pulse/apply/prop-101")]
+
+    ledger_doc = resolve_run.load(ledger_path)
+    step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
+    assert step["status"] == "failed"
+    assert ledger_doc["status"] == "failed"
+
+
+def test_reconcile_applied_step_is_idempotent_noop(tmp_path):
+    ledger_path = create_test_ledger(tmp_path)
+    result_path = tmp_path / "apply-status-repo1.yaml"
+    gh_ops = FakeGhOps()
+
+    apply_reconcile.open_apply_pr(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        base="main",
+        pushed_sha="pushed_sha_111",
+        title="Apply proposal prop-101",
+        body="Automated apply PR",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    gh_ops.prs[("testorg/repo1", "pulse/apply/prop-101")] = {
+        "url": "https://github.com/testorg/repo1/pull/1",
+        "state": "MERGED",
+        "merged": True,
+        "merge_commit_sha": "merged_commit_sha_999",
+        "base": "main",
+        "title": "Apply proposal prop-101",
+        "body": "Automated apply PR",
+    }
+
+    advance_calls = []
+    apply_reconcile.reconcile_apply(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        advance_base=lambda repo, sha: advance_calls.append((repo, sha)),
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+    assert len(advance_calls) == 1
+
+    # Re-run on already applied step
+    doc2 = apply_reconcile.reconcile_apply(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        advance_base=lambda repo, sha: advance_calls.append((repo, sha)),
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+    assert doc2["state"] == "applied"
+    assert len(advance_calls) == 1  # No duplicate advance!
+
+
+def test_lease_concurrency_blocks_second_actor(tmp_path):
+    ledger_path = create_test_ledger(tmp_path)
+    result_path = tmp_path / "apply-status-repo1.yaml"
+    gh_ops = FakeGhOps()
+
+    apply_reconcile.open_apply_pr(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        base="main",
+        pushed_sha="pushed_sha_111",
+        title="Apply proposal prop-101",
+        body="Automated apply PR",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        actor_id="actor1@machine1",
+        workspace="testorg",
+    )
+
+    with pytest.raises(resolve_run.LeaseError):
+        apply_reconcile.reconcile_apply(
+            ledger_path=ledger_path,
+            step_id="reconcile-repo1",
+            proposal_id="prop-101",
+            repo="testorg/repo1",
+            branch="pulse/apply/prop-101",
+            result_path=result_path,
+            gh_ops=gh_ops,
+            advance_base=lambda repo, sha: None,
+            actor_id="actor2@machine2",
+            workspace="testorg",
+        )
+
+
+def test_merge_detected_gate_evaluator_fail_closed(tmp_path):
+    result_path = tmp_path / "apply-status.yaml"
+
+    # Missing file
+    satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
+    assert satisfied is False
+
+    # State pr_opened
+    apply_reconcile.write_apply_status(
+        result_path,
+        proposal_id="p1",
+        repo="r1",
+        branch="b1",
+        state="pr_opened",
+        pushed_sha="sha1",
+        pr_url="https://pr1",
+    )
+    satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
+    assert satisfied is False
+
+    # State rejected
+    apply_reconcile.write_apply_status(
+        result_path,
+        proposal_id="p1",
+        repo="r1",
+        branch="b1",
+        state="rejected",
+        reason="closed",
+    )
+    satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
+    assert satisfied is False
+
+    # State applied with merged_sha
+    apply_reconcile.write_apply_status(
+        result_path,
+        proposal_id="p1",
+        repo="r1",
+        branch="b1",
+        state="applied",
+        pushed_sha="sha1",
+        pr_url="https://pr1",
+        merged_sha="sha_merged_456",
+    )
+    satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
+    assert satisfied is True
+    assert "sha_merged_456" in detail

--- a/lib/pulse/scripts/tests/test_apply_reconcile.py
+++ b/lib/pulse/scripts/tests/test_apply_reconcile.py
@@ -45,6 +45,14 @@ class FakeGhOps(apply_reconcile.GhOps):
                 "url": "",
             }
         pr = self.prs[key]
+        if pr.get("state") == "ERROR":
+            return {
+                "state": "ERROR",
+                "merged": False,
+                "merge_commit_sha": None,
+                "url": "",
+                "error": pr.get("error", "simulated gh view_pr execution failure"),
+            }
         return {
             "state": pr["state"],
             "merged": pr["merged"],
@@ -114,7 +122,6 @@ def test_open_apply_pr_creates_and_reuses_pr(tmp_path):
     assert validate_result.validate(doc, "apply-status") == []
     assert gh_ops.create_calls == 1
 
-    # Second pass reuses PR without creating duplicate
     doc2 = apply_reconcile.open_apply_pr(
         ledger_path=ledger_path,
         step_id="reconcile-repo1",
@@ -161,6 +168,11 @@ def test_reconcile_open_pr_withholds_base(tmp_path):
     )
 
     advance_calls = []
+
+    def advance_fake(r, s):
+        advance_calls.append((r, s))
+        return {"state": "ok"}
+
     doc = apply_reconcile.reconcile_apply(
         ledger_path=ledger_path,
         step_id="reconcile-repo1",
@@ -169,7 +181,7 @@ def test_reconcile_open_pr_withholds_base(tmp_path):
         branch="pulse/apply/prop-101",
         result_path=result_path,
         gh_ops=gh_ops,
-        advance_base=lambda repo, sha: advance_calls.append((repo, sha)),
+        advance_base=advance_fake,
         actor_id="octocat@mba-m4",
         workspace="testorg",
     )
@@ -183,6 +195,65 @@ def test_reconcile_open_pr_withholds_base(tmp_path):
     ledger_doc = resolve_run.load(ledger_path)
     step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
     assert step["status"] == "blocked-on-gate"
+
+
+def test_reconcile_gh_error_withholds_and_does_not_delete_branch(tmp_path):
+    """Critical fix: transient gh view_pr error must NOT trigger branch deletion or terminal failure."""
+    ledger_path = create_test_ledger(tmp_path)
+    result_path = tmp_path / "apply-status-repo1.yaml"
+    gh_ops = FakeGhOps()
+
+    apply_reconcile.open_apply_pr(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        base="main",
+        pushed_sha="pushed_sha_111",
+        title="Apply proposal prop-101",
+        body="Automated apply PR",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    # Simulate network outage / rate limit failure on gh view_pr
+    gh_ops.prs[("testorg/repo1", "pulse/apply/prop-101")] = {
+        "state": "ERROR",
+        "error": "rate limit exceeded",
+    }
+
+    advance_calls = []
+
+    def advance_fake(r, s):
+        advance_calls.append((r, s))
+        return {"state": "ok"}
+
+    doc = apply_reconcile.reconcile_apply(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        advance_base=advance_fake,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    # Step must WITHHOLD: status remains blocked-on-gate, branch NOT deleted, run NOT failed
+    assert doc["state"] == "pr_opened"
+    assert gh_ops.deleted_branches == []
+    assert advance_calls == []
+
+    ledger_doc = resolve_run.load(ledger_path)
+    step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
+    assert step["status"] == "blocked-on-gate"
+    assert ledger_doc["status"] == "blocked-on-gate"
+    assert any("rate limit" in note for note in step["notes"])
 
 
 def test_reconcile_merged_pr_advances_base_off_merged_sha(tmp_path):
@@ -206,7 +277,6 @@ def test_reconcile_merged_pr_advances_base_off_merged_sha(tmp_path):
         workspace="testorg",
     )
 
-    # Mark PR merged in fake
     gh_ops.prs[("testorg/repo1", "pulse/apply/prop-101")] = {
         "url": "https://github.com/testorg/repo1/pull/1",
         "state": "MERGED",
@@ -218,6 +288,11 @@ def test_reconcile_merged_pr_advances_base_off_merged_sha(tmp_path):
     }
 
     advance_calls = []
+
+    def advance_fake(r, s):
+        advance_calls.append((r, s))
+        return {"state": "ok"}
+
     doc = apply_reconcile.reconcile_apply(
         ledger_path=ledger_path,
         step_id="reconcile-repo1",
@@ -226,7 +301,7 @@ def test_reconcile_merged_pr_advances_base_off_merged_sha(tmp_path):
         branch="pulse/apply/prop-101",
         result_path=result_path,
         gh_ops=gh_ops,
-        advance_base=lambda repo, sha: advance_calls.append((repo, sha)),
+        advance_base=advance_fake,
         actor_id="octocat@mba-m4",
         workspace="testorg",
     )
@@ -244,6 +319,107 @@ def test_reconcile_merged_pr_advances_base_off_merged_sha(tmp_path):
     ledger_doc = resolve_run.load(ledger_path)
     step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
     assert step["status"] == "done"
+
+
+def test_reconcile_applied_crash_recovery(tmp_path):
+    """Important 1 fix: crash after writing applied status but before advance_base finishes resume execution."""
+    ledger_path = create_test_ledger(tmp_path)
+    result_path = tmp_path / "apply-status-repo1.yaml"
+    gh_ops = FakeGhOps()
+
+    # Pre-write an applied status file, but ledger step is still blocked-on-gate (simulating a crash)
+    apply_reconcile.write_apply_status(
+        result_path,
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        state="applied",
+        pushed_sha="pushed_sha_111",
+        pr_url="https://github.com/testorg/repo1/pull/1",
+        merged_sha="merged_commit_sha_777",
+        workspace="testorg",
+    )
+
+    advance_calls = []
+
+    def advance_fake(r, s):
+        advance_calls.append((r, s))
+        return {"state": "ok"}
+
+    doc = apply_reconcile.reconcile_apply(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        advance_base=advance_fake,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    assert doc["state"] == "applied"
+    assert advance_calls == [("testorg/repo1", "merged_commit_sha_777")]
+
+    ledger_doc = resolve_run.load(ledger_path)
+    step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
+    assert step["status"] == "done"
+
+
+def test_reconcile_advance_base_failure_keeps_step_blocked(tmp_path):
+    """Important 2 fix: advance_base failure must NOT mark step done."""
+    ledger_path = create_test_ledger(tmp_path)
+    result_path = tmp_path / "apply-status-repo1.yaml"
+    gh_ops = FakeGhOps()
+
+    apply_reconcile.open_apply_pr(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        base="main",
+        pushed_sha="pushed_sha_111",
+        title="Apply proposal prop-101",
+        body="Automated apply PR",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    gh_ops.prs[("testorg/repo1", "pulse/apply/prop-101")] = {
+        "url": "https://github.com/testorg/repo1/pull/1",
+        "state": "MERGED",
+        "merged": True,
+        "merge_commit_sha": "merged_commit_sha_999",
+        "base": "main",
+        "title": "Apply proposal prop-101",
+        "body": "Automated apply PR",
+    }
+
+    def failing_advance(r, s):
+        return {"state": "failed", "reason": "git push rejected"}
+
+    doc = apply_reconcile.reconcile_apply(
+        ledger_path=ledger_path,
+        step_id="reconcile-repo1",
+        proposal_id="prop-101",
+        repo="testorg/repo1",
+        branch="pulse/apply/prop-101",
+        result_path=result_path,
+        gh_ops=gh_ops,
+        advance_base=failing_advance,
+        actor_id="octocat@mba-m4",
+        workspace="testorg",
+    )
+
+    assert doc["state"] == "applied"
+    ledger_doc = resolve_run.load(ledger_path)
+    step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
+    assert step["status"] == "blocked-on-gate"
+    assert any("git push rejected" in note for note in step["notes"])
 
 
 def test_reconcile_closed_unmerged_pr_rejects_and_deletes_branch(tmp_path):
@@ -267,11 +443,15 @@ def test_reconcile_closed_unmerged_pr_rejects_and_deletes_branch(tmp_path):
         workspace="testorg",
     )
 
-    # Mark PR closed unmerged
     gh_ops.prs[("testorg/repo1", "pulse/apply/prop-101")]["state"] = "CLOSED"
     gh_ops.prs[("testorg/repo1", "pulse/apply/prop-101")]["merged"] = False
 
     advance_calls = []
+
+    def advance_fake(r, s):
+        advance_calls.append((r, s))
+        return {"state": "ok"}
+
     doc = apply_reconcile.reconcile_apply(
         ledger_path=ledger_path,
         step_id="reconcile-repo1",
@@ -280,7 +460,7 @@ def test_reconcile_closed_unmerged_pr_rejects_and_deletes_branch(tmp_path):
         branch="pulse/apply/prop-101",
         result_path=result_path,
         gh_ops=gh_ops,
-        advance_base=lambda repo, sha: advance_calls.append((repo, sha)),
+        advance_base=advance_fake,
         actor_id="octocat@mba-m4",
         workspace="testorg",
     )
@@ -329,6 +509,11 @@ def test_reconcile_applied_step_is_idempotent_noop(tmp_path):
     }
 
     advance_calls = []
+
+    def advance_fake(r, s):
+        advance_calls.append((r, s))
+        return {"state": "ok"}
+
     apply_reconcile.reconcile_apply(
         ledger_path=ledger_path,
         step_id="reconcile-repo1",
@@ -337,13 +522,12 @@ def test_reconcile_applied_step_is_idempotent_noop(tmp_path):
         branch="pulse/apply/prop-101",
         result_path=result_path,
         gh_ops=gh_ops,
-        advance_base=lambda repo, sha: advance_calls.append((repo, sha)),
+        advance_base=advance_fake,
         actor_id="octocat@mba-m4",
         workspace="testorg",
     )
     assert len(advance_calls) == 1
 
-    # Re-run on already applied step
     doc2 = apply_reconcile.reconcile_apply(
         ledger_path=ledger_path,
         step_id="reconcile-repo1",
@@ -352,12 +536,12 @@ def test_reconcile_applied_step_is_idempotent_noop(tmp_path):
         branch="pulse/apply/prop-101",
         result_path=result_path,
         gh_ops=gh_ops,
-        advance_base=lambda repo, sha: advance_calls.append((repo, sha)),
+        advance_base=advance_fake,
         actor_id="octocat@mba-m4",
         workspace="testorg",
     )
     assert doc2["state"] == "applied"
-    assert len(advance_calls) == 1  # No duplicate advance!
+    assert len(advance_calls) == 1  # Idempotent: no duplicate advance!
 
 
 def test_lease_concurrency_blocks_second_actor(tmp_path):
@@ -390,7 +574,7 @@ def test_lease_concurrency_blocks_second_actor(tmp_path):
             branch="pulse/apply/prop-101",
             result_path=result_path,
             gh_ops=gh_ops,
-            advance_base=lambda repo, sha: None,
+            advance_base=lambda repo, sha: {"state": "ok"},
             actor_id="actor2@machine2",
             workspace="testorg",
         )
@@ -399,11 +583,9 @@ def test_lease_concurrency_blocks_second_actor(tmp_path):
 def test_merge_detected_gate_evaluator_fail_closed(tmp_path):
     result_path = tmp_path / "apply-status.yaml"
 
-    # Missing file
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
     assert satisfied is False
 
-    # State pr_opened
     apply_reconcile.write_apply_status(
         result_path,
         proposal_id="p1",
@@ -416,7 +598,6 @@ def test_merge_detected_gate_evaluator_fail_closed(tmp_path):
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
     assert satisfied is False
 
-    # State rejected
     apply_reconcile.write_apply_status(
         result_path,
         proposal_id="p1",
@@ -428,7 +609,6 @@ def test_merge_detected_gate_evaluator_fail_closed(tmp_path):
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
     assert satisfied is False
 
-    # State applied with merged_sha
     apply_reconcile.write_apply_status(
         result_path,
         proposal_id="p1",

--- a/lib/pulse/scripts/tests/test_executor_on_path.py
+++ b/lib/pulse/scripts/tests/test_executor_on_path.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 import hashlib
 import json
 from pathlib import Path
-import subprocess
-import sys
 import pytest
 
 from lib.pulse.scripts import mutation_plan
@@ -58,6 +56,13 @@ def test_probe_required_tool_returns_blocked_when_tool_absent(tmp_path):
     assert result["state"] == "blocked"
     assert "npm" in result["reason"]
     assert "nodejs" in result["reason"]
+
+
+def test_probe_required_tool_honors_explicit_path_env(tmp_path):
+    fake_path = str(tmp_path)
+    # Even for a known console script, an explicit path_env must not fall back to sysconfig scripts
+    result = executor_probe.probe_required_tool("pulse-apply-doc-patch", path_env=fake_path)
+    assert result["state"] == "blocked"
 
 
 def test_apply_doc_patch_entry_applies_change_and_rejects_path_escape(tmp_path, monkeypatch):
@@ -136,3 +141,25 @@ def test_apply_marketplace_entry_applies_change_and_rejects_path_escape(tmp_path
     patch_path.write_text(patch_escape)
     ret_escape = apply_marketplace_entry.main(["--patch", ".hiivmind/marketplace-entry-patch.yaml"])
     assert ret_escape != 0
+
+
+def test_apply_marketplace_entry_with_raw_content_replacement(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    target = tmp_path / "marketplace.json"
+    initial = '{"plugins": []}\n'
+    target.write_text(initial)
+
+    patch_path = tmp_path / ".hiivmind" / "marketplace-entry-patch.yaml"
+    patch_path.parent.mkdir(parents=True, exist_ok=True)
+    new_text = '{"plugins": [{"name": "new-plugin", "version": "1.0.0"}]}\n'
+    patch_content = (
+        "path: marketplace.json\n"
+        f"base_blob: {_blob(initial)}\n"
+        f"content: '{new_text.strip()}'\n"
+        "output_paths: [marketplace.json]\n"
+    )
+    patch_path.write_text(patch_content)
+
+    ret = apply_marketplace_entry.main(["--patch", ".hiivmind/marketplace-entry-patch.yaml"])
+    assert ret == 0
+    assert target.read_text() == new_text.strip()

--- a/lib/pulse/scripts/tests/test_executor_on_path.py
+++ b/lib/pulse/scripts/tests/test_executor_on_path.py
@@ -1,0 +1,138 @@
+"""Tests for Task 1 (B1): Executor on PATH & command_argv safety checks."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+import sys
+import pytest
+
+from lib.pulse.scripts import mutation_plan
+from lib.pulse.scripts import executor_probe
+from lib.pulse.scripts import apply_doc_patch_entry
+from lib.pulse.scripts import apply_marketplace_entry
+
+
+TEMPLATE_PATH = Path("templates/transformations.yaml.template").resolve()
+
+
+def _blob(text: str) -> str:
+    data = text.encode()
+    return hashlib.sha1(f"blob {len(data)}\0".encode() + data).hexdigest()
+
+
+def test_registry_command_argv_has_no_repo_relative_script_paths():
+    registry = mutation_plan.load_registry(TEMPLATE_PATH)
+    doc_entry = registry.get("plan-sync-doc-patch")
+    assert doc_entry.command_argv[0] == "pulse-apply-doc-patch"
+
+    mkt_entry = registry.get("marketplace-entry-update")
+    assert mkt_entry.command_argv[0] == "pulse-apply-marketplace-entry"
+
+    for entry_id, entry in registry.transformations.items():
+        executor_probe.validate_command_argv(entry.command_argv, entry_id)
+
+
+def test_argv_linter_rejects_synthetic_repo_relative_script_path():
+    synthetic_data = {
+        "transformations": {
+            "bad-transformation": {
+                "id": "bad-transformation",
+                "command_argv": ["uv", "run", "foo/bar.py"],
+                "applies_to": ["always"],
+                "validation": {"kind": "none"},
+                "allow_scheduled": False,
+            }
+        }
+    }
+    with pytest.raises(mutation_plan.MutationPlanError, match=r"repo-relative script path"):
+        mutation_plan.load_registry(synthetic_data)
+
+
+def test_probe_required_tool_returns_blocked_when_tool_absent(tmp_path):
+    # Fake empty PATH
+    fake_path = str(tmp_path)
+    result = executor_probe.probe_required_tool("npm", ecosystem="nodejs", path_env=fake_path)
+    assert result["state"] == "blocked"
+    assert "npm" in result["reason"]
+    assert "nodejs" in result["reason"]
+
+
+def test_apply_doc_patch_entry_applies_change_and_rejects_path_escape(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    doc_content = "---\nsync:\n  base:\n    blob: old\n---\n# Old title\n"
+    target = tmp_path / "plans" / "widget.md"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(doc_content)
+
+    patch_path = tmp_path / ".hiivmind" / "plan-sync-patch.yaml"
+    patch_path.parent.mkdir(parents=True, exist_ok=True)
+    patch_content = (
+        "path: plans/widget.md\n"
+        f"base_blob: {_blob(doc_content)}\n"
+        "doc_patch: {title: 'New title'}\n"
+        "sync_patch: {blob: 'new'}\n"
+        "output_paths: [plans/widget.md]\n"
+    )
+    patch_path.write_text(patch_content)
+
+    ret = apply_doc_patch_entry.main(["--patch", ".hiivmind/plan-sync-patch.yaml"])
+    assert ret == 0
+    assert "New title" in target.read_text()
+
+    # Path escape test
+    patch_escape = (
+        "path: ../escaping.md\n"
+        f"base_blob: {_blob(doc_content)}\n"
+        "doc_patch: {}\n"
+        "sync_patch: {}\n"
+        "output_paths: ['plans/widget.md']\n"
+    )
+    patch_path.write_text(patch_escape)
+    ret_escape = apply_doc_patch_entry.main(["--patch", ".hiivmind/plan-sync-patch.yaml"])
+    assert ret_escape != 0
+
+
+def test_apply_marketplace_entry_applies_change_and_rejects_path_escape(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    mkt_doc = {
+        "plugins": [
+            {"name": "hiivmind-pulse-gh", "version": "0.1.0"}
+        ]
+    }
+    target = tmp_path / "marketplace.json"
+    doc_text = json.dumps(mkt_doc, indent=2) + "\n"
+    target.write_text(doc_text)
+
+    patch_path = tmp_path / ".hiivmind" / "marketplace-entry-patch.yaml"
+    patch_path.parent.mkdir(parents=True, exist_ok=True)
+    patch_content = (
+        "path: marketplace.json\n"
+        f"base_blob: {_blob(doc_text)}\n"
+        "entry_patch: {name: 'hiivmind-pulse-gh', version: '0.2.0'}\n"
+        "output_paths: [marketplace.json]\n"
+    )
+    patch_path.write_text(patch_content)
+
+    ret = apply_marketplace_entry.main(["--patch", ".hiivmind/marketplace-entry-patch.yaml"])
+    assert ret == 0
+    updated = json.loads(target.read_text())
+    assert updated["plugins"][0]["version"] == "0.2.0"
+
+    # Base blob mismatch test
+    patch_path.write_text(patch_content)  # target now has 0.2.0 text, so old base_blob will mismatch
+    ret_mismatch = apply_marketplace_entry.main(["--patch", ".hiivmind/marketplace-entry-patch.yaml"])
+    assert ret_mismatch != 0
+
+    # Path escape test
+    patch_escape = (
+        "path: ../escaping.json\n"
+        "base_blob: deadbeef\n"
+        "entry_patch: {name: 'hiivmind-pulse-gh', version: '0.2.0'}\n"
+        "output_paths: ['marketplace.json']\n"
+    )
+    patch_path.write_text(patch_escape)
+    ret_escape = apply_marketplace_entry.main(["--patch", ".hiivmind/marketplace-entry-patch.yaml"])
+    assert ret_escape != 0

--- a/lib/pulse/scripts/tests/test_mutation_plan.py
+++ b/lib/pulse/scripts/tests/test_mutation_plan.py
@@ -466,3 +466,94 @@ def test_interactive_actor_allowed_for_non_scheduled_transformation():
         registry=registry,
     )
     assert proposal.transformation == "interactive-only"
+
+
+# --- bound_paths & paths_changed validation -------------------------------
+
+
+def test_registry_paths_changed_validation_loads_kind():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["validation"] = {"kind": "paths_changed"}
+    registry = mutation_plan.load_registry(data)
+    validation = registry.get("format-python").validation
+    assert validation.kind == "paths_changed"
+    assert validation.path is None
+    assert validation.schema is None
+
+
+def test_registry_paths_changed_validation_rejects_extra_fields():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["validation"] = {
+        "kind": "paths_changed",
+        "path": "some/path",
+    }
+    with pytest.raises(mutation_plan.MutationPlanError, match="takes no path/schema"):
+        mutation_plan.load_registry(data)
+
+
+def test_build_proposal_accepts_and_normalizes_bound_paths():
+    proposal = mutation_plan.build_proposal(
+        id="run-1",
+        selection=["acme/api"],
+        transformation="format-python",
+        expected_shas={"acme/api": "abc123"},
+        actor=minimal_actor(),
+        bound_paths={"acme/api": ["docs/a.md", ".generated/docs/**"]},
+    )
+    assert proposal.bound_paths == {"acme/api": ("docs/a.md", ".generated/docs/**")}
+
+
+def test_build_proposal_rejects_bound_paths_key_outside_selection():
+    with pytest.raises(mutation_plan.MutationPlanError, match="entry outside selection"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=["acme/api"],
+            transformation="format-python",
+            expected_shas={"acme/api": "abc123"},
+            actor=minimal_actor(),
+            bound_paths={"acme/api": ["docs/a.md"], "acme/other": ["x"]},
+        )
+
+
+def test_validate_proposal_enforces_bound_paths_covers_selection_for_paths_changed():
+    data = minimal_registry_data()
+    data["transformations"]["format-python"]["validation"] = {"kind": "paths_changed"}
+    registry = mutation_plan.load_registry(data)
+
+    # Missing bound_paths entry for selected repo acme/api
+    with pytest.raises(mutation_plan.MutationPlanError, match="missing entry for"):
+        mutation_plan.build_proposal(
+            id="run-1",
+            selection=["acme/api"],
+            transformation="format-python",
+            expected_shas={"acme/api": "abc123"},
+            actor=minimal_actor(),
+            registry=registry,
+        )
+
+    # Valid when bound_paths covers selection
+    proposal = mutation_plan.build_proposal(
+        id="run-1",
+        selection=["acme/api"],
+        transformation="format-python",
+        expected_shas={"acme/api": "abc123"},
+        actor=minimal_actor(),
+        bound_paths={"acme/api": ["docs/a.md"]},
+        registry=registry,
+    )
+    assert proposal.bound_paths == {"acme/api": ("docs/a.md",)}
+
+
+def test_validate_proposal_allows_absent_bound_paths_for_none_kind():
+    data = minimal_registry_data()
+    registry = mutation_plan.load_registry(data)
+    proposal = mutation_plan.build_proposal(
+        id="run-1",
+        selection=["acme/api"],
+        transformation="format-python",
+        expected_shas={"acme/api": "abc123"},
+        actor=minimal_actor(),
+        registry=registry,
+    )
+    assert proposal.bound_paths == {}
+

--- a/lib/pulse/scripts/tests/test_nave_adapter.py
+++ b/lib/pulse/scripts/tests/test_nave_adapter.py
@@ -1,6 +1,7 @@
 """Tests for the external Nave CLI adapter."""
 
 import json
+import subprocess
 from pathlib import Path
 
 from lib.pulse.scripts import nave_adapter
@@ -673,3 +674,86 @@ def test_cli_pen_show_and_status_use_fixtures(monkeypatch, capsys):
 
     assert nave_adapter.main(["pen-status", "--name", "nave/api-audit"]) == 0
     assert json.loads(capsys.readouterr().out)["repos"][0]["owner"] == "acme"
+
+
+def _init_git_repo_for_adapter(path: Path) -> str:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True, capture_output=True)
+    (path / "init.txt").write_text("initial content\n")
+    subprocess.run(["git", "add", "init.txt"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=path, check=True, capture_output=True)
+    res = subprocess.run(["git", "rev-parse", "HEAD"], cwd=path, check=True, capture_output=True, text=True)
+    return res.stdout.strip()
+
+
+def test_provision_apply_branch_success(tmp_path):
+    repo_path = tmp_path / "acme" / "widget"
+    base_sha = _init_git_repo_for_adapter(repo_path)
+
+    branch_name = "pulse/apply/prop-100"
+    results = nave_adapter.provision_apply_branch(
+        clone_paths={"acme/widget": repo_path},
+        branch=branch_name,
+        base_shas={"acme/widget": base_sha},
+    )
+
+    assert results == {"acme/widget": {"state": "ok"}}
+
+    # Verify symbolic ref (current branch) and commit SHA
+    branch_ref = subprocess.run(
+        ["git", "symbolic-ref", "--short", "HEAD"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert branch_ref == branch_name
+
+    current_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert current_sha == base_sha
+
+
+def test_provision_apply_branch_already_exists(tmp_path):
+    repo_path = tmp_path / "acme" / "widget"
+    base_sha = _init_git_repo_for_adapter(repo_path)
+    branch_name = "pulse/apply/prop-100"
+
+    # Provision first time
+    nave_adapter.provision_apply_branch(
+        clone_paths={"acme/widget": repo_path},
+        branch=branch_name,
+        base_shas={"acme/widget": base_sha},
+    )
+
+    # Provision second time -> failure
+    results = nave_adapter.provision_apply_branch(
+        clone_paths={"acme/widget": repo_path},
+        branch=branch_name,
+        base_shas={"acme/widget": base_sha},
+    )
+
+    assert results["acme/widget"]["state"] == "failed"
+    assert "already exists" in results["acme/widget"]["reason"]
+
+
+def test_provision_apply_branch_missing_base_sha(tmp_path):
+    repo_path = tmp_path / "acme" / "widget"
+    _init_git_repo_for_adapter(repo_path)
+
+    results = nave_adapter.provision_apply_branch(
+        clone_paths={"acme/widget": repo_path},
+        branch="pulse/apply/prop-100",
+        base_shas={},
+    )
+
+    assert results["acme/widget"]["state"] == "failed"
+    assert "missing base SHA" in results["acme/widget"]["reason"]
+

--- a/lib/pulse/scripts/tests/test_nave_adapter.py
+++ b/lib/pulse/scripts/tests/test_nave_adapter.py
@@ -757,3 +757,108 @@ def test_provision_apply_branch_missing_base_sha(tmp_path):
     assert results["acme/widget"]["state"] == "failed"
     assert "missing base SHA" in results["acme/widget"]["reason"]
 
+
+def test_commit_apply_clones_success(tmp_path):
+    repo_path = tmp_path / "acme" / "widget"
+    base_sha = _init_git_repo_for_adapter(repo_path)
+
+    # Provision branch first
+    nave_adapter.provision_apply_branch(
+        clone_paths={"acme/widget": repo_path},
+        branch="pulse/apply/prop-100",
+        base_shas={"acme/widget": base_sha},
+    )
+
+    # Make working tree change
+    (repo_path / "file.txt").write_text("change\n")
+
+    message = "pulse-apply prop-100 by octocat@laptop"
+    results = nave_adapter.commit_apply_clones(
+        clone_paths={"acme/widget": repo_path},
+        message=message,
+    )
+
+    assert results == {"acme/widget": {"state": "ok"}}
+
+    # Verify commit log
+    log = subprocess.run(
+        ["git", "log", "-1", "--pretty=%s"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    assert log == message
+
+
+def test_commit_apply_clones_nothing_to_commit(tmp_path):
+    repo_path = tmp_path / "acme" / "widget"
+    _init_git_repo_for_adapter(repo_path)
+
+    # Clean working tree -> nothing to commit
+    results = nave_adapter.commit_apply_clones(
+        clone_paths={"acme/widget": repo_path},
+        message="pulse-apply prop-100 by octocat@laptop",
+    )
+
+    assert results["acme/widget"]["state"] == "failed"
+    assert "nothing to commit" in results["acme/widget"]["reason"].lower()
+
+
+def test_push_apply_clones_success(tmp_path):
+    bare_remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(bare_remote)], check=True, capture_output=True)
+
+    repo_path = tmp_path / "acme" / "widget"
+    base_sha = _init_git_repo_for_adapter(repo_path)
+    subprocess.run(
+        ["git", "remote", "add", "origin", str(bare_remote)],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+    )
+
+    branch_name = "pulse/apply/prop-100"
+    nave_adapter.provision_apply_branch(
+        clone_paths={"acme/widget": repo_path},
+        branch=branch_name,
+        base_shas={"acme/widget": base_sha},
+    )
+    (repo_path / "file.txt").write_text("change\n")
+    nave_adapter.commit_apply_clones(
+        clone_paths={"acme/widget": repo_path},
+        message="pulse-apply prop-100 by octocat@laptop",
+    )
+
+    results = nave_adapter.push_apply_clones(
+        clone_paths={"acme/widget": repo_path},
+        branch=branch_name,
+    )
+
+    assert results == {"acme/widget": {"state": "ok"}}
+
+    # Verify branch exists on remote
+    remote_branches = subprocess.run(
+        ["git", "branch", "-a"],
+        cwd=repo_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert f"remotes/origin/{branch_name}" in remote_branches
+
+
+def test_push_apply_clones_failure(tmp_path):
+    repo_path = tmp_path / "acme" / "widget"
+    _init_git_repo_for_adapter(repo_path)
+
+    # No origin remote configured
+    results = nave_adapter.push_apply_clones(
+        clone_paths={"acme/widget": repo_path},
+        branch="pulse/apply/prop-100",
+    )
+
+    assert results["acme/widget"]["state"] == "failed"
+    assert results["acme/widget"]["reason"]
+
+

--- a/lib/pulse/scripts/tests/test_object_apply.py
+++ b/lib/pulse/scripts/tests/test_object_apply.py
@@ -232,3 +232,72 @@ def test_f8_demonstrator_apply_issue_field_patch():
     assert res["state"] == "applied"
     assert res.get("noop") is False
     assert gh_ops.state["myorg/myrepo#42"]["milestone"] == "v2.0"
+
+
+def test_build_gh_api_post_args_formatting():
+    args = object_apply.build_gh_api_post_args(
+        "repos/owner/repo/releases",
+        {"tag_name": "v1.0.0", "target_commitish": "main"},
+        gh_binary="gh",
+    )
+    assert args == [
+        "gh",
+        "api",
+        "-X",
+        "POST",
+        "repos/owner/repo/releases",
+        "-f",
+        "tag_name=v1.0.0",
+        "-f",
+        "target_commitish=main",
+    ]
+
+
+def test_simplified_blocked_verbs_still_block():
+    precondition = object_apply.Precondition(
+        target="org/repo", field="name", expected="repo"
+    )
+    for verb in ("delete-repo", "archive", "transfer", "remove-all-members"):
+        write = object_apply.ObjectWrite(
+            verb=verb,
+            target="org/repo",
+            payload={},
+            precondition=precondition,
+        )
+        res = object_apply.apply_object_write(
+            write,
+            policy="allow-listed",
+            mutation_allowlist=[verb],
+            gh_ops=FakeObjectGhOps({"org/repo": {"name": "repo"}}),
+        )
+        assert res["state"] == "blocked"
+        assert "operation blocklist" in res["reason"]
+
+
+def test_type_error_propagates_unswallowed():
+    class TypeErrorGhOps(object_apply.ObjectGhOps):
+        def get_state(self, precondition: object_apply.Precondition) -> object:
+            raise TypeError("unexpected type error in custom gh op")
+
+        def apply_write(self, write: object_apply.ObjectWrite) -> dict[str, object]:
+            raise TypeError("unexpected type error in custom write op")
+
+    gh_ops = TypeErrorGhOps()
+    precondition = object_apply.Precondition(
+        target="org/repo#1", field="state", expected="open"
+    )
+    write = object_apply.ObjectWrite(
+        verb="update-field",
+        target="org/repo#1",
+        payload={"field": "state", "value": "closed"},
+        precondition=precondition,
+    )
+
+    with pytest.raises(TypeError, match="unexpected type error in custom gh op"):
+        object_apply.apply_object_write(
+            write,
+            policy="allow-listed",
+            mutation_allowlist=["update-field"],
+            gh_ops=gh_ops,
+        )
+

--- a/lib/pulse/scripts/tests/test_object_apply.py
+++ b/lib/pulse/scripts/tests/test_object_apply.py
@@ -1,0 +1,234 @@
+"""Tests for object_apply.py — precondition-guarded, idempotent Path B GitHub object writes (F11 Task 7)."""
+
+import pytest
+
+from lib.pulse.scripts import object_apply
+
+
+class FakeObjectGhOps(object_apply.ObjectGhOps):
+
+    def __init__(self, initial_state: dict[str, dict[str, object]] | None = None) -> None:
+        # store state as {target: {field: value}}
+        self.state: dict[str, dict[str, object]] = initial_state or {}
+        self.writes: list[object_apply.ObjectWrite] = []
+        self.fail_get_state: bool = False
+        self.fail_apply_write: bool = False
+
+    def get_state(self, precondition: object_apply.Precondition) -> object:
+        if self.fail_get_state:
+            raise object_apply.GhExecutionError("simulated gh api execution failure")
+        target_state = self.state.get(precondition.target, {})
+        if precondition.field not in target_state:
+            raise object_apply.GhExecutionError(
+                f"field {precondition.field} not found for {precondition.target}"
+            )
+        return target_state[precondition.field]
+
+    def apply_write(self, write: object_apply.ObjectWrite) -> dict[str, object]:
+        if self.fail_apply_write:
+            raise object_apply.GhExecutionError("simulated gh write failure")
+        self.writes.append(write)
+        target = write.target
+        if target not in self.state:
+            self.state[target] = {}
+
+        field = write.payload.get("field") or write.precondition.field
+        val = write.desired if write.desired is not None else write.payload.get("value")
+        self.state[target][field] = val
+        return {"state": "applied", "target": target, "field": field, "value": val}
+
+
+def test_allow_listed_success_and_idempotent_repeat():
+    gh_ops = FakeObjectGhOps({"org/repo#1": {"state": "open"}})
+    precondition = object_apply.Precondition(
+        target="org/repo#1", field="state", expected="open"
+    )
+    write = object_apply.ObjectWrite(
+        verb="update-field",
+        target="org/repo#1",
+        payload={"field": "state", "value": "closed"},
+        precondition=precondition,
+        desired="closed",
+    )
+
+    # 1. First execution applies write
+    res1 = object_apply.apply_object_write(
+        write,
+        policy="allow-listed",
+        mutation_allowlist=["update-field"],
+        gh_ops=gh_ops,
+    )
+    assert res1["state"] == "applied"
+    assert res1.get("noop") is False
+    assert len(gh_ops.writes) == 1
+    assert gh_ops.state["org/repo#1"]["state"] == "closed"
+
+    # 2. Repeat execution is idempotent no-op (no new write)
+    res2 = object_apply.apply_object_write(
+        write,
+        policy="allow-listed",
+        mutation_allowlist=["update-field"],
+        gh_ops=gh_ops,
+    )
+    assert res2["state"] == "applied"
+    assert res2.get("noop") is True
+    assert len(gh_ops.writes) == 1
+
+
+def test_precondition_mismatch_blocks():
+    gh_ops = FakeObjectGhOps({"org/repo#1": {"state": "in_progress"}})
+    precondition = object_apply.Precondition(
+        target="org/repo#1", field="state", expected="open"
+    )
+    write = object_apply.ObjectWrite(
+        verb="update-field",
+        target="org/repo#1",
+        payload={"field": "state", "value": "closed"},
+        precondition=precondition,
+        desired="closed",
+    )
+
+    res = object_apply.apply_object_write(
+        write,
+        policy="allow-listed",
+        mutation_allowlist=["update-field"],
+        gh_ops=gh_ops,
+    )
+    assert res["state"] == "blocked"
+    assert "precondition mismatch" in res["reason"]
+    assert len(gh_ops.writes) == 0
+
+
+def test_verb_not_in_allowlist_proposed():
+    gh_ops = FakeObjectGhOps({"org/repo#1": {"state": "open"}})
+    precondition = object_apply.Precondition(
+        target="org/repo#1", field="state", expected="open"
+    )
+    write = object_apply.ObjectWrite(
+        verb="update-field",
+        target="org/repo#1",
+        payload={"field": "state", "value": "closed"},
+        precondition=precondition,
+        desired="closed",
+    )
+
+    res = object_apply.apply_object_write(
+        write,
+        policy="allow-listed",
+        mutation_allowlist=["label", "comment"],
+        gh_ops=gh_ops,
+    )
+    assert res["state"] == "proposed"
+    assert res["action"] == "update-field org/repo#1"
+    assert len(gh_ops.writes) == 0
+
+
+def test_blocklisted_verb_blocked_unconditionally():
+    gh_ops = FakeObjectGhOps({"org/repo": {"name": "repo"}})
+    precondition = object_apply.Precondition(
+        target="org/repo", field="name", expected="repo"
+    )
+    write = object_apply.ObjectWrite(
+        verb="delete",
+        target="org/repo",
+        payload={},
+        precondition=precondition,
+    )
+
+    for pol in ("allow-listed", "allow", "propose"):
+        res = object_apply.apply_object_write(
+            write,
+            policy=pol,
+            mutation_allowlist=["delete"],
+            gh_ops=gh_ops,
+        )
+        assert res["state"] == "blocked"
+        assert "operation blocklist" in res["reason"]
+    assert len(gh_ops.writes) == 0
+
+
+def test_allow_policy_blocked_in_v1():
+    gh_ops = FakeObjectGhOps({"org/repo#1": {"state": "open"}})
+    precondition = object_apply.Precondition(
+        target="org/repo#1", field="state", expected="open"
+    )
+    write = object_apply.ObjectWrite(
+        verb="update-field",
+        target="org/repo#1",
+        payload={"field": "state", "value": "closed"},
+        precondition=precondition,
+    )
+
+    res = object_apply.apply_object_write(
+        write,
+        policy="allow",
+        gh_ops=gh_ops,
+    )
+    assert res["state"] == "blocked"
+    assert "allow is reserved and blocked in v1" in res["reason"]
+    assert len(gh_ops.writes) == 0
+
+
+def test_propose_policy_returns_proposed():
+    gh_ops = FakeObjectGhOps({"org/repo#1": {"state": "open"}})
+    precondition = object_apply.Precondition(
+        target="org/repo#1", field="state", expected="open"
+    )
+    write = object_apply.ObjectWrite(
+        verb="update-field",
+        target="org/repo#1",
+        payload={"field": "state", "value": "closed"},
+        precondition=precondition,
+    )
+
+    res = object_apply.apply_object_write(
+        write,
+        policy="propose",
+        gh_ops=gh_ops,
+    )
+    assert res["state"] == "proposed"
+    assert res["action"] == "update-field org/repo#1"
+    assert len(gh_ops.writes) == 0
+
+
+def test_gh_execution_error_during_get_state_fails_safe():
+    gh_ops = FakeObjectGhOps({"org/repo#1": {"state": "open"}})
+    gh_ops.fail_get_state = True
+    precondition = object_apply.Precondition(
+        target="org/repo#1", field="state", expected="open"
+    )
+    write = object_apply.ObjectWrite(
+        verb="update-field",
+        target="org/repo#1",
+        payload={"field": "state", "value": "closed"},
+        precondition=precondition,
+    )
+
+    res = object_apply.apply_object_write(
+        write,
+        policy="allow-listed",
+        mutation_allowlist=["update-field"],
+        gh_ops=gh_ops,
+    )
+    assert res["state"] == "blocked"
+    assert "precondition unconfirmable" in res["reason"]
+    assert len(gh_ops.writes) == 0
+
+
+def test_f8_demonstrator_apply_issue_field_patch():
+    gh_ops = FakeObjectGhOps({"myorg/myrepo#42": {"milestone": "v1.0"}})
+
+    res = object_apply.apply_issue_field_patch(
+        issue_repo="myorg/myrepo",
+        issue_number=42,
+        field="milestone",
+        target_value="v2.0",
+        expected_value="v1.0",
+        policy="allow-listed",
+        mutation_allowlist=["update-field"],
+        gh_ops=gh_ops,
+    )
+
+    assert res["state"] == "applied"
+    assert res.get("noop") is False
+    assert gh_ops.state["myorg/myrepo#42"]["milestone"] == "v2.0"

--- a/lib/pulse/scripts/tests/test_pen_clone_reader.py
+++ b/lib/pulse/scripts/tests/test_pen_clone_reader.py
@@ -105,3 +105,33 @@ def test_make_pen_clone_reader_env_var_fallback(tmp_path, monkeypatch):
     monkeypatch.setenv("PULSE_PEN_ROOT", str(tmp_path))
     readers = make_pen_clone_reader(selection=("org/project",))
     assert readers.read_repo_head("org/project") is not None
+
+
+def test_read_repo_changed_paths_renames_and_deletions(tmp_path):
+    repo_dir = tmp_path / "acme" / "widget"
+    _init_git_repo(repo_dir)
+
+    (repo_dir / "old.txt").write_text("old content\n")
+    (repo_dir / "to_delete.txt").write_text("will be deleted\n")
+    subprocess.run(["git", "add", "old.txt", "to_delete.txt"], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "add old and to_delete"], cwd=repo_dir, check=True, capture_output=True)
+
+    readers = make_pen_clone_reader(clone_root=tmp_path, selection=("acme/widget",))
+
+    # 1. Test deletion via git rm
+    subprocess.run(["git", "rm", "to_delete.txt"], cwd=repo_dir, check=True, capture_output=True)
+    changed = readers.read_repo_changed_paths("acme/widget")
+    assert "to_delete.txt" in changed
+
+    # 2. Test staged rename via git mv
+    subprocess.run(["git", "mv", "old.txt", "new.txt"], cwd=repo_dir, check=True, capture_output=True)
+    changed = readers.read_repo_changed_paths("acme/widget")
+    assert "old.txt" in changed
+    assert "new.txt" in changed
+
+    # 3. Test rename + subsequent edit (status 'RM')
+    (repo_dir / "new.txt").write_text("modified after rename\n")
+    changed_after_edit = readers.read_repo_changed_paths("acme/widget")
+    assert "old.txt" in changed_after_edit
+    assert "new.txt" in changed_after_edit
+

--- a/lib/pulse/scripts/tests/test_pen_clone_reader.py
+++ b/lib/pulse/scripts/tests/test_pen_clone_reader.py
@@ -1,0 +1,107 @@
+"""Tests for pen_clone_reader module — clone root contract and git seams."""
+
+import os
+import subprocess
+from pathlib import Path
+import pytest
+
+from lib.pulse.scripts.pen_clone_reader import (
+    PenCloneReaderError,
+    PenCloneReaders,
+    make_pen_clone_reader,
+)
+
+
+def _init_git_repo(path: Path) -> str:
+    """Initialize a real git repository with an initial commit and return HEAD SHA."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True, capture_output=True)
+    (path / "init.txt").write_text("initial content\n")
+    subprocess.run(["git", "add", "init.txt"], cwd=path, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=path, check=True, capture_output=True)
+    res = subprocess.run(["git", "rev-parse", "HEAD"], cwd=path, check=True, capture_output=True, text=True)
+    return res.stdout.strip()
+
+
+def test_make_pen_clone_reader_unset_root(monkeypatch):
+    monkeypatch.delenv("PULSE_PEN_ROOT", raising=False)
+    with pytest.raises(PenCloneReaderError, match="PULSE_PEN_ROOT"):
+        make_pen_clone_reader(clone_root=None, selection=("owner/repo",))
+
+
+def test_make_pen_clone_reader_missing_root_dir(tmp_path):
+    missing_dir = tmp_path / "nonexistent"
+    with pytest.raises(PenCloneReaderError, match="does not exist"):
+        make_pen_clone_reader(clone_root=missing_dir, selection=("owner/repo",))
+
+
+def test_make_pen_clone_reader_absent_repo_checkout(tmp_path):
+    with pytest.raises(PenCloneReaderError, match="not found"):
+        make_pen_clone_reader(clone_root=tmp_path, selection=("owner/repo",))
+
+
+def test_make_pen_clone_reader_not_a_git_repo(tmp_path):
+    repo_dir = tmp_path / "owner" / "repo"
+    repo_dir.mkdir(parents=True)
+    (repo_dir / "somefile.txt").write_text("not git")
+    with pytest.raises(PenCloneReaderError, match="not a git worktree"):
+        make_pen_clone_reader(clone_root=tmp_path, selection=("owner/repo",))
+
+
+def test_make_pen_clone_reader_invalid_repo_format(tmp_path):
+    with pytest.raises(PenCloneReaderError, match="Invalid repo format"):
+        make_pen_clone_reader(clone_root=tmp_path, selection=("invalid-format",))
+
+
+def test_pen_clone_reader_seams(tmp_path):
+    repo_dir = tmp_path / "acme" / "widget"
+    head_sha = _init_git_repo(repo_dir)
+
+    # Add a second committed file
+    (repo_dir / "unchanged.txt").write_text("unchanged\n")
+    subprocess.run(["git", "add", "unchanged.txt"], cwd=repo_dir, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "add unchanged"], cwd=repo_dir, check=True, capture_output=True)
+    head_sha = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo_dir, check=True, capture_output=True, text=True).stdout.strip()
+
+    readers = make_pen_clone_reader(clone_root=tmp_path, selection=("acme/widget",))
+    assert isinstance(readers, PenCloneReaders)
+
+    # 1. read_repo_head
+    assert readers.read_repo_head("acme/widget") == head_sha
+    with pytest.raises(KeyError):
+        readers.read_repo_head("unknown/repo")
+
+    # 2. read_repo_file
+    assert readers.read_repo_file("acme/widget", "init.txt") == b"initial content\n"
+    with pytest.raises(FileNotFoundError):
+        readers.read_repo_file("acme/widget", "nonexistent.txt")
+    with pytest.raises(FileNotFoundError):
+        readers.read_repo_file("acme/widget", "../outside.txt")
+    with pytest.raises(KeyError):
+        readers.read_repo_file("unknown/repo", "init.txt")
+
+    # 3. read_repo_changed_paths
+    # Clean tree initially
+    assert readers.read_repo_changed_paths("acme/widget") == ()
+
+    # Modify tracked init.txt and create untracked new_file.txt
+    (repo_dir / "init.txt").write_text("modified content\n")
+    (repo_dir / "untracked.txt").write_text("untracked content\n")
+
+    changed = readers.read_repo_changed_paths("acme/widget")
+    assert changed == ("init.txt", "untracked.txt")
+    assert "unchanged.txt" not in changed
+
+    with pytest.raises(KeyError):
+        readers.read_repo_changed_paths("unknown/repo")
+
+
+def test_make_pen_clone_reader_env_var_fallback(tmp_path, monkeypatch):
+    repo_dir = tmp_path / "org" / "project"
+    _init_git_repo(repo_dir)
+
+    monkeypatch.setenv("PULSE_PEN_ROOT", str(tmp_path))
+    readers = make_pen_clone_reader(selection=("org/project",))
+    assert readers.read_repo_head("org/project") is not None

--- a/lib/pulse/scripts/tests/test_pen_orchestrator.py
+++ b/lib/pulse/scripts/tests/test_pen_orchestrator.py
@@ -64,7 +64,7 @@ def make_entry(validation=None):
     return registry.get("format-python")
 
 
-def make_proposal(selection=("acme/api", "acme/web"), mutation_policy="propose"):
+def make_proposal(selection=("acme/api", "acme/web"), mutation_policy="propose", bound_paths=None):
     return mutation_plan.build_proposal(
         id="run-1",
         selection=list(selection),
@@ -72,11 +72,12 @@ def make_proposal(selection=("acme/api", "acme/web"), mutation_policy="propose")
         expected_shas={repo: "deadbeef" for repo in selection},
         actor={"gh_login": "octocat", "machine": "laptop", "mode": "interactive"},
         mutation_policy=mutation_policy,
+        bound_paths=bound_paths,
     )
 
 
-def make_plan(selection=("acme/api", "acme/web"), mutation_policy="propose", request_push=False, validation=None):
-    proposal = make_proposal(selection=selection, mutation_policy=mutation_policy)
+def make_plan(selection=("acme/api", "acme/web"), mutation_policy="propose", request_push=False, validation=None, bound_paths=None):
+    proposal = make_proposal(selection=selection, mutation_policy=mutation_policy, bound_paths=bound_paths)
     entry = make_entry(validation=validation)
     return pen_orchestrator.PenPlan(
         proposal=proposal,
@@ -558,3 +559,195 @@ def test_pen_selection_mismatch_blocks_the_run():
     assert result.state == "blocked"
     assert "does not match" in result.reason or "do not match" in result.reason
     assert result.repo_outcomes == {repo: "blocked" for repo in SELECTION}
+
+
+# --- paths_changed validation kind ----------------------------------------
+
+
+def _paths_changed_plan(bound_paths=None):
+    if bound_paths is None:
+        bound_paths = {repo: ("docs/a.md",) for repo in SELECTION}
+    return make_plan(
+        validation={"kind": "paths_changed"},
+        bound_paths=bound_paths,
+    )
+
+
+def test_paths_changed_without_reader_fails_closed_as_blocked():
+    plan = _paths_changed_plan()
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    result = pen_orchestrator.execute(plan, runner, read_repo_head=matching_head)
+
+    assert result.state == "blocked"
+    assert "paths_changed" in result.reason
+    assert "read_repo_changed_paths" in result.reason
+    assert result.repo_outcomes == {repo: "blocked" for repo in SELECTION}
+
+
+def test_paths_changed_exact_and_glob_match_passes():
+    bound_paths = {
+        "acme/api": ("docs/a.md", ".generated/docs/**"),
+        "acme/web": (".generated/docs/**",),
+    }
+    plan = _paths_changed_plan(bound_paths=bound_paths)
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    def read_repo_changed_paths(repo):
+        if repo == "acme/api":
+            return ("docs/a.md", ".generated/docs/sub/page.html")
+        return (".generated/docs/index.html",)
+
+    result = pen_orchestrator.execute(
+        plan,
+        runner,
+        read_repo_head=matching_head,
+        read_repo_changed_paths=read_repo_changed_paths,
+    )
+
+    assert result.state == "proposed"
+    assert result.reason is None
+    assert result.repo_outcomes == {repo: "ok" for repo in SELECTION}
+
+
+def test_paths_changed_glob_matches_deep_subdirectories():
+    # Explicitly prove .generated/docs/sub/page.html matches .generated/docs/**
+    bound_paths = {repo: (".generated/docs/**",) for repo in SELECTION}
+    plan = _paths_changed_plan(bound_paths=bound_paths)
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    def read_repo_changed_paths(repo):
+        return (".generated/docs/sub/page.html",)
+
+    result = pen_orchestrator.execute(
+        plan,
+        runner,
+        read_repo_head=matching_head,
+        read_repo_changed_paths=read_repo_changed_paths,
+    )
+
+    assert result.state == "proposed"
+    assert result.repo_outcomes == {repo: "ok" for repo in SELECTION}
+
+
+def test_paths_changed_fails_on_out_of_allowlist_change():
+    bound_paths = {repo: ("docs/a.md",) for repo in SELECTION}
+    plan = _paths_changed_plan(bound_paths=bound_paths)
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    def read_repo_changed_paths(repo):
+        if repo == "acme/api":
+            return ("docs/a.md", "src/secret.py")
+        return ("docs/a.md",)
+
+    result = pen_orchestrator.execute(
+        plan,
+        runner,
+        read_repo_head=matching_head,
+        read_repo_changed_paths=read_repo_changed_paths,
+    )
+
+    assert result.state == "failed"
+    assert result.repo_outcomes == {"acme/api": "failed", "acme/web": "ok"}
+    assert "acme/api" in result.reason
+    assert "src/secret.py" in result.reason
+
+
+def test_paths_changed_fails_on_missing_exact_path():
+    bound_paths = {repo: ("docs/a.md", "docs/b.md") for repo in SELECTION}
+    plan = _paths_changed_plan(bound_paths=bound_paths)
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    def read_repo_changed_paths(repo):
+        if repo == "acme/api":
+            return ("docs/a.md",)  # missing exact docs/b.md
+        return ("docs/a.md", "docs/b.md")
+
+    result = pen_orchestrator.execute(
+        plan,
+        runner,
+        read_repo_head=matching_head,
+        read_repo_changed_paths=read_repo_changed_paths,
+    )
+
+    assert result.state == "failed"
+    assert result.repo_outcomes == {"acme/api": "failed", "acme/web": "ok"}
+    assert "acme/api" in result.reason
+    assert "docs/b.md" in result.reason
+
+
+def test_paths_changed_fails_on_silent_noop():
+    bound_paths = {repo: ("docs/**",) for repo in SELECTION}
+    plan = _paths_changed_plan(bound_paths=bound_paths)
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    def read_repo_changed_paths(repo):
+        if repo == "acme/api":
+            return ()  # silent no-op
+        return ("docs/a.md",)
+
+    result = pen_orchestrator.execute(
+        plan,
+        runner,
+        read_repo_head=matching_head,
+        read_repo_changed_paths=read_repo_changed_paths,
+    )
+
+    assert result.state == "failed"
+    assert result.repo_outcomes == {"acme/api": "failed", "acme/web": "ok"}
+    assert "acme/api" in result.reason
+    assert "no paths changed" in result.reason or "no-op" in result.reason
+
+
+def test_paths_changed_on_neutral_transformation_fixture():
+    # Prove the guard on a neutral transformation entry (`regenerate-docs-index`)
+    neutral_registry_data = {
+        "transformations": {
+            "regenerate-docs-index": {
+                "id": "regenerate-docs-index",
+                "command_argv": ["mkdocs", "build", "--site-dir", ".generated/docs"],
+                "applies_to": ["evidence_path:mkdocs.yml"],
+                "validation": {"kind": "paths_changed"},
+                "allow_scheduled": True,
+            }
+        }
+    }
+    registry = mutation_plan.load_registry(neutral_registry_data)
+    entry = registry.get("regenerate-docs-index")
+    proposal = mutation_plan.build_proposal(
+        id="run-neutral",
+        selection=["acme/api"],
+        transformation="regenerate-docs-index",
+        expected_shas={"acme/api": "deadbeef"},
+        actor={"gh_login": "octocat", "machine": "laptop", "mode": "interactive"},
+        bound_paths={"acme/api": [".generated/docs/**"]},
+        registry=registry,
+    )
+    plan = pen_orchestrator.PenPlan(
+        proposal=proposal,
+        entry=entry,
+        pen_name="nave/docs-gen",
+        query=nave_adapter.PenQuery(),
+    )
+    runner = QueuedRunner(
+        [
+            *create_sequence([("acme", "api")]),
+            pen_status_completed([repo_state("acme", "api")]),
+            nave_adapter.Completed(0, "built docs", ""),
+            pen_status_completed([repo_state("acme", "api")]),
+        ]
+    )
+
+    def read_repo_changed_paths(repo):
+        return (".generated/docs/index.html", ".generated/docs/search/search_index.json")
+
+    result = pen_orchestrator.execute(
+        plan,
+        runner,
+        read_repo_head=lambda repo: "deadbeef",
+        read_repo_changed_paths=read_repo_changed_paths,
+    )
+
+    assert result.state == "proposed"
+    assert result.repo_outcomes == {"acme/api": "ok"}
+

--- a/lib/pulse/scripts/tests/test_pen_orchestrator.py
+++ b/lib/pulse/scripts/tests/test_pen_orchestrator.py
@@ -918,3 +918,66 @@ def test_propose_policy_still_proposed_and_never_provisions_or_pushes():
     assert apply_ops.calls == []
 
 
+def test_allow_listed_provision_missing_repo_fails_closed_as_blocked():
+    plan = make_plan(mutation_policy="allow-listed")
+    # acme/web omitted from provision_branch results
+    apply_ops = RecordingApplyOps(
+        prov_results={"acme/api": {"state": "ok"}}
+    )
+    runner = QueuedRunner(_clean_preflight_sequence())
+
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_head=matching_head, apply_ops=apply_ops
+    )
+
+    assert result.state == "blocked"
+    assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "blocked"}
+    assert "acme/web" in result.reason
+    assert "missing provision result" in result.reason
+    assert not any("exec" in call for call in runner.calls)
+
+
+def test_allow_listed_commit_missing_repo_fails_closed_without_push():
+    plan = make_plan(mutation_policy="allow-listed")
+    # acme/web omitted from commit_repos results
+    apply_ops = RecordingApplyOps(
+        commit_results={"acme/api": {"state": "ok"}}
+    )
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_head=matching_head, apply_ops=apply_ops
+    )
+
+    assert result.state == "failed"
+    assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "failed"}
+    assert "acme/web" in result.reason
+    assert "missing commit result" in result.reason
+    # Ensure NO push call was made
+    assert [c[0] for c in apply_ops.calls] == ["provision_branch", "commit_repos"]
+
+
+def test_allow_listed_push_missing_repo_fails_closed():
+    plan = make_plan(mutation_policy="allow-listed")
+    # acme/web omitted from push_repos results
+    apply_ops = RecordingApplyOps(
+        push_results={"acme/api": {"state": "ok"}}
+    )
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_head=matching_head, apply_ops=apply_ops
+    )
+
+    assert result.state == "failed"
+    assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "failed"}
+    assert "acme/web" in result.reason
+    assert "missing push result" in result.reason
+    assert [c[0] for c in apply_ops.calls] == [
+        "provision_branch",
+        "commit_repos",
+        "push_repos",
+    ]
+
+
+

--- a/lib/pulse/scripts/tests/test_pen_orchestrator.py
+++ b/lib/pulse/scripts/tests/test_pen_orchestrator.py
@@ -751,3 +751,170 @@ def test_paths_changed_on_neutral_transformation_fixture():
     assert result.state == "proposed"
     assert result.repo_outcomes == {"acme/api": "ok"}
 
+
+# --- allow-listed apply mode tests ---------------------------------------
+
+
+class RecordingApplyOps:
+    def __init__(self, prov_results=None, commit_results=None, push_results=None):
+        self.calls = []
+        self.prov_results = prov_results
+        self.commit_results = commit_results
+        self.push_results = push_results
+
+    def provision_branch(self, branch, base_shas):
+        self.calls.append(("provision_branch", branch, base_shas))
+        if self.prov_results is not None:
+            return self.prov_results
+        return {repo: {"state": "ok"} for repo in base_shas}
+
+    def commit_repos(self, message):
+        self.calls.append(("commit_repos", message))
+        if self.commit_results is not None:
+            return self.commit_results
+        return {"acme/api": {"state": "ok"}, "acme/web": {"state": "ok"}}
+
+    def push_repos(self, branch):
+        self.calls.append(("push_repos", branch))
+        if self.push_results is not None:
+            return self.push_results
+        return {"acme/api": {"state": "ok"}, "acme/web": {"state": "ok"}}
+
+
+def test_allow_listed_success_provisions_execs_validates_commits_and_pushes():
+    plan = make_plan(mutation_policy="allow-listed")
+    apply_ops = RecordingApplyOps()
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_head=matching_head, apply_ops=apply_ops
+    )
+
+    assert result.state == "pushed"
+    assert result.reason is None
+    assert result.repo_outcomes == {repo: "ok" for repo in SELECTION}
+    assert len(apply_ops.calls) == 3
+    assert apply_ops.calls[0] == (
+        "provision_branch",
+        "pulse/apply/run-1",
+        {"acme/api": "deadbeef", "acme/web": "deadbeef"},
+    )
+    assert apply_ops.calls[1] == (
+        "commit_repos",
+        "pulse-apply run-1 by octocat@laptop",
+    )
+    assert apply_ops.calls[2] == ("push_repos", "pulse/apply/run-1")
+
+
+def test_allow_listed_provision_failure_blocks_before_exec():
+    plan = make_plan(mutation_policy="allow-listed")
+    apply_ops = RecordingApplyOps(
+        prov_results={
+            "acme/api": {"state": "ok"},
+            "acme/web": {"state": "failed", "reason": "branch exists"},
+        }
+    )
+    runner = QueuedRunner(_clean_preflight_sequence())
+
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_head=matching_head, apply_ops=apply_ops
+    )
+
+    assert result.state == "blocked"
+    assert "provision" in result.reason
+    assert apply_ops.calls == [
+        (
+            "provision_branch",
+            "pulse/apply/run-1",
+            {"acme/api": "deadbeef", "acme/web": "deadbeef"},
+        )
+    ]
+    assert not any("exec" in call for call in runner.calls)
+
+
+def test_allow_listed_validation_failure_fails_without_commit_or_push():
+    plan = make_plan(
+        mutation_policy="allow-listed",
+        validation={
+            "kind": "json_schema",
+            "path": "package-lock.json",
+            "schema": {"type": "object"},
+        },
+    )
+    apply_ops = RecordingApplyOps()
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_head=matching_head, apply_ops=apply_ops
+    )
+
+    assert result.state == "failed"
+    assert "json_schema" in result.reason
+    assert [c[0] for c in apply_ops.calls] == ["provision_branch"]
+
+
+def test_allow_listed_commit_failure_fails_and_does_not_push_any_repo():
+    plan = make_plan(mutation_policy="allow-listed")
+    apply_ops = RecordingApplyOps(
+        commit_results={
+            "acme/api": {"state": "ok"},
+            "acme/web": {"state": "failed", "reason": "nothing to commit"},
+        }
+    )
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_head=matching_head, apply_ops=apply_ops
+    )
+
+    assert result.state == "failed"
+    assert result.repo_outcomes == {"acme/api": "ok", "acme/web": "failed"}
+    assert "nothing to commit" in result.reason
+    assert [c[0] for c in apply_ops.calls] == ["provision_branch", "commit_repos"]
+
+
+def test_allow_listed_without_apply_ops_blocks():
+    plan = make_plan(mutation_policy="allow-listed")
+    result = pen_orchestrator.execute(plan, NoCallRunner(), apply_ops=None)
+
+    assert result.state == "blocked"
+    assert "apply_ops" in result.reason
+
+
+def test_allow_listed_expected_sha_mismatch_returns_recoverable_block():
+    plan = make_plan(mutation_policy="allow-listed")
+    runner = QueuedRunner(_clean_preflight_sequence())
+
+    def read_repo_head(repo):
+        return "deadbeef" if repo == "acme/api" else "badsha"
+
+    apply_ops = RecordingApplyOps()
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_head=read_repo_head, apply_ops=apply_ops
+    )
+
+    assert result.state == "blocked"
+    assert "rebuild expected_shas" in result.reason or "recovery" in result.reason or "stale base" in result.reason
+    assert apply_ops.calls == []
+
+
+def test_allow_policy_remains_blocked():
+    plan = make_plan(mutation_policy="allow")
+    result = pen_orchestrator.execute(plan, NoCallRunner())
+
+    assert result.state == "blocked"
+
+
+def test_propose_policy_still_proposed_and_never_provisions_or_pushes():
+    plan = make_plan(mutation_policy="propose")
+    apply_ops = RecordingApplyOps()
+    runner = QueuedRunner(_exec_ok_sequence())
+
+    result = pen_orchestrator.execute(
+        plan, runner, read_repo_head=matching_head, apply_ops=apply_ops
+    )
+
+    assert result.state == "proposed"
+    assert apply_ops.calls == []
+
+

--- a/lib/pulse/scripts/tests/test_validate_result.py
+++ b/lib/pulse/scripts/tests/test_validate_result.py
@@ -19,8 +19,9 @@ FIXTURES = Path("lib/pulse/scripts/tests/fixtures")
 KINDS = [
     "status", "healthcheck", "refresh", "workflow-run", "fleet-membership",
     "impact", "repo-mutation", "generated-artifact", "plan-sync",
-    "marketplace-sync",
+    "marketplace-sync", "apply-status",
 ]
+
 
 
 def run_validator(path, kind):
@@ -1158,3 +1159,102 @@ def test_validate_sync_binding_rejects_invalid_issue_reference(issue, expected):
         block["issue"] = issue
 
     assert expected in validate_result.validate_sync_binding(block)
+
+
+@pytest.mark.parametrize("state", ["pushed", "pr_opened", "applied", "rejected"])
+def test_apply_status_accepts_valid_states(tmp_path, state):
+    doc = yaml.safe_load((FIXTURES / "apply-status-valid.yaml").read_text())
+    doc["state"] = state
+    if state == "pushed":
+        doc["pr_url"] = None
+        doc["merged_sha"] = None
+        doc["reason"] = None
+    elif state == "pr_opened":
+        doc["pr_url"] = "https://github.com/testorg/widget/pull/42"
+        doc["merged_sha"] = None
+        doc["reason"] = None
+    elif state == "applied":
+        doc["pr_url"] = "https://github.com/testorg/widget/pull/42"
+        doc["merged_sha"] = "fedcba9876543210fedcba9876543210fedcba98"
+        doc["reason"] = None
+    elif state == "rejected":
+        doc["pr_url"] = "https://github.com/testorg/widget/pull/42"
+        doc["merged_sha"] = None
+        doc["reason"] = "Closed without merging"
+    path = tmp_path / "apply-status.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    assert validate_result.validate(doc, "apply-status") == []
+    result = run_validator(path, "apply-status")
+    assert result.returncode == 0, result.stderr
+
+
+def test_apply_status_pushed_missing_pushed_sha(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "apply-status-valid.yaml").read_text())
+    doc["state"] = "pushed"
+    doc["pushed_sha"] = None
+    doc["pr_url"] = None
+    path = tmp_path / "apply-status.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "apply-status")
+    assert result.returncode == 1
+    assert "pushed_sha must not be null when state is pushed" in result.stderr
+
+
+def test_apply_status_pr_opened_missing_pr_url(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "apply-status-valid.yaml").read_text())
+    doc["state"] = "pr_opened"
+    doc["pr_url"] = None
+    path = tmp_path / "apply-status.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "apply-status")
+    assert result.returncode == 1
+    assert "pr_url must not be null when state is pr_opened" in result.stderr
+
+
+def test_apply_status_applied_missing_merged_sha(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "apply-status-valid.yaml").read_text())
+    doc["state"] = "applied"
+    doc["merged_sha"] = None
+    path = tmp_path / "apply-status.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "apply-status")
+    assert result.returncode == 1
+    assert "merged_sha must not be null when state is applied" in result.stderr
+
+
+def test_apply_status_rejected_null_reason(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "apply-status-valid.yaml").read_text())
+    doc["state"] = "rejected"
+    doc["reason"] = None
+    path = tmp_path / "apply-status.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "apply-status")
+    assert result.returncode == 1
+    assert "reason must not be null when state is rejected" in result.stderr
+
+
+def test_apply_status_rejects_invalid_state(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "apply-status-valid.yaml").read_text())
+    doc["state"] = "unknown_state"
+    path = tmp_path / "apply-status.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "apply-status")
+    assert result.returncode == 1
+    assert "state invalid: unknown_state" in result.stderr
+
+
+def test_apply_status_kind_mismatch(tmp_path):
+    doc = yaml.safe_load((FIXTURES / "apply-status-valid.yaml").read_text())
+    path = tmp_path / "apply-status.yaml"
+    path.write_text(yaml.safe_dump(doc))
+
+    result = run_validator(path, "repo-mutation")
+    assert result.returncode == 1
+    assert "kind mismatch" in result.stderr
+

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -5,7 +5,7 @@
 # ///
 """Validate a headless result file against the pulse result contract.
 
-Usage: validate_result.py <result.yaml> --kind status|healthcheck|refresh|workflow-run|fleet-membership|impact|repo-mutation|generated-artifact|plan-sync|marketplace-sync
+Usage: validate_result.py <result.yaml> --kind status|healthcheck|refresh|workflow-run|fleet-membership|impact|repo-mutation|generated-artifact|plan-sync|marketplace-sync|apply-status
 
 See lib/patterns/headless-contract.md for the schemas.
 
@@ -39,7 +39,10 @@ OUTCOMES = {"success", "failure", "skipped-cooldown", "aborted"}
 SEVERITIES = {"low", "medium", "high"}
 EDGE_STATES = {"current", "stale", "unknown"}
 REPO_MUTATION_STATES = {"proposed", "blocked", "failed"}
+APPLY_STATUS_STATES = {"pushed", "pr_opened", "applied", "rejected"}
+
 REPO_OUTCOME_STATES = {"ok", "failed", "blocked"}
+
 GENERATED_ARTIFACT_STATES = {
     "current",
     "template-drift",
@@ -648,7 +651,26 @@ def validate(data, kind: str) -> list[str]:
             _require(proposal, "proposal_id", str, errors, ctx=ctx)
         _validate_string_list(data, "proposed_actions", errors)
 
+    elif kind == "apply-status":
+        state = _require_enum(data, "state", APPLY_STATUS_STATES, errors)
+        _require(data, "proposal_id", str, errors)
+        _validate_string_list(data, "selection", errors)
+        _require(data, "branch", str, errors)
+        _require_nullable(data, "pushed_sha", str, errors)
+        _require_nullable(data, "pr_url", str, errors)
+        _require_nullable(data, "merged_sha", str, errors)
+        _require_nullable(data, "reason", str, errors)
+        if state in {"pushed", "pr_opened", "applied"} and data.get("pushed_sha") is None:
+            _err(errors, f"pushed_sha must not be null when state is {state}")
+        if state in {"pr_opened", "applied"} and data.get("pr_url") is None:
+            _err(errors, f"pr_url must not be null when state is {state}")
+        if state == "applied" and data.get("merged_sha") is None:
+            _err(errors, "merged_sha must not be null when state is applied")
+        if state == "rejected" and data.get("reason") is None:
+            _err(errors, "reason must not be null when state is rejected")
+
     return errors
+
 
 
 def main():
@@ -658,7 +680,8 @@ def main():
                         choices=["status", "healthcheck", "refresh", "workflow-run",
                                  "fleet-membership", "impact", "repo-mutation",
                                  "generated-artifact", "plan-sync",
-                                 "marketplace-sync"])
+                                 "marketplace-sync", "apply-status"])
+
     args = parser.parse_args()
 
     path = Path(args.file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,10 @@ description = "Dev/test environment for hiivmind-pulse-gh plugin scripts (the sc
 requires-python = ">=3.10"
 dependencies = []
 
+[project.scripts]
+pulse-apply-doc-patch = "lib.pulse.scripts.apply_doc_patch_entry:main"
+pulse-apply-marketplace-entry = "lib.pulse.scripts.apply_marketplace_entry:main"
+
 [dependency-groups]
 dev = [
     "pytest>=8.0",

--- a/skills/gh-marketplace-sync-headless/SKILL.md
+++ b/skills/gh-marketplace-sync-headless/SKILL.md
@@ -184,6 +184,8 @@ For every non-`in_sync` / non-`not_applicable` / non-`unknown` drift (so
    or run a pen. With `mutation_policy: apply`, append a deferred-action
    note naming the F9 v1 limitation instead of applying.
 
+Under `on_mutation: allow-listed`, marketplace entry writes land on GitHub via `lib/pulse/scripts/object_apply.py` (`apply_object_write`). The write is guarded by a typed `Precondition` (target file/version expected state) and verb `mutation_allowlist` check. Path B operates independently of Path A.
+
 **See:** `lib/pulse/scripts/marketplace_sync.py`,
 `lib/pulse/scripts/mutation_plan.py`,
 `lib/patterns/repository-mutations.md`.

--- a/skills/gh-plan-sync-headless/SKILL.md
+++ b/skills/gh-plan-sync-headless/SKILL.md
@@ -160,6 +160,8 @@ its `github_mutation` output.
 4. Never call GitHub to apply the patch. With `mutation_policy: apply`, append a
    deferred-action note naming the V1 limitation instead of applying it.
 
+Under `on_mutation: allow-listed`, GitHub object-side writes (issue/milestone field patches) are executed through `lib/pulse/scripts/object_apply.py` (`apply_object_write` / `apply_issue_field_patch`). The write is guarded by a typed `Precondition` descriptor matching expected live state, checked for verb `mutation_allowlist` membership, and evaluated for idempotency before writing. Path B operates independently of Path A.
+
 ## Phase 5: APPLY_DOC
 
 For every non-conflicted reconciliation with a document or frontmatter-base patch,

--- a/skills/gh-plan-sync-headless/SKILL.md
+++ b/skills/gh-plan-sync-headless/SKILL.md
@@ -192,7 +192,11 @@ neither path, so it never persists `base_patch` or advances `sync.base.blob`.
 Copy any returned finalization findings into `FINDINGS`. A later apply-capable
 consumer must re-snapshot and pass confirmed outcomes before it may persist bases.
 
-**See:** `lib/pulse/scripts/plan_sync.py`, `lib/patterns/plan-sync-binding.md` § V1 limitation.
+Under allow-listed apply mode, `apply_reconcile.py` drives the resumable two-phase loop per repo:
+1. `open_apply_pr`: Opens a PR (`create_or_get_pr`), writes `apply-status` at state `pr_opened`, and updates the run ledger step to `blocked-on-gate`.
+2. `reconcile_apply`: Checks PR state via `view_pr`. On `MERGED`, writes `apply-status` state `applied` with `merged_sha`, clears the `merge_detected` gate, and advances base off `merged_sha`. On `CLOSED` unmerged, writes `state: rejected`, deletes the remote branch, and marks the ledger step `failed` (terminal).
+
+**See:** `lib/pulse/scripts/plan_sync.py`, `lib/pulse/scripts/apply_reconcile.py`, `lib/patterns/plan-sync-binding.md` § V1 limitation.
 
 ## Phase 7: RECORD
 

--- a/templates/transformations.yaml.template
+++ b/templates/transformations.yaml.template
@@ -87,9 +87,7 @@ transformations:
   plan-sync-doc-patch:
     id: plan-sync-doc-patch
     command_argv:
-      - uv
-      - run
-      - lib/pulse/scripts/apply_doc_patch.py
+      - pulse-apply-doc-patch
       - --patch
       - .hiivmind/plan-sync-patch.yaml
     applies_to:
@@ -146,9 +144,7 @@ transformations:
   marketplace-entry-update:
     id: marketplace-entry-update
     command_argv:
-      - uv
-      - run
-      - lib/pulse/scripts/apply_marketplace_entry.py
+      - pulse-apply-marketplace-entry
       - --patch
       - .hiivmind/marketplace-entry-patch.yaml
     applies_to:

--- a/templates/transformations.yaml.template
+++ b/templates/transformations.yaml.template
@@ -31,8 +31,9 @@ transformations:
   #                                        # Same grammar as scorecard check
   #                                        # applicability (profile_dispatch.py).
   #   validation:
-  #     kind: none | json_schema          # Required. `none` takes no other
-  #                                        # keys. `json_schema` requires:
+  #     kind: none | json_schema | paths_changed # Required. `none` and `paths_changed`
+  #                                        # take no other keys (`paths_changed` bounds
+  #                                        # are carried on Proposal). `json_schema` requires:
   #     path: {{repo_relative_path}}      #   file the transformation is
   #                                        #   expected to produce/modify
   #     schema: {{inline_json_schema}}    #   parsed content must satisfy this
@@ -93,7 +94,7 @@ transformations:
     applies_to:
       - always
     validation:
-      kind: none
+      kind: paths_changed
     allow_scheduled: false
 
   # F9 v1 dogfood overlay: regenerate the corpus-navigation skill under the
@@ -188,5 +189,5 @@ transformations:
     applies_to:
       - evidence_path:mkdocs.yml
     validation:
-      kind: none
+      kind: paths_changed
     allow_scheduled: true


### PR DESCRIPTION
Implements **F11 apply-mode** per `docs/superpowers/plans/2026-07-22-f11-apply-mode.md` (the plan revised against the GLM 5.2 design review). Lets a validated propose-mode proposal **land**, across two paths sharing one trust model. Executed via SDD on agy (Gemini 3.6 Flash / 3.1 Pro), every gate re-run and every diff read by the controller; final whole-branch review verdict **SHIP** (0 findings).

## What lands
**Path A — repo files via a Nave pen** (`allow-listed` policy): provision per-proposal branch `pulse/apply/{id}` off the guarded base SHA → `pen_exec` transformation → validate → **commit-all → push-all** → state `pushed`; then open PR → detect merge → advance the base off the **merged** SHA.
**Path B — GitHub objects via `gh`**: precondition-guarded, idempotent writes under `on_mutation` (verb-allowlist dialect).

## Tasks (each per-task reviewed + fixed, then a clean final review)
- **T1** appliers reachable on PATH (console entry points; argv linter) — closes B1
- **T2** orchestrator-enforced `bound_paths` + `paths_changed` validation kind — closes B2, proven on a neutral transformation (I7)
- **T3** pen apply substrate: per-proposal branch targeting + fail-closed clone reader — closes C1/C2
- **T4** `allow-listed` commit/push in `pen_orchestrator` (commit-all-then-push, no stranded push; attributed message; recoverable stale-SHA block)
- **T5** `apply-status` result kind (`pushed`/`pr_opened`/`applied`/`rejected`) — the file the merge gate reads (I1)
- **T6** PR open → merge-detect (`merge_detected` gate) → base advance; fail-safe on transient gh errors; crash-safe base advancement — closes B3/B4
- **T7** GitHub-object apply engine under `on_mutation` (typed precondition = Path B's expected-SHA) — closes I5
- **T8** neutral end-to-end acceptance (two-suite) + **structural (AST) neutrality guard** — closes B5/I8

## Safety invariants (verified whole-branch)
- A push can **never** target a base branch — only `pulse/apply/{id}`.
- No stranded partial push (commit-all before push-all).
- A transient `gh` error never deletes a branch or falsely terminates (fail-safe/withhold).
- Base advances **only** on a confirmed merge, off `merged_sha` (never `pushed_sha`); a step is `done` only after base advancement confirms.
- Every guard fails closed; apply-mode carries **no plugin knowledge** (AST guard).

## Deferred by design
`allow` (unattended direct push) + scheduled auto-apply (v2); auto-merge (Pulse never merges); real F5/F8 base-writer wiring (injected `advance_base` seam); F4 dependency-coherence apply.

**1000 tests passing.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)