### PR TITLE
feat: fold headless-sibling proposals into workflow-run (F10 last-mile, pulse-gh side)

### DIFF
--- a/docs/backlogs/2026-07-30-f10-followups.md
+++ b/docs/backlogs/2026-07-30-f10-followups.md
@@ -10,18 +10,15 @@ F10→F11-contract blocker.
 
 ---
 
-## 1. `proposed_actions` consistency across drivers [Minor — tie to scheduler PR]
+## 1. `proposed_actions` consistency across drivers [Minor — ✅ RESOLVED in PR #140]
 
-Marketplace-sync and generated-artifact emit a `proposed_actions` string when a transformation
-is scheduled-gated (`marketplace_sync.py` ~432-441, `generated_artifacts.py` ~640-659), but
-**plan-sync records only a `gated_transformation` finding** for a gated doc-patch — no
-`proposed_actions` line (`plan_sync.py` ~454-477). The propose-only constraint is still met
-(the finding is present; `proposals` stays empty), but the scheduler PR-body projection
-("Needs attention → `proposed_actions`", see
-`docs/superpowers/plans/2026-07-29-f10-scheduler-composition.md`) would omit the plan-sync line
-while the other two emit one. **Fix when the scheduler-composition PR lands** (that is when the
-projection actually matters): have plan-sync's gated path append a `proposed_actions` entry for
-consistency.
+~~Marketplace-sync and generated-artifact emit a `proposed_actions` string when a transformation
+is scheduled-gated, but plan-sync records only a `gated_transformation` finding for a gated
+doc-patch — no `proposed_actions` line.~~ **Fixed in PR #140** (the pulse-gh half of the
+scheduler-composition work): `plan_sync.build_result`'s gated doc-patch path now appends a
+`proposed_actions` line matching marketplace-sync / generated-artifacts, and the plan-sync
+scheduled acceptance assertion was strengthened from `is not None` to non-empty. All three
+drivers now project uniformly into the workflow-run proposal fold (`subresult_fold.py`).
 
 ## 2. Skill rewrite depth drift [Minor — maintainability]
 

--- a/docs/superpowers/plans/2026-07-29-f10-scheduler-composition.md
+++ b/docs/superpowers/plans/2026-07-29-f10-scheduler-composition.md
@@ -102,12 +102,18 @@ The scheduler-repo PR lands these tests:
 4. **Compatibility:** an empty/absent `automation.scheduled_workflows` runs the maintenance
    flow unchanged (status → refresh → healthcheck → PR) with no Workflow-runs section.
 
-## Open follow-up (tracked, not blocking this spec)
+## Open follow-up — ✅ RESOLVED
 
-- Verify/implement `gh-workflow-run-headless` folding of inner driver `proposals[]` →
-  `workflow-run-result.yaml` `proposed_actions`. If absent, it is a small **plugin-repo**
-  task (not scheduler), because the projection surface (`proposed_actions`) already exists in
-  Phase 6. Capture in the F10 backlog / `docs/backlogs/` if deferred.
+- ~~Verify/implement `gh-workflow-run-headless` folding of inner driver `proposals[]` →
+  `workflow-run-result.yaml` `proposed_actions`.~~ **Confirmed absent and implemented in
+  hiivmind-pulse-gh PR #140.** The executor's `INVOKE skill X` projection previously invoked
+  the sibling driver and discarded its result envelope; `lib/pulse/scripts/subresult_fold.py`
+  now folds the sibling's `findings` / `proposed_actions` / `asks_recorded` into the
+  workflow-run result (a deterministic pass-through — `proposals[]` is the F11 re-derivation
+  channel and is intentionally not re-rendered). Wired into `workflow-execution.md` and
+  `gh-workflow-run-headless`. Workspace enrollment of the four `periodic` workflows is
+  `hiivmind/hiivmind-workspace` PR #2. **With both merged, F10's "triggered end-to-end" gate
+  closes** — the scheduler template itself needed no functional change.
 
 ## Provenance
 

--- a/lib/patterns/workflow-execution.md
+++ b/lib/patterns/workflow-execution.md
@@ -330,9 +330,29 @@ delete, …); read-only operations always execute.
 | Mutation | per `on_mutation` — **propose**: append a one-line description (verb + target) to `proposed_actions`, do not execute; **allow-listed**: execute if the operation's verb is in `mutation_allowlist`, else propose; **allow**: execute |
 | `SHOW` / `PRESENT` phases | no user to show to; notable items become `findings` entries — `kind` from the workflow's domain (e.g. `stale-item`, `ci-failure`), `severity` via `INFER` with `inferred: true` |
 | `INFER` | executes normally; any finding it classifies carries `inferred: true` and its label in `classification` |
-| `INVOKE skill X` | if a headless sibling exists (`X-headless`), invoke it with explicit inputs (its `workspace_path` = the context's `workspace_root`); otherwise append `"invoke {X}"` to `proposed_actions` |
+| `INVOKE skill X` | if a headless sibling exists (`X-headless`), invoke it with explicit inputs (its `workspace_path` = the context's `workspace_root`), **then fold its result** (see below); otherwise append `"invoke {X}"` to `proposed_actions` |
 | `STOP "reason"` | normal completion (outcome `success`); the reason lands in the result summary, not `errors` |
 | `params` with `default: null` | if the caller did not supply the param: append to `asks_recorded`, outcome `aborted` |
+
+### Folding a headless sibling's result (`INVOKE skill X-headless`)
+
+When `INVOKE skill X` resolves to a headless sibling, that sibling writes its **own**
+`{kind}-result.yaml` (e.g. `marketplace-sync-result.yaml`) — a separate envelope from the
+`workflow-run-result.yaml` this run emits. Because the sibling's file is gitignored and the
+maintenance PR body is the only delivery channel for a scheduled run, the sibling's surfaced
+items **must be folded into this run's accumulators**, or a scheduled F6–F9 run reports zero
+proposals even when the sibling proposed many. After the sibling returns:
+
+```bash
+uv run "${PLUGIN_ROOT}/lib/pulse/scripts/subresult_fold.py" <sibling result path>
+```
+
+It prints `{"findings": [...], "proposed_actions": [...], "asks_recorded": [...]}`. **Extend**
+FINDINGS, PROPOSED_ACTIONS, and ASKS_RECORDED with those lists (never replace). The fold is a
+deterministic pass-through of the sibling's human-facing surface — it deliberately does **not**
+re-render the sibling's `proposals[]` (each proposal already has a `proposed_actions` line;
+`proposals[]` is the F11 re-derivation channel and `workflow-run` has no `proposals` field). A
+non-foldable/malformed sibling result is a run error appended to `errors`, not a silent skip.
 
 ### Unconditional rules (regardless of `on_mutation`)
 

--- a/lib/pulse/scripts/plan_sync.py
+++ b/lib/pulse/scripts/plan_sync.py
@@ -460,6 +460,14 @@ def build_result(
                 "detail": plans.gated_transformation,
                 "inferred": False,
             })
+            # Emit a proposed_actions line for the withheld doc patch so the
+            # scheduler PR-body projection surfaces it — parity with the gated
+            # paths in marketplace_sync.build_result / generated_artifacts (a
+            # gated transformation records the intended action without a
+            # proposal id, since build_apply_plans withheld the proposal).
+            result["proposed_actions"].append(
+                f"propose document patch for {document.path} at {document.head}"
+            )
 
         if plans.repo_mutation is not None:
             result["doc_patches"] += 1

--- a/lib/pulse/scripts/subresult_fold.py
+++ b/lib/pulse/scripts/subresult_fold.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["pyyaml>=6.0"]
+# ///
+"""Fold an inner headless-sibling result envelope into workflow-run accumulators.
+
+When a v2 workflow's pseudocode does ``INVOKE skill X-headless`` (see
+``lib/patterns/workflow-execution.md`` § Headless Execution), the executor runs
+the sibling driver, which writes its OWN ``{kind}-result.yaml`` (e.g.
+``marketplace-sync-result.yaml``). That file is gitignored and overwritten per
+run, and the maintenance PR body is the ONLY delivery channel for a scheduled
+run's proposals. So the executor MUST fold the sibling's surfaced items into the
+``workflow-run-result.yaml`` it emits — otherwise a scheduled F6–F9 run reports
+zero proposals even when the sibling proposed many.
+
+This module is that fold: deterministic and unit-tested, so the projection is a
+concrete callable rather than a prose instruction that silently no-ops (the
+exact failure mode that hid the gap until F10 was dogfooded).
+
+**Contract — pass-through of the human-facing surface, not re-derivation.**
+Every F10 driver already emits one ``proposed_actions`` string per proposal AND
+per withheld/gated action; its ``proposals[]`` list is the *separate* machine
+re-derivation channel (``{binding, transformation, proposal_id}``) consumed by
+apply-mode (F11), and the ``workflow-run`` kind has no ``proposals`` field. So
+the fold carries the inner ``findings``, ``proposed_actions``, and
+``asks_recorded`` through verbatim and deliberately does NOT render
+``proposals[]`` into ``proposed_actions`` — doing so would duplicate every line.
+
+The fold is generic over any inner headless envelope: it takes ``findings`` /
+``proposed_actions`` / ``asks_recorded`` when present (kinds that currently carry
+them include marketplace-sync, plan-sync, generated-artifact, impact, and
+fleet-membership) and contributes nothing for an envelope that lacks them. It is
+never the caller's job to know which kinds surface what.
+
+Usage: subresult_fold.py <inner-result.yaml>
+       → prints JSON {"findings": [...], "proposed_actions": [...], "asks_recorded": [...]}
+         on stdout; the executor extends its workflow-run accumulators with each list.
+
+Exit codes: 0 ok (JSON on stdout), 2 file missing/unparseable, 3 not foldable.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+FOLDED_FIELDS = ("findings", "proposed_actions", "asks_recorded")
+
+
+class SubresultFoldError(ValueError):
+    """Raised when an inner result envelope cannot be folded into a workflow-run."""
+
+
+def fold_subresult(inner: Any) -> dict[str, list]:
+    """Return the ``findings`` / ``proposed_actions`` / ``asks_recorded`` to merge
+    into a workflow-run result, given an inner headless result envelope.
+
+    Each folded field is optional on the input (an envelope that omits it
+    contributes an empty list), but when present it MUST be a list — a scalar or
+    mapping there signals a malformed sibling result and raises rather than
+    silently dropping data. ``findings`` mappings are shallow-copied so the
+    caller can mutate its accumulator without aliasing the parsed input.
+    """
+    if not isinstance(inner, Mapping):
+        raise SubresultFoldError("inner result must be a mapping")
+
+    folded: dict[str, list] = {}
+    for field in FOLDED_FIELDS:
+        value = inner.get(field, [])
+        if value is None:
+            value = []
+        if not isinstance(value, list):
+            kind = inner.get("kind", "<unknown>")
+            raise SubresultFoldError(
+                f"{kind} result field {field!r} must be a list, got {type(value).__name__}"
+            )
+        if field == "findings":
+            folded[field] = [dict(item) if isinstance(item, Mapping) else item for item in value]
+        else:
+            folded[field] = list(value)
+    return folded
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("result", help="path to an inner {kind}-result.yaml to fold")
+    args = ap.parse_args(argv)
+
+    path = Path(args.result)
+    if not path.exists():
+        print(f"error: file not found: {path}", file=sys.stderr)
+        return 2
+    try:
+        inner = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        print(f"error: could not read {path}: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        folded = fold_subresult(inner)
+    except SubresultFoldError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 3
+
+    json.dump(folded, sys.stdout, ensure_ascii=False)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/lib/pulse/scripts/subresult_fold.py
+++ b/lib/pulse/scripts/subresult_fold.py
@@ -70,19 +70,35 @@ def fold_subresult(inner: Any) -> dict[str, list]:
     if not isinstance(inner, Mapping):
         raise SubresultFoldError("inner result must be a mapping")
 
+    kind = inner.get("kind", "<unknown>")
     folded: dict[str, list] = {}
     for field in FOLDED_FIELDS:
         value = inner.get(field, [])
         if value is None:
             value = []
         if not isinstance(value, list):
-            kind = inner.get("kind", "<unknown>")
             raise SubresultFoldError(
                 f"{kind} result field {field!r} must be a list, got {type(value).__name__}"
             )
+        # Validate element shapes at this trust boundary — the sibling file is a
+        # separate, gitignored artifact. A malformed element must raise here (→
+        # recorded as a fold error) rather than pass through and blow up the
+        # OUTER workflow-run schema validation, which reads as a skill bug.
         if field == "findings":
-            folded[field] = [dict(item) if isinstance(item, Mapping) else item for item in value]
+            for i, item in enumerate(value):
+                if not isinstance(item, Mapping):
+                    raise SubresultFoldError(
+                        f"{kind} result findings[{i}] must be a mapping, "
+                        f"got {type(item).__name__}"
+                    )
+            folded[field] = [dict(item) for item in value]
         else:
+            for i, item in enumerate(value):
+                if not isinstance(item, str):
+                    raise SubresultFoldError(
+                        f"{kind} result {field}[{i}] must be a string, "
+                        f"got {type(item).__name__}"
+                    )
             folded[field] = list(value)
     return folded
 
@@ -98,7 +114,7 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     try:
         inner = yaml.safe_load(path.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError) as exc:
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
         print(f"error: could not read {path}: {exc}", file=sys.stderr)
         return 2
 

--- a/lib/pulse/scripts/tests/test_runnable_spine_acceptance.py
+++ b/lib/pulse/scripts/tests/test_runnable_spine_acceptance.py
@@ -201,7 +201,7 @@ def test_plan_sync_scheduled_gates_allow_scheduled_false(tmp_path):
     assert data["proposals"] == [], "scheduled must emit no runnable proposals"
     gated = [f for f in data["findings"] if f.get("kind") == "gated_transformation"]
     assert len(gated) == 1
-    assert data.get("proposed_actions") is not None
+    assert data["proposed_actions"], "gated path must record a proposed_action"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/pulse/scripts/tests/test_subresult_fold.py
+++ b/lib/pulse/scripts/tests/test_subresult_fold.py
@@ -105,6 +105,23 @@ def test_fold_rejects_non_list_field():
         fold_subresult({"kind": "plan-sync", "findings": "oops"})
 
 
+def test_fold_rejects_malformed_finding_element():
+    # A non-mapping in findings must raise here (recorded as a fold error), not
+    # pass through and fail the outer workflow-run schema validation later.
+    with pytest.raises(SubresultFoldError):
+        fold_subresult({"kind": "plan-sync", "findings": ["oops"]})
+
+
+def test_fold_rejects_non_string_action_element():
+    with pytest.raises(SubresultFoldError):
+        fold_subresult({"kind": "plan-sync", "proposed_actions": [{"not": "a string"}]})
+
+
+def test_fold_rejects_non_string_ask_element():
+    with pytest.raises(SubresultFoldError):
+        fold_subresult({"kind": "plan-sync", "asks_recorded": [123]})
+
+
 # --------------------------------------------------------------------------- #
 # CLI
 # --------------------------------------------------------------------------- #
@@ -136,6 +153,24 @@ def test_cli_non_foldable_exit_3(tmp_path):
     bad = tmp_path / "bad.yaml"
     bad.write_text("- just\n- a\n- list\n", encoding="utf-8")
     proc = _run_cli(bad)
+    assert proc.returncode == 3
+
+
+def test_cli_invalid_utf8_exit_2(tmp_path):
+    # Invalid UTF-8 bytes must map to the documented "unparseable" exit 2, not an
+    # uncaught UnicodeDecodeError traceback (exit 1).
+    bad = tmp_path / "bad-bytes.yaml"
+    bad.write_bytes(b"\xff\xfe not utf-8")
+    proc = _run_cli(bad)
+    assert proc.returncode == 2
+
+
+def test_cli_malformed_finding_exit_3(tmp_path):
+    inner = tmp_path / "marketplace-sync-result.yaml"
+    payload = _marketplace_result()
+    payload["findings"] = ["not-a-mapping"]
+    inner.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    proc = _run_cli(inner)
     assert proc.returncode == 3
 
 

--- a/lib/pulse/scripts/tests/test_subresult_fold.py
+++ b/lib/pulse/scripts/tests/test_subresult_fold.py
@@ -1,0 +1,173 @@
+"""Fold of an inner headless-sibling result into workflow-run accumulators.
+
+Guards the F10 layer-4 defect: a scheduled `INVOKE skill X-headless` workflow
+must surface the sibling's proposals in its `workflow-run-result.yaml`, or the
+maintenance PR body shows nothing. Covers the pure fold, the anti-duplication
+contract (proposals[] is NOT re-rendered), the CLI, and a round-trip proving the
+folded surface satisfies the workflow-run schema.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lib.pulse.scripts import subresult_fold, validate_result
+from lib.pulse.scripts.subresult_fold import SubresultFoldError, fold_subresult
+
+SCRIPT = Path(subresult_fold.__file__)
+
+
+def _marketplace_result():
+    """A realistic marketplace-sync envelope: one proposal + one gated action."""
+    return {
+        "contract_version": 1,
+        "kind": "marketplace-sync",
+        "workspace": "hiivmind",
+        "run_at": "2026-07-30T12:00:00Z",
+        "actor": {"gh_login": "octocat", "machine": "host", "mode": "scheduled"},
+        "bindings_scanned": 2,
+        "in_sync": 0,
+        "drift": 2,
+        "missing_entry": 0,
+        "unknown": 0,
+        "not_applicable": 0,
+        "findings": [
+            {"kind": "gated_transformation", "repo": "hiivmind/mp", "severity": "medium",
+             "detail": "allow_scheduled: false"},
+        ],
+        "proposals": [
+            {"binding": "plug-a", "transformation": "marketplace-entry-update",
+             "proposal_id": "mp-1"},
+        ],
+        "proposed_actions": [
+            "propose marketplace entry update for plug-a to 2.0.0",
+            "propose marketplace entry update for plug-b to 3.0.0",
+        ],
+        "errors": [],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# Pure fold
+# --------------------------------------------------------------------------- #
+
+def test_fold_passes_findings_and_actions_and_asks_through():
+    inner = _marketplace_result()
+    inner["asks_recorded"] = ["Q1: which release channel?"]
+    folded = fold_subresult(inner)
+    assert folded["findings"] == inner["findings"]
+    assert folded["proposed_actions"] == inner["proposed_actions"]
+    assert folded["asks_recorded"] == ["Q1: which release channel?"]
+
+
+def test_fold_does_not_re_render_proposals_no_duplication():
+    """The load-bearing design assertion: proposals[] is the F11 re-derivation
+    channel and is NOT projected — proposed_actions keeps the driver's own lines
+    verbatim, so a proposal never appears twice."""
+    inner = _marketplace_result()
+    folded = fold_subresult(inner)
+    # Two driver-authored action lines in, exactly two out — proposals[] (len 1)
+    # contributed nothing extra.
+    assert folded["proposed_actions"] == inner["proposed_actions"]
+    assert len(folded["proposed_actions"]) == 2
+
+
+def test_fold_missing_fields_default_to_empty_lists():
+    folded = fold_subresult({"kind": "plan-sync"})
+    assert folded == {"findings": [], "proposed_actions": [], "asks_recorded": []}
+
+
+def test_fold_null_field_treated_as_empty():
+    folded = fold_subresult({"kind": "plan-sync", "proposed_actions": None})
+    assert folded["proposed_actions"] == []
+
+
+def test_fold_findings_are_copied_not_aliased():
+    inner = _marketplace_result()
+    folded = fold_subresult(inner)
+    folded["findings"][0]["severity"] = "high"
+    assert inner["findings"][0]["severity"] == "medium"
+
+
+def test_fold_rejects_non_mapping():
+    with pytest.raises(SubresultFoldError):
+        fold_subresult(["not", "a", "mapping"])
+
+
+def test_fold_rejects_non_list_field():
+    with pytest.raises(SubresultFoldError):
+        fold_subresult({"kind": "plan-sync", "findings": "oops"})
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+def _run_cli(path: Path):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(path)],
+        capture_output=True, text=True,
+    )
+
+
+def test_cli_prints_folded_json(tmp_path):
+    inner = tmp_path / "marketplace-sync-result.yaml"
+    inner.write_text(yaml.safe_dump(_marketplace_result()), encoding="utf-8")
+    proc = _run_cli(inner)
+    assert proc.returncode == 0, proc.stderr
+    out = json.loads(proc.stdout)
+    assert out["proposed_actions"] == _marketplace_result()["proposed_actions"]
+    assert out["findings"][0]["kind"] == "gated_transformation"
+    assert out["asks_recorded"] == []
+
+
+def test_cli_missing_file_exit_2(tmp_path):
+    proc = _run_cli(tmp_path / "nope.yaml")
+    assert proc.returncode == 2
+
+
+def test_cli_non_foldable_exit_3(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("- just\n- a\n- list\n", encoding="utf-8")
+    proc = _run_cli(bad)
+    assert proc.returncode == 3
+
+
+# --------------------------------------------------------------------------- #
+# Round-trip: folded surface satisfies the workflow-run schema
+# --------------------------------------------------------------------------- #
+
+def _workflow_run_envelope(folded, *, workflow):
+    return {
+        "contract_version": 1,
+        "kind": "workflow-run",
+        "workspace": "hiivmind",
+        "run_at": "2026-07-30T12:00:00Z",
+        "actor": {"gh_login": "octocat", "machine": "host", "mode": "scheduled"},
+        "workflow": workflow,
+        "repos": [],
+        "run_id": "2026-07-30-octocat-120000",
+        "outcome": "success",
+        "findings": list(folded["findings"]),
+        "proposed_actions": list(folded["proposed_actions"]),
+        "asks_recorded": list(folded["asks_recorded"]),
+        "errors": [],
+    }
+
+
+@pytest.mark.parametrize("kind", ["marketplace-sync", "plan-sync", "generated-artifact"])
+def test_folded_surface_builds_a_valid_workflow_run(kind):
+    inner = _marketplace_result()
+    inner["kind"] = kind  # fold is generic over kind; the surface fields are identical
+    folded = fold_subresult(inner)
+    envelope = _workflow_run_envelope(folded, workflow=kind)
+    assert validate_result.validate(envelope, "workflow-run") == []
+    # The sibling's proposals reach the PR-body projection surface.
+    assert envelope["proposed_actions"], "folded workflow-run must carry sibling actions"
+    assert any(f["kind"] == "gated_transformation" for f in envelope["findings"])

--- a/skills/gh-workflow-run-headless/SKILL.md
+++ b/skills/gh-workflow-run-headless/SKILL.md
@@ -88,6 +88,15 @@ workspace_root: {workspace_path}, repo: {repo input}}`, applying the Headless Ex
 projection with the workflow's `headless:` policy. Accumulate FINDINGS,
 PROPOSED_ACTIONS, ASKS_RECORDED per the projection table.
 
+- **Driver-backed workflows** (whose pseudocode is `INVOKE skill X-headless`, e.g. the
+  F6–F9 marketplace-sync / plan-sync / generated-artifact workflows) produce their
+  proposals in the sibling's own `{kind}-result.yaml`. Per the executor's "Folding a
+  headless sibling's result" rule, run
+  `uv run "${CLAUDE_PLUGIN_ROOT}/lib/pulse/scripts/subresult_fold.py" <sibling result>`
+  and extend FINDINGS / PROPOSED_ACTIONS / ASKS_RECORDED with its output — otherwise this
+  run's result carries none of the sibling's proposals and the scheduled PR body shows
+  nothing. A fold error (`exit 3`) is appended to ERRORS.
+
 - Pseudocode completed (end or `STOP`) → OUTCOME = `success`.
 - Unrecoverable error → OUTCOME = `failure`, append to ERRORS, proceed to Phase 4.
 - `on_ask: abort` triggered → OUTCOME = `aborted`, proceed to Phase 4.


### PR DESCRIPTION
## What

Closes the **F10 layer-4 defect**: a scheduled `INVOKE skill X-headless` workflow (marketplace-sync / plan-sync / generated-artifact) invoked its sibling driver but **discarded the sibling's result envelope**, so a scheduled run surfaced **zero proposals** in the maintenance PR body — even when the sibling proposed many. The sibling's `{kind}-result.yaml` is gitignored and the PR body is the only delivery channel, so the discarded proposals were simply lost.

This is the pulse-gh half of "the F10 scheduler PR" (the real work; the scheduler template was already generic — see the cross-repo map in `docs/backlogs/README.md`). Workspace enrollment of the four `periodic` workflows lands as a separate PR against `hiivmind/hiivmind-workspace`.

## Changes

- **`lib/pulse/scripts/subresult_fold.py`** (new) — deterministic, unit-tested fold of an inner headless envelope's `findings` / `proposed_actions` / `asks_recorded` into the outer `workflow-run` accumulators. Generic over any headless sibling. **Pass-through by design:** `proposals[]` is the F11 (apply-mode) re-derivation channel and is deliberately **not** re-rendered — each proposal already has a `proposed_actions` line, and `workflow-run` has no `proposals` field, so re-rendering would duplicate every line. CLI exit codes: 2 missing/unparseable, 3 non-foldable/malformed.
- **Executor prose wiring** — `lib/patterns/workflow-execution.md` (the `INVOKE skill X` projection now folds the sibling result) + `gh-workflow-run-headless` Phase 3 (shells `subresult_fold.py`, extends the accumulators, records a fold error to `errors`).
- **Ride-along (F10 follow-up Minor #1)** — `plan_sync.build_result` now appends a `proposed_actions` line on the gated doc-patch path, matching `marketplace_sync` / `generated_artifacts`, so all three drivers project uniformly. Acceptance assertion strengthened from `is not None` to non-empty.

## Review

Adversarial review (codex, standard tier) returned two Important findings, both fixed + tested in the second commit: uncaught `UnicodeDecodeError` (→ exit 2) and malformed list *elements* passing through to blow up outer validation (→ recorded as a clean fold error).

## Tests

`+test_subresult_fold.py` (18 tests: pure fold, anti-duplication contract, element-shape rejection, CLI exit codes, workflow-run round-trip validation). **Full suite: 1098 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)