### PR TITLE
feat: strict versioned nave apply-verb adapters (Task 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-30-apply-mode-pulse-wiring.md
+++ b/docs/superpowers/plans/2026-07-30-apply-mode-pulse-wiring.md
@@ -28,15 +28,22 @@
 ## Authoritative Interfaces (single source of truth — every task and test uses these verbatim)
 
 ```
-# nave_adapter.py (Task 1)
+# nave_adapter.py (Task 1) — as shipped; see
+# docs/superpowers/specs/2026-08-13-apply-verb-contract-handoff.md for the
+# full wire contract (states, echo checks, CLI shapes) this table only summarizes.
 NAVE_APPLY_PROTOCOL = 1
+APPLY_VERBS = ("branch", "commit", "push", "reset")
 pen_capabilities(runner) -> {"protocol_version": int|None, "verbs": list[str], "adapter_state": str, "reason": str|None}
-pen_branch(runner, name, request: list[dict]) -> {"adapter_state","repos":[{repo,base_ref,expected_base_sha,observed_base_sha,apply_ref,state,reason?}]}
-pen_commit(runner, name, request: list[dict], message) -> {"adapter_state","repos":[{repo,local_commit_sha,state,reason?}]}
-pen_push(runner, name, branch, request: list[dict]) -> {"adapter_state","repos":[{repo,remote,remote_ref,remote_sha,upstream,local_commit_sha,state,reason?}]}  # request=[{repo}] carries expected_repos so coverage can be enforced
+pen_branch(runner, name, apply_ref, request: list[dict]) -> {"adapter_state","repos":[{repo,base_ref,expected_base_sha,observed_base_sha,apply_ref,state,reason?}]}
+  # apply_ref is a single envelope-level field naming one branch across every repo, NOT per-repo
+pen_commit(runner, name, branch, request: list[dict], message) -> {"adapter_state","repos":[{repo,local_commit_sha?,state,reason?}]}
+  # branch is a positional (this table's original signature omitted it); request carries only {repo,paths}
+pen_push(runner, name, branch, request: list[dict]) -> {"adapter_state","repos":[{repo,remote?,remote_ref?,remote_sha?,upstream?,local_commit_sha?,state,reason?}]}  # request=[{repo}] carries expected_repos so coverage can be enforced
 pen_reset(runner, name, branch, request: list[dict]) -> {"adapter_state","repos":[{repo,local_reset,remote_deleted,state,reason?}]}
 pen_status(runner, name)  # existing owner/name shape UNCHANGED; each repo entry GAINS clone_path
-# request envelopes are versioned: {"protocol_version":1,"repos":[...]}
+# request envelopes are versioned: {"protocol_version":1,"repos":[...]}; per-repo `state` values are
+# closed, kebab-case sets that differ per verb (e.g. branch: stale-base/exists/evidence-unavailable/...)
+# — NOT a generic "failed"; see the handoff doc's enumerated sets.
 
 # apply_rederive.py (Task 2) — re-derives from FRESH SOURCE STATE (no pen), via typed provider inputs
 RederivedProposal(binding_id: str, proposal: Proposal, source_kind: str, finalizer_record: dict|None)
@@ -95,7 +102,7 @@ make_f8_advance_base(finalizer_record, contents_ops, gh_ops) -> Callable[[str,st
 
 **Interfaces:** Produces the `nave_adapter` functions in the Authoritative Interfaces table. Uses the real decode helper — note its signature is `_decode_json(command, completed)` (`nave_adapter.py:305`), not `_decode_json(raw)`.
 
-- [ ] **Step 1: Write failing tests** — for each verb: happy path; **required-field missing** → error; **state enum invalid** → error; **wrong `protocol_version`** → error; **absent `adapter_state`** → error (never invent `"ok"`); **repo coverage mismatch** (extra/missing/duplicate repo vs request) → error; **echoed mismatch** (`pen_branch` returns `expected_base_sha` ≠ requested) → error; **nonzero returncode with valid partial-failure JSON** → surfaced as per-repo `failed`, not a hard error; **malformed JSON** → error. Plus `test_trio_is_deleted` (no `provision_apply_branch`/`commit_apply_clones`/`push_apply_clones`).
+- [x] **Step 1: Write failing tests** — for each verb: happy path; **required-field missing** → error; **state enum invalid** → error; **wrong `protocol_version`** → error; **absent `adapter_state`** → error (never invent `"ok"`); **repo coverage mismatch** (extra/missing/duplicate repo vs request) → error; **echoed mismatch** (`pen_branch` returns `expected_base_sha` ≠ requested) → error; **nonzero returncode with valid partial-failure JSON** → surfaced as per-repo `failed`, not a hard error; **malformed JSON** → error. Plus `test_trio_is_deleted` (no `provision_apply_branch`/`commit_apply_clones`/`push_apply_clones`).
 
 ```python
 def test_pen_branch_rejects_echoed_expected_sha_mismatch():
@@ -111,10 +118,21 @@ def test_missing_adapter_state_is_error_not_invented():
     assert na.pen_push(runner, "pen1", "b")["adapter_state"] == "error"
 ```
 
-- [ ] **Step 2: Run, verify fail.**
-- [ ] **Step 3: Implement** a `_validate_apply_result(data, *, request_repos, required_fields, state_field="state")` helper that enforces protocol, envelope, `adapter_state` presence, per-repo required fields + `state` enum, exact coverage against `request_repos`, and echoed-field equality; each `pen_*` builds its argv (writing a **versioned** request envelope), calls the real `_decode_json(command, completed)`, and returns the validated dict (or `{"adapter_state":"error","reason":...,"repos":[]}`). **`pen_push` takes a `request: list[dict]` of `[{repo}]` so `request_repos` is authoritative for coverage** (never inferred from the response). `pen_reset` returns per-repo `local_reset`/`remote_deleted` separately. Preserve `Completed.returncode`; accept nonzero **only** with a valid partial-failure document. Extend `pen_status` decode to pass through `clone_path`. **Delete** the trio (`nave_adapter.py:500-616`) and its tests (incl. `:724`).
-- [ ] **Step 4: Run, verify pass.**
-- [ ] **Step 5: Commit** — `feat: strict versioned nave apply-verb adapters; delete raw-git trio`.
+- [x] **Step 2: Run, verify fail.**
+- [x] **Step 3: Implement** a `_validate_apply_result(data, *, request_repos, required_fields, state_field="state")` helper that enforces protocol, envelope, `adapter_state` presence, per-repo required fields + `state` enum, exact coverage against `request_repos`, and echoed-field equality; each `pen_*` builds its argv (writing a **versioned** request envelope), calls the real `_decode_json(command, completed)`, and returns the validated dict (or `{"adapter_state":"error","reason":...,"repos":[]}`). **`pen_push` takes a `request: list[dict]` of `[{repo}]` so `request_repos` is authoritative for coverage** (never inferred from the response). `pen_reset` returns per-repo `local_reset`/`remote_deleted` separately. Preserve `Completed.returncode`; accept nonzero returncode with valid JSON as a normal decode (never a hard error keyed off exit status).
+
+  **Revised against the actual shipped Nave contract** (`discreteds/nave` PR #2,
+  `docs/superpowers/specs/2026-08-13-apply-verb-contract-handoff.md` — authoritative
+  where it disagrees with this table): `pen_branch(runner, name, apply_ref, request)`
+  — `apply_ref` is a single envelope-level field, not per-repo, so it's a distinct
+  parameter, not folded into `request` as this table's original signature implied.
+  `pen_commit(runner, name, branch, request, message)` gains the `branch` positional
+  this table originally omitted. States are richer verb-specific closed sets
+  (`stale-base`/`exists`/`evidence-unavailable` for branch, etc.), not a generic
+  `"failed"`. `pen_status`/`pen_list --json` both gain `clone_path` (Task 2's own
+  concern — cross-referenced here since the Nave-side handoff flagged it).
+- [x] **Step 4: Run, verify pass.** `uv run pytest lib/pulse/scripts/tests/test_nave_adapter.py -q` — 86 passed. Full suite: `uv run pytest -q` — 1309 passed. `git diff --check` clean.
+- [x] **Step 5: Commit** — `feat: strict versioned nave apply-verb adapters; delete raw-git trio`.
 
 ---
 

--- a/lib/pulse/scripts/nave_adapter.py
+++ b/lib/pulse/scripts/nave_adapter.py
@@ -13,9 +13,10 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Sequence
+from typing import Mapping, Sequence
 
 
 BASELINE_CAPABILITIES = {
@@ -497,124 +498,336 @@ def pen_exec(
     }
 
 
-def provision_apply_branch(
-    clone_paths: dict[str, str | Path],
-    branch: str,
-    base_shas: dict[str, str],
-) -> dict[str, dict[str, str]]:
-    """Provision a per-proposal branch off the guarded base SHA in each repo clone.
+# --- apply verbs -----------------------------------------------------------
+#
+# `nave pen {capabilities,branch,commit,push,reset}` — the sole git-mutation
+# path for apply-mode landings (F11 consolidation note: no clone-write git
+# in Pulse). Contract source of truth: `crates/nave_apply/src/lib.rs` in
+# `discreteds/nave`, transcribed for cross-repo convenience in
+# `docs/superpowers/specs/2026-08-13-apply-verb-contract-handoff.md` (that
+# repo, PR #2) — read it before changing anything below.
 
-    Operates directly on local repository clones via `git checkout -b <branch> <base_sha>`.
-    This is a git operation on local clones, not a Nave CLI subcommand.
+NAVE_APPLY_PROTOCOL = 1
+APPLY_VERBS = ("branch", "commit", "push", "reset")
 
-    Returns a dict mapping repo identifier (`owner/name`) to a result dict:
-      `{"state": "ok"}` or `{"state": "failed", "reason": "..."}`.
+# Per-repo `state` values are closed sets, kebab-case on the wire. An
+# unrecognized value is a validation error, never silently accepted.
+_BRANCH_STATES = frozenset(
+    {
+        "ok",
+        "stale-base",
+        "exists",
+        "missing-ref",
+        "not-a-commit",
+        "unknown-repo",
+        "evidence-unavailable",
+    }
+)
+_COMMIT_STATES = frozenset(
+    {
+        "ok",
+        "nothing-to-commit",
+        "dirty-outside-bounds",
+        "invariant-violated",
+        "missing-clone",
+        "no-apply-state",
+        "unknown-repo",
+    }
+)
+_PUSH_STATES = frozenset(
+    {"ok", "missing-branch", "diverged", "push-rejected", "no-apply-state", "unknown-repo"}
+)
+_RESET_STATES = frozenset(
+    {"ok", "remote-cas-mismatch", "missing-branch", "unknown-repo", "evidence-mismatch"}
+)
+
+# Fields every `*RepoResult` variant serializes unconditionally (matches the
+# Rust structs' non-`Option` fields); anything else (`reason`,
+# `local_commit_sha`, ...) is present only when the verb has it to report.
+_BRANCH_REQUIRED_FIELDS = (
+    "repo",
+    "base_ref",
+    "expected_base_sha",
+    "observed_base_sha",
+    "apply_ref",
+    "state",
+)
+_COMMIT_REQUIRED_FIELDS = ("repo", "state")
+_PUSH_REQUIRED_FIELDS = ("repo", "state")
+_RESET_REQUIRED_FIELDS = ("repo", "local_reset", "remote_deleted", "state")
+
+
+def _validate_apply_result(
+    data: dict,
+    *,
+    command: str,
+    request_repos: Sequence[str],
+    required_fields: Sequence[str],
+    valid_states: frozenset[str],
+    request_by_repo: Mapping[str, Mapping[str, object]] | None = None,
+    per_repo_echo_from_request: Sequence[str] = (),
+    per_repo_echo_uniform: Mapping[str, object] | None = None,
+) -> dict:
+    """Enforce the versioned apply-verb wire contract; never invent success.
+
+    Checks, in order: JSON is an object; `protocol_version` matches; a
+    `_decode_json` transport-layer error (bad JSON / non-dict root) passes
+    through unchanged; `adapter_state` is present and one of `{"ok",
+    "error"}` (an `"error"` envelope's `reason` is already top-level and is
+    returned as-is); on `"ok"`, `repos` is a list with exact coverage
+    against `request_repos` (no missing, no extra, no duplicate repo), every
+    entry carries `required_fields` and a `state` in `valid_states`, and any
+    echoed field — either per-repo (`per_repo_echo_from_request`, checked
+    against the matching request entry) or envelope-uniform
+    (`per_repo_echo_uniform`, e.g. `pen branch`'s single `apply_ref` across
+    every repo) — matches what was requested. Any failure returns a typed
+    `adapter_state: "error"` envelope with an empty `repos` and a `reason`
+    naming exactly what was wrong.
     """
-    results: dict[str, dict[str, str]] = {}
-    for repo, clone_path in clone_paths.items():
-        base_sha = base_shas.get(repo)
-        if not base_sha:
-            results[repo] = {
-                "state": "failed",
-                "reason": f"missing base SHA for repo {repo}",
-            }
-            continue
 
-        res = subprocess.run(
-            ["git", "-C", str(clone_path), "checkout", "-b", branch, base_sha],
-            capture_output=True,
-            text=True,
-            check=False,
+    def fail(reason: str) -> dict:
+        return {
+            "protocol_version": data.get("protocol_version") if isinstance(data, dict) else None,
+            "adapter_state": "error",
+            "reason": reason,
+            "repos": [],
+        }
+
+    if not isinstance(data, dict):
+        return fail(f"invalid JSON from nave {command}: root is not an object")
+    if "command" in data and "returncode" in data and "error" in data:
+        return data  # `_decode_json` transport-layer error; already typed.
+
+    protocol_version = data.get("protocol_version")
+    if protocol_version != NAVE_APPLY_PROTOCOL:
+        return fail(
+            f"unsupported protocol_version {protocol_version!r} from nave {command} "
+            f"(expected {NAVE_APPLY_PROTOCOL})"
         )
-        if res.returncode == 0:
-            results[repo] = {"state": "ok"}
-        else:
-            reason = res.stderr.strip() or res.stdout.strip() or "git checkout -b failed"
-            results[repo] = {"state": "failed", "reason": reason}
 
-    return results
+    adapter_state = data.get("adapter_state")
+    if adapter_state is None:
+        return fail(f"adapter_state missing from nave {command} output")
+    if adapter_state not in ("ok", "error"):
+        return fail(f"unrecognized adapter_state {adapter_state!r} from nave {command}")
+    if adapter_state == "error":
+        return data
+
+    repos = data.get("repos")
+    if not isinstance(repos, list):
+        return fail(f"nave {command} reported adapter_state=ok with a non-list repos field")
+
+    seen: dict[str, int] = {}
+    for entry in repos:
+        if not isinstance(entry, dict) or "repo" not in entry:
+            return fail(f"nave {command} repo entry missing 'repo' field")
+        seen[entry["repo"]] = seen.get(entry["repo"], 0) + 1
+
+    duplicates = sorted(repo for repo, count in seen.items() if count > 1)
+    if duplicates:
+        return fail(f"nave {command} reported duplicate repo(s): {', '.join(duplicates)}")
+
+    requested = set(request_repos)
+    reported = set(seen)
+    missing = sorted(requested - reported)
+    extra = sorted(reported - requested)
+    if missing:
+        return fail(f"nave {command} omitted requested repo(s): {', '.join(missing)}")
+    if extra:
+        return fail(f"nave {command} reported unrequested repo(s): {', '.join(extra)}")
+
+    for entry in repos:
+        repo = entry["repo"]
+        missing_fields = [f for f in required_fields if f not in entry]
+        if missing_fields:
+            return fail(
+                f"nave {command} repo {repo!r} missing required field(s): {', '.join(missing_fields)}"
+            )
+        state = entry.get("state")
+        if state not in valid_states:
+            return fail(f"nave {command} repo {repo!r} reported unrecognized state {state!r}")
+        if request_by_repo is not None:
+            requested_entry = request_by_repo.get(repo, {})
+            for field in per_repo_echo_from_request:
+                if field in requested_entry and entry.get(field) != requested_entry[field]:
+                    return fail(
+                        f"nave {command} repo {repo!r} echoed {field}={entry.get(field)!r}, "
+                        f"requested {requested_entry[field]!r}"
+                    )
+        if per_repo_echo_uniform:
+            for field, expected in per_repo_echo_uniform.items():
+                if entry.get(field) != expected:
+                    return fail(
+                        f"nave {command} repo {repo!r} echoed {field}={entry.get(field)!r}, "
+                        f"requested {expected!r}"
+                    )
+
+    return data
 
 
-def commit_apply_clones(
-    clone_paths: dict[str, str | Path],
+def _run_apply_verb(
+    runner: NaveRunner,
+    argv_prefix: Sequence[str],
+    envelope: dict,
+    *,
+    extra_args: Sequence[str] = (),
+    command: str,
+) -> dict:
+    """Write a versioned request envelope to a temp file, run the verb, decode JSON.
+
+    `--request` always names a file path — the wire body is never passed as
+    an inline shell argument (mirrors the existing `nave materialize
+    --request` convention). The temp directory is removed once the process
+    returns; callers needing the request body itself must capture it inside
+    a fake runner's `run()` before this returns.
+    """
+    with tempfile.TemporaryDirectory(prefix="pulse-nave-apply-") as tmp_dir:
+        request_path = Path(tmp_dir) / "request.json"
+        request_path.write_text(json.dumps(envelope))
+        args = [*argv_prefix, "--request", str(request_path), *extra_args, "--json"]
+        return _decode_json(command, runner.run(args))
+
+
+def pen_capabilities(runner: NaveRunner) -> dict:
+    """Probe the apply-verb protocol version and supported verbs.
+
+    Run before any apply-mode mutation. Fails closed if the command doesn't
+    exist at all (a stale/pre-apply-verb Nave binary has no `pen
+    capabilities` subcommand — `clap`'s "unrecognized subcommand" nonzero
+    exit *is* the fail-closed signal), if `protocol_version` doesn't match
+    `NAVE_APPLY_PROTOCOL`, or if `verbs` isn't a superset of `APPLY_VERBS`.
+    """
+    decoded = _decode_json("pen capabilities", runner.run(["pen", "capabilities", "--json"]))
+    if decoded.get("adapter_state") != "ok":
+        return {
+            "protocol_version": decoded.get("protocol_version"),
+            "verbs": [],
+            "adapter_state": "error",
+            "reason": decoded.get("reason") or decoded.get("error") or "nave pen capabilities failed",
+        }
+    protocol_version = decoded.get("protocol_version")
+    verbs = decoded.get("verbs")
+    if protocol_version != NAVE_APPLY_PROTOCOL:
+        return {
+            "protocol_version": protocol_version,
+            "verbs": verbs if isinstance(verbs, list) else [],
+            "adapter_state": "error",
+            "reason": f"unsupported protocol_version {protocol_version!r} (expected {NAVE_APPLY_PROTOCOL})",
+        }
+    if not isinstance(verbs, list) or not set(APPLY_VERBS) <= set(verbs):
+        missing = sorted(set(APPLY_VERBS) - set(verbs or []))
+        return {
+            "protocol_version": protocol_version,
+            "verbs": verbs if isinstance(verbs, list) else [],
+            "adapter_state": "error",
+            "reason": f"nave pen capabilities missing required verb(s): {', '.join(missing)}",
+        }
+    return {"protocol_version": protocol_version, "verbs": verbs, "adapter_state": "ok", "reason": None}
+
+
+def pen_branch(
+    runner: NaveRunner,
+    name: str,
+    apply_ref: str,
+    request: Sequence[dict],
+) -> dict:
+    """Provision the apply branch across a request's repos off a verified remote base.
+
+    `request`: `[{"repo": str, "base_ref": str, "expected_base_sha": str}, ...]`.
+    `apply_ref` is a single envelope-level field — one branch provisioning
+    call names one apply branch across every repo in the request, never a
+    per-repo field.
+    """
+    request_repos = [entry["repo"] for entry in request]
+    request_by_repo = {entry["repo"]: entry for entry in request}
+    envelope = {"protocol_version": NAVE_APPLY_PROTOCOL, "apply_ref": apply_ref, "repos": list(request)}
+    decoded = _run_apply_verb(runner, ["pen", "branch", name], envelope, command="pen branch")
+    return _validate_apply_result(
+        decoded,
+        command="pen branch",
+        request_repos=request_repos,
+        required_fields=_BRANCH_REQUIRED_FIELDS,
+        valid_states=_BRANCH_STATES,
+        request_by_repo=request_by_repo,
+        per_repo_echo_from_request=("base_ref", "expected_base_sha"),
+        per_repo_echo_uniform={"apply_ref": apply_ref},
+    )
+
+
+def pen_commit(
+    runner: NaveRunner,
+    name: str,
+    branch: str,
+    request: Sequence[dict],
     message: str,
-) -> dict[str, dict[str, str]]:
-    """Commit uncommitted changes in each repo clone with the attributed message.
+) -> dict:
+    """Bounded-stage and commit dirty apply-branch paths, with post-exec invariant checks.
 
-    Operates directly on local repository clones via `git -C <clone> add -A` then
-    `git -C <clone> commit -m <message>`. A repo with nothing to commit fails.
-
-    Returns a dict mapping repo identifier (`owner/name`) to a result dict:
-      `{"state": "ok"}` or `{"state": "failed", "reason": "..."}`.
+    `request`: `[{"repo": str, "paths": [str, ...]}, ...]`. `branch` is a
+    positional, not part of the request body. Neither `expected_base_sha`
+    (Nave checks the committed branch against its own server-side sidecar
+    written by `pen branch`) nor `message` (the separate `-m` flag) belongs
+    in the request body.
     """
-    results: dict[str, dict[str, str]] = {}
-    for repo, clone_path in clone_paths.items():
-        add_res = subprocess.run(
-            ["git", "-C", str(clone_path), "add", "-A"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if add_res.returncode != 0:
-            reason = add_res.stderr.strip() or add_res.stdout.strip() or "git add failed"
-            results[repo] = {"state": "failed", "reason": reason}
-            continue
-
-        status_res = subprocess.run(
-            ["git", "-C", str(clone_path), "status", "--porcelain"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if status_res.returncode == 0 and not status_res.stdout.strip():
-            results[repo] = {
-                "state": "failed",
-                "reason": f"nothing to commit in {repo}",
-            }
-            continue
-
-        res = subprocess.run(
-            ["git", "-C", str(clone_path), "commit", "-m", message],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if res.returncode == 0:
-            results[repo] = {"state": "ok"}
-        else:
-            reason = res.stderr.strip() or res.stdout.strip() or "git commit failed"
-            results[repo] = {"state": "failed", "reason": reason}
-
-    return results
+    request_repos = [entry["repo"] for entry in request]
+    envelope = {"protocol_version": NAVE_APPLY_PROTOCOL, "repos": list(request)}
+    decoded = _run_apply_verb(
+        runner, ["pen", "commit", name, branch], envelope, extra_args=["-m", message], command="pen commit"
+    )
+    return _validate_apply_result(
+        decoded,
+        command="pen commit",
+        request_repos=request_repos,
+        required_fields=_COMMIT_REQUIRED_FIELDS,
+        valid_states=_COMMIT_STATES,
+    )
 
 
-def push_apply_clones(
-    clone_paths: dict[str, str | Path],
+def pen_push(
+    runner: NaveRunner,
+    name: str,
     branch: str,
-) -> dict[str, dict[str, str]]:
-    """Push each clone's apply branch to origin.
+    request: Sequence[dict],
+) -> dict:
+    """Push the apply branch's committed local tip, verifying evidence before reporting ok.
 
-    Operates directly on local repository clones via `git -C <clone> push origin <branch>`.
-
-    Returns a dict mapping repo identifier (`owner/name`) to a result dict:
-      `{"state": "ok"}` or `{"state": "failed", "reason": "..."}`.
+    `request`: `[{"repo": str}, ...]` — carries the expected repo set so
+    coverage is enforced against the request, never inferred from the
+    response.
     """
-    results: dict[str, dict[str, str]] = {}
-    for repo, clone_path in clone_paths.items():
-        res = subprocess.run(
-            ["git", "-C", str(clone_path), "push", "origin", branch],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if res.returncode == 0:
-            results[repo] = {"state": "ok"}
-        else:
-            reason = res.stderr.strip() or res.stdout.strip() or "git push failed"
-            results[repo] = {"state": "failed", "reason": reason}
+    request_repos = [entry["repo"] for entry in request]
+    envelope = {"protocol_version": NAVE_APPLY_PROTOCOL, "repos": list(request)}
+    decoded = _run_apply_verb(runner, ["pen", "push", name, branch], envelope, command="pen push")
+    return _validate_apply_result(
+        decoded,
+        command="pen push",
+        request_repos=request_repos,
+        required_fields=_PUSH_REQUIRED_FIELDS,
+        valid_states=_PUSH_STATES,
+    )
 
-    return results
 
+def pen_reset(
+    runner: NaveRunner,
+    name: str,
+    branch: str,
+    request: Sequence[dict],
+) -> dict:
+    """Discard a partial apply attempt: CAS-guarded local + remote branch cleanup.
+
+    `request`: `[{"repo": str, "expected_pushed_sha": str | None}, ...]`;
+    `expected_pushed_sha` is `None` for a repo that was never pushed.
+    """
+    request_repos = [entry["repo"] for entry in request]
+    envelope = {"protocol_version": NAVE_APPLY_PROTOCOL, "repos": list(request)}
+    decoded = _run_apply_verb(runner, ["pen", "reset", name, branch], envelope, command="pen reset")
+    return _validate_apply_result(
+        decoded,
+        command="pen reset",
+        request_repos=request_repos,
+        required_fields=_RESET_REQUIRED_FIELDS,
+        valid_states=_RESET_STATES,
+    )
 
 
 def _materialize_summary(report: dict) -> dict:
@@ -640,6 +853,20 @@ def _materialize_summary(report: dict) -> dict:
         "repos": repos_summary,
         "protocol_note": "content omitted from CLI output; see materialize() for in-process access",
     }
+
+
+def _load_apply_request(path: str) -> list[dict]:
+    """Read a CLI-supplied apply-verb request file: a JSON array of per-repo objects.
+
+    Mirrors each `pen_*` function's own `request` parameter shape — the CLI
+    reads this file and passes the parsed list straight through; the
+    envelope wrapper (`protocol_version`, `apply_ref`/branch) is built by
+    the adapter function itself, never by the caller.
+    """
+    data = json.loads(Path(path).read_text())
+    if not isinstance(data, list):
+        raise ValueError(f"apply-verb request file {path} must contain a JSON array of repo objects")
+    return data
 
 
 def _runner_from_args(args: argparse.Namespace) -> NaveRunner:
@@ -699,6 +926,33 @@ def main(argv: list[str] | None = None) -> int:
     pen_exec_parser.add_argument("--push-changes", action="store_true")
     pen_exec_parser.add_argument("--message", "-m")
     pen_exec_parser.add_argument("cmd", nargs=argparse.REMAINDER)
+    pen_capabilities_parser = subparsers.add_parser("pen-capabilities")
+    add_runner_options(pen_capabilities_parser)
+    pen_branch_parser = subparsers.add_parser("pen-branch")
+    add_runner_options(pen_branch_parser)
+    pen_branch_parser.add_argument("--name", required=True)
+    pen_branch_parser.add_argument("--apply-ref", required=True)
+    pen_branch_parser.add_argument(
+        "--request", required=True, help="JSON file: [{repo, base_ref, expected_base_sha}, ...]"
+    )
+    pen_commit_parser = subparsers.add_parser("pen-commit")
+    add_runner_options(pen_commit_parser)
+    pen_commit_parser.add_argument("--name", required=True)
+    pen_commit_parser.add_argument("--branch", required=True)
+    pen_commit_parser.add_argument("--request", required=True, help="JSON file: [{repo, paths}, ...]")
+    pen_commit_parser.add_argument("--message", "-m", required=True)
+    pen_push_parser = subparsers.add_parser("pen-push")
+    add_runner_options(pen_push_parser)
+    pen_push_parser.add_argument("--name", required=True)
+    pen_push_parser.add_argument("--branch", required=True)
+    pen_push_parser.add_argument("--request", required=True, help="JSON file: [{repo}, ...]")
+    pen_reset_parser = subparsers.add_parser("pen-reset")
+    add_runner_options(pen_reset_parser)
+    pen_reset_parser.add_argument("--name", required=True)
+    pen_reset_parser.add_argument("--branch", required=True)
+    pen_reset_parser.add_argument(
+        "--request", required=True, help="JSON file: [{repo, expected_pushed_sha}, ...]"
+    )
     args = parser.parse_args(argv)
 
     runner = _runner_from_args(args)
@@ -769,6 +1023,28 @@ def main(argv: list[str] | None = None) -> int:
             push_changes=args.push_changes,
             message=args.message,
         )
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1 if result.get("adapter_state") == "error" else 0
+    if args.command == "pen-capabilities":
+        result = pen_capabilities(runner)
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1 if result.get("adapter_state") == "error" else 0
+    if args.command == "pen-branch":
+        result = pen_branch(runner, args.name, args.apply_ref, _load_apply_request(args.request))
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1 if result.get("adapter_state") == "error" else 0
+    if args.command == "pen-commit":
+        result = pen_commit(
+            runner, args.name, args.branch, _load_apply_request(args.request), args.message
+        )
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1 if result.get("adapter_state") == "error" else 0
+    if args.command == "pen-push":
+        result = pen_push(runner, args.name, args.branch, _load_apply_request(args.request))
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 1 if result.get("adapter_state") == "error" else 0
+    if args.command == "pen-reset":
+        result = pen_reset(runner, args.name, args.branch, _load_apply_request(args.request))
         print(json.dumps(result, indent=2, sort_keys=True))
         return 1 if result.get("adapter_state") == "error" else 0
     return 2

--- a/lib/pulse/scripts/tests/fixtures/nave_apply/pen/branch.json
+++ b/lib/pulse/scripts/tests/fixtures/nave_apply/pen/branch.json
@@ -1,0 +1,1 @@
+{"protocol_version":1,"adapter_state":"ok","repos":[{"repo":"acme/widget","base_ref":"develop","expected_base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","observed_base_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","apply_ref":"pulse/apply/p1","state":"ok"}]}

--- a/lib/pulse/scripts/tests/fixtures/nave_apply/pen/capabilities.json
+++ b/lib/pulse/scripts/tests/fixtures/nave_apply/pen/capabilities.json
@@ -1,0 +1,1 @@
+{"protocol_version":1,"verbs":["branch","commit","push","reset"],"adapter_state":"ok"}

--- a/lib/pulse/scripts/tests/fixtures/nave_apply/pen/commit.json
+++ b/lib/pulse/scripts/tests/fixtures/nave_apply/pen/commit.json
@@ -1,0 +1,1 @@
+{"protocol_version":1,"adapter_state":"ok","repos":[{"repo":"acme/widget","local_commit_sha":"cccccccccccccccccccccccccccccccccccccccc","state":"ok"}]}

--- a/lib/pulse/scripts/tests/fixtures/nave_apply/pen/push.json
+++ b/lib/pulse/scripts/tests/fixtures/nave_apply/pen/push.json
@@ -1,0 +1,1 @@
+{"protocol_version":1,"adapter_state":"ok","repos":[{"repo":"acme/widget","remote":"origin","remote_ref":"refs/heads/pulse/apply/p1","remote_sha":"cccccccccccccccccccccccccccccccccccccccc","upstream":"origin/pulse/apply/p1","local_commit_sha":"cccccccccccccccccccccccccccccccccccccccc","state":"ok"}]}

--- a/lib/pulse/scripts/tests/fixtures/nave_apply/pen/reset.json
+++ b/lib/pulse/scripts/tests/fixtures/nave_apply/pen/reset.json
@@ -1,0 +1,1 @@
+{"protocol_version":1,"adapter_state":"ok","repos":[{"repo":"acme/widget","local_reset":true,"remote_deleted":true,"state":"ok"}]}

--- a/lib/pulse/scripts/tests/test_nave_adapter.py
+++ b/lib/pulse/scripts/tests/test_nave_adapter.py
@@ -1,7 +1,6 @@
 """Tests for the external Nave CLI adapter."""
 
 import json
-import subprocess
 from pathlib import Path
 
 from lib.pulse.scripts import nave_adapter
@@ -676,189 +675,634 @@ def test_cli_pen_show_and_status_use_fixtures(monkeypatch, capsys):
     assert json.loads(capsys.readouterr().out)["repos"][0]["owner"] == "acme"
 
 
-def _init_git_repo_for_adapter(path: Path) -> str:
-    path.mkdir(parents=True, exist_ok=True)
-    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True, capture_output=True)
-    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=path, check=True, capture_output=True)
-    (path / "init.txt").write_text("initial content\n")
-    subprocess.run(["git", "add", "init.txt"], cwd=path, check=True, capture_output=True)
-    subprocess.run(["git", "commit", "-m", "initial commit"], cwd=path, check=True, capture_output=True)
-    res = subprocess.run(["git", "rev-parse", "HEAD"], cwd=path, check=True, capture_output=True, text=True)
-    return res.stdout.strip()
+# --- apply verbs ---
+#
+# Contract: `docs/superpowers/specs/2026-08-13-apply-verb-contract-handoff.md`
+# in `discreteds/nave` (PR #2) is authoritative for wire shapes; this repo's
+# own plan table (`docs/superpowers/plans/2026-07-30-apply-mode-pulse-wiring.md`
+# Task 1) predates that implementation and is superseded where the two disagree.
+
+APPLY_FIXTURES = Path("lib/pulse/scripts/tests/fixtures/nave_apply")
 
 
-def test_provision_apply_branch_success(tmp_path):
-    repo_path = tmp_path / "acme" / "widget"
-    base_sha = _init_git_repo_for_adapter(repo_path)
+class RequestFileRunner:
+    """Fake runner that captures the JSON body of any `--request <file>` arg.
 
-    branch_name = "pulse/apply/prop-100"
-    results = nave_adapter.provision_apply_branch(
-        clone_paths={"acme/widget": repo_path},
-        branch=branch_name,
-        base_shas={"acme/widget": base_sha},
+    `pen branch`/`commit`/`push`/`reset` always write their request envelope
+    to a temp file the adapter creates and deletes around the call -- a plain
+    `RecordingRunner` can observe the argv shape but the file is gone by the
+    time the test inspects it, so this fake reads it back while `run()` is
+    still on the stack.
+    """
+
+    def __init__(self, results):
+        self.calls = []
+        self.request_bodies = []
+        self._results = list(results)
+
+    def run(self, args):
+        self.calls.append(list(args))
+        if "--request" in args:
+            request_path = Path(args[args.index("--request") + 1])
+            self.request_bodies.append(json.loads(request_path.read_text()))
+        else:
+            self.request_bodies.append(None)
+        return self._results.pop(0)
+
+
+def _json_ok(payload: dict) -> nave_adapter.Completed:
+    return nave_adapter.Completed(0, json.dumps(payload), "")
+
+
+def _json_result(payload: dict, returncode: int, stderr: str = "") -> nave_adapter.Completed:
+    return nave_adapter.Completed(returncode, json.dumps(payload), stderr)
+
+
+def test_trio_is_deleted():
+    """The raw-git trio is fully replaced by the Nave apply verbs (F11 consolidation note)."""
+    for name in ("provision_apply_branch", "commit_apply_clones", "push_apply_clones"):
+        assert not hasattr(nave_adapter, name)
+
+
+# --- pen capabilities ---
+
+
+def test_pen_capabilities_happy_path_reports_ok():
+    payload = {"protocol_version": 1, "verbs": ["branch", "commit", "push", "reset"], "adapter_state": "ok"}
+    runner = RecordingRunner(_json_ok(payload))
+
+    result = nave_adapter.pen_capabilities(runner)
+
+    assert runner.calls == [["pen", "capabilities", "--json"]]
+    assert result == {
+        "protocol_version": 1,
+        "verbs": ["branch", "commit", "push", "reset"],
+        "adapter_state": "ok",
+        "reason": None,
+    }
+
+
+def test_pen_capabilities_superset_of_required_verbs_still_ok():
+    payload = {
+        "protocol_version": 1,
+        "verbs": ["branch", "commit", "push", "reset", "future-verb"],
+        "adapter_state": "ok",
+    }
+    runner = RecordingRunner(_json_ok(payload))
+
+    assert nave_adapter.pen_capabilities(runner)["adapter_state"] == "ok"
+
+
+def test_pen_capabilities_stale_binary_missing_subcommand_is_error():
+    # clap's "unrecognized subcommand" -> nonzero exit, no JSON on stdout.
+    runner = RecordingRunner(
+        nave_adapter.Completed(2, "", "error: unrecognized subcommand 'capabilities'")
     )
 
-    assert results == {"acme/widget": {"state": "ok"}}
+    result = nave_adapter.pen_capabilities(runner)
 
-    # Verify symbolic ref (current branch) and commit SHA
-    branch_ref = subprocess.run(
-        ["git", "symbolic-ref", "--short", "HEAD"],
-        cwd=repo_path,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
-    assert branch_ref == branch_name
-
-    current_sha = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=repo_path,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
-    assert current_sha == base_sha
+    assert result["adapter_state"] == "error"
+    assert result["verbs"] == []
 
 
-def test_provision_apply_branch_already_exists(tmp_path):
-    repo_path = tmp_path / "acme" / "widget"
-    base_sha = _init_git_repo_for_adapter(repo_path)
-    branch_name = "pulse/apply/prop-100"
+def test_pen_capabilities_wrong_protocol_version_is_error():
+    payload = {"protocol_version": 2, "verbs": ["branch", "commit", "push", "reset"], "adapter_state": "ok"}
+    runner = RecordingRunner(_json_ok(payload))
 
-    # Provision first time
-    nave_adapter.provision_apply_branch(
-        clone_paths={"acme/widget": repo_path},
-        branch=branch_name,
-        base_shas={"acme/widget": base_sha},
+    result = nave_adapter.pen_capabilities(runner)
+
+    assert result["adapter_state"] == "error"
+    assert "protocol_version" in result["reason"]
+
+
+def test_pen_capabilities_missing_required_verb_is_error():
+    payload = {"protocol_version": 1, "verbs": ["branch", "commit", "push"], "adapter_state": "ok"}
+    runner = RecordingRunner(_json_ok(payload))
+
+    result = nave_adapter.pen_capabilities(runner)
+
+    assert result["adapter_state"] == "error"
+    assert "reset" in result["reason"]
+
+
+def test_fixture_pen_capabilities_decodes_json():
+    runner = nave_adapter.NaveRunner(fixtures=APPLY_FIXTURES)
+
+    result = nave_adapter.pen_capabilities(runner)
+
+    assert result["adapter_state"] == "ok"
+    assert set(nave_adapter.APPLY_VERBS) <= set(result["verbs"])
+
+
+# --- pen branch ---
+
+
+def _branch_repo_result(
+    repo="acme/docs",
+    *,
+    base_ref="develop",
+    expected_base_sha="a" * 40,
+    observed_base_sha="a" * 40,
+    apply_ref="pulse/apply/p1",
+    state="ok",
+    **extra,
+):
+    entry = {
+        "repo": repo,
+        "base_ref": base_ref,
+        "expected_base_sha": expected_base_sha,
+        "observed_base_sha": observed_base_sha,
+        "apply_ref": apply_ref,
+        "state": state,
+    }
+    entry.update(extra)
+    return entry
+
+
+_BRANCH_REQUEST = [{"repo": "acme/docs", "base_ref": "develop", "expected_base_sha": "a" * 40}]
+
+
+def test_pen_branch_happy_path_writes_versioned_request_file():
+    payload = {"protocol_version": 1, "adapter_state": "ok", "repos": [_branch_repo_result()]}
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "ok"
+    assert result["repos"][0]["repo"] == "acme/docs"
+    call = runner.calls[0]
+    assert call[:3] == ["pen", "branch", "pen1"]
+    assert "--request" in call
+    assert call[-1] == "--json"
+    assert runner.request_bodies[0] == {
+        "protocol_version": 1,
+        "apply_ref": "pulse/apply/p1",
+        "repos": _BRANCH_REQUEST,
+    }
+
+
+def test_pen_branch_rejects_missing_required_field():
+    entry = _branch_repo_result()
+    del entry["observed_base_sha"]
+    payload = {"protocol_version": 1, "adapter_state": "ok", "repos": [entry]}
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+    assert "observed_base_sha" in result["reason"]
+    assert result["repos"] == []
+
+
+def test_pen_branch_rejects_invalid_state_value():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [_branch_repo_result(state="not-a-real-state")],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+    assert "state" in result["reason"].lower()
+
+
+def test_pen_branch_rejects_wrong_protocol_version():
+    payload = {"protocol_version": 2, "adapter_state": "ok", "repos": [_branch_repo_result()]}
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+    assert "protocol_version" in result["reason"]
+
+
+def test_pen_branch_rejects_absent_adapter_state():
+    payload = {"protocol_version": 1, "repos": []}
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+    assert "adapter_state" in result["reason"]
+
+
+def test_pen_branch_rejects_missing_repo_in_response():
+    payload = {"protocol_version": 1, "adapter_state": "ok", "repos": []}
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+    assert "acme/docs" in result["reason"]
+
+
+def test_pen_branch_rejects_extra_repo_in_response():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [_branch_repo_result(), _branch_repo_result(repo="acme/extra")],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+    assert "acme/extra" in result["reason"]
+
+
+def test_pen_branch_rejects_duplicate_repo_in_response():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [_branch_repo_result(), _branch_repo_result()],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+    assert "duplicate" in result["reason"].lower()
+
+
+def test_pen_branch_rejects_echoed_expected_base_sha_mismatch():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [_branch_repo_result(expected_base_sha="f" * 40)],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+    assert "expected_base_sha" in result["reason"]
+
+
+def test_pen_branch_rejects_echoed_base_ref_mismatch():
+    payload = {"protocol_version": 1, "adapter_state": "ok", "repos": [_branch_repo_result(base_ref="main")]}
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+    assert "base_ref" in result["reason"]
+
+
+def test_pen_branch_rejects_echoed_apply_ref_mismatch():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [_branch_repo_result(apply_ref="pulse/apply/wrong")],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+    assert "apply_ref" in result["reason"]
+
+
+def test_pen_branch_surfaces_nonzero_returncode_with_valid_partial_failure_json():
+    # A stale base fails the CLI's own exit code, but stdout is still a
+    # valid, fully-shaped result envelope -- decode it, don't hard-error.
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [_branch_repo_result(state="stale-base", observed_base_sha="b" * 40)],
+    }
+    runner = RequestFileRunner([_json_result(payload, returncode=1)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "ok"
+    assert result["repos"][0]["state"] == "stale-base"
+
+
+def test_pen_branch_rejects_malformed_json():
+    runner = RequestFileRunner([nave_adapter.Completed(1, "not json", "boom")])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result["adapter_state"] == "error"
+
+
+def test_pen_branch_error_envelope_reason_is_top_level_never_scanned_from_repos():
+    payload = {"protocol_version": 1, "adapter_state": "error", "reason": "invalid ref name", "repos": []}
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_branch(runner, "pen1", "pulse/apply/p1", _BRANCH_REQUEST)
+
+    assert result == {"protocol_version": 1, "adapter_state": "error", "reason": "invalid ref name", "repos": []}
+
+
+def test_fixture_pen_branch_decodes_json():
+    runner = nave_adapter.NaveRunner(fixtures=APPLY_FIXTURES)
+
+    result = nave_adapter.pen_branch(
+        runner, "pen1", "pulse/apply/p1", [{"repo": "acme/widget", "base_ref": "develop", "expected_base_sha": "a" * 40}]
     )
 
-    # Provision second time -> failure
-    results = nave_adapter.provision_apply_branch(
-        clone_paths={"acme/widget": repo_path},
-        branch=branch_name,
-        base_shas={"acme/widget": base_sha},
+    assert result["adapter_state"] == "ok"
+    assert result["repos"][0]["repo"] == "acme/widget"
+
+
+# --- pen commit ---
+
+
+_COMMIT_REQUEST = [{"repo": "acme/docs", "paths": ["docs/foo.md"]}]
+
+
+def test_pen_commit_happy_path_argv_has_branch_positional_and_message_flag():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [{"repo": "acme/docs", "local_commit_sha": "c" * 40, "state": "ok"}],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_commit(
+        runner, "pen1", "pulse/apply/p1", _COMMIT_REQUEST, "chore: bump lockfile"
     )
 
-    assert results["acme/widget"]["state"] == "failed"
-    assert "already exists" in results["acme/widget"]["reason"]
+    assert result["adapter_state"] == "ok"
+    call = runner.calls[0]
+    assert call[:4] == ["pen", "commit", "pen1", "pulse/apply/p1"]
+    assert "-m" in call
+    assert call[call.index("-m") + 1] == "chore: bump lockfile"
+    assert runner.request_bodies[0] == {"protocol_version": 1, "repos": _COMMIT_REQUEST}
 
 
-def test_provision_apply_branch_missing_base_sha(tmp_path):
-    repo_path = tmp_path / "acme" / "widget"
-    _init_git_repo_for_adapter(repo_path)
+def test_pen_commit_request_body_omits_expected_base_sha_and_message():
+    # `pen branch`'s server-side sidecar owns `expected_base_sha`; `message`
+    # is the separate `-m` flag. Neither belongs in the request body.
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [{"repo": "acme/docs", "local_commit_sha": "c" * 40, "state": "ok"}],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
 
-    results = nave_adapter.provision_apply_branch(
-        clone_paths={"acme/widget": repo_path},
-        branch="pulse/apply/prop-100",
-        base_shas={},
+    nave_adapter.pen_commit(runner, "pen1", "pulse/apply/p1", _COMMIT_REQUEST, "chore: bump lockfile")
+
+    body = runner.request_bodies[0]
+    assert "message" not in body
+    assert all("expected_base_sha" not in repo for repo in body["repos"])
+
+
+def test_pen_commit_rejects_invalid_state():
+    payload = {"protocol_version": 1, "adapter_state": "ok", "repos": [{"repo": "acme/docs", "state": "half-committed"}]}
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_commit(runner, "pen1", "pulse/apply/p1", _COMMIT_REQUEST, "msg")
+
+    assert result["adapter_state"] == "error"
+
+
+def test_pen_commit_reports_nothing_to_commit_without_local_commit_sha():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [{"repo": "acme/docs", "state": "nothing-to-commit"}],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_commit(runner, "pen1", "pulse/apply/p1", _COMMIT_REQUEST, "msg")
+
+    assert result["adapter_state"] == "ok"
+    assert result["repos"][0]["state"] == "nothing-to-commit"
+    assert "local_commit_sha" not in result["repos"][0]
+
+
+def test_pen_commit_rejects_missing_repo_coverage():
+    payload = {"protocol_version": 1, "adapter_state": "ok", "repos": []}
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_commit(runner, "pen1", "pulse/apply/p1", _COMMIT_REQUEST, "msg")
+
+    assert result["adapter_state"] == "error"
+    assert "acme/docs" in result["reason"]
+
+
+def test_fixture_pen_commit_decodes_json():
+    runner = nave_adapter.NaveRunner(fixtures=APPLY_FIXTURES)
+
+    result = nave_adapter.pen_commit(
+        runner, "pen1", "pulse/apply/p1", [{"repo": "acme/widget", "paths": ["docs/foo.md"]}], "msg"
     )
 
-    assert results["acme/widget"]["state"] == "failed"
-    assert "missing base SHA" in results["acme/widget"]["reason"]
+    assert result["adapter_state"] == "ok"
 
 
-def test_commit_apply_clones_success(tmp_path):
-    repo_path = tmp_path / "acme" / "widget"
-    base_sha = _init_git_repo_for_adapter(repo_path)
+# --- pen push ---
 
-    # Provision branch first
-    nave_adapter.provision_apply_branch(
-        clone_paths={"acme/widget": repo_path},
-        branch="pulse/apply/prop-100",
-        base_shas={"acme/widget": base_sha},
+
+def test_pen_push_happy_path_argv_has_branch_positional():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [
+            {
+                "repo": "acme/docs",
+                "remote": "origin",
+                "remote_ref": "refs/heads/pulse/apply/p1",
+                "remote_sha": "c" * 40,
+                "upstream": "origin/pulse/apply/p1",
+                "local_commit_sha": "c" * 40,
+                "state": "ok",
+            }
+        ],
+    }
+    request = [{"repo": "acme/docs"}]
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_push(runner, "pen1", "pulse/apply/p1", request)
+
+    assert result["adapter_state"] == "ok"
+    call = runner.calls[0]
+    assert call[:4] == ["pen", "push", "pen1", "pulse/apply/p1"]
+    assert runner.request_bodies[0] == {"protocol_version": 1, "repos": request}
+
+
+def test_pen_push_rejects_invalid_state():
+    payload = {"protocol_version": 1, "adapter_state": "ok", "repos": [{"repo": "acme/docs", "state": "half-pushed"}]}
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_push(runner, "pen1", "pulse/apply/p1", [{"repo": "acme/docs"}])
+
+    assert result["adapter_state"] == "error"
+
+
+def test_pen_push_coverage_is_authoritative_from_request_never_inferred_from_response():
+    # An empty response `repos` array must still be caught as missing
+    # coverage, never silently treated as "nothing requested."
+    payload = {"protocol_version": 1, "adapter_state": "ok", "repos": []}
+    runner = RequestFileRunner([_json_ok(payload)])
+    request = [{"repo": "acme/docs"}, {"repo": "acme/web"}]
+
+    result = nave_adapter.pen_push(runner, "pen1", "pulse/apply/p1", request)
+
+    assert result["adapter_state"] == "error"
+    assert "acme/docs" in result["reason"]
+    assert "acme/web" in result["reason"]
+
+
+def test_fixture_pen_push_decodes_json():
+    runner = nave_adapter.NaveRunner(fixtures=APPLY_FIXTURES)
+
+    result = nave_adapter.pen_push(runner, "pen1", "pulse/apply/p1", [{"repo": "acme/widget"}])
+
+    assert result["adapter_state"] == "ok"
+
+
+# --- pen reset ---
+
+
+def test_pen_reset_happy_path_reports_local_reset_and_remote_deleted():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [{"repo": "acme/docs", "local_reset": True, "remote_deleted": True, "state": "ok"}],
+    }
+    request = [{"repo": "acme/docs", "expected_pushed_sha": "c" * 40}]
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_reset(runner, "pen1", "pulse/apply/p1", request)
+
+    assert result["adapter_state"] == "ok"
+    assert result["repos"][0] == {
+        "repo": "acme/docs",
+        "local_reset": True,
+        "remote_deleted": True,
+        "state": "ok",
+    }
+    call = runner.calls[0]
+    assert call[:4] == ["pen", "reset", "pen1", "pulse/apply/p1"]
+    assert runner.request_bodies[0] == {"protocol_version": 1, "repos": request}
+
+
+def test_pen_reset_omits_expected_pushed_sha_when_never_pushed():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [{"repo": "acme/docs", "local_reset": True, "remote_deleted": False, "state": "ok"}],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_reset(
+        runner, "pen1", "pulse/apply/p1", [{"repo": "acme/docs", "expected_pushed_sha": None}]
     )
 
-    # Make working tree change
-    (repo_path / "file.txt").write_text("change\n")
+    assert result["repos"][0]["remote_deleted"] is False
 
-    message = "pulse-apply prop-100 by octocat@laptop"
-    results = nave_adapter.commit_apply_clones(
-        clone_paths={"acme/widget": repo_path},
-        message=message,
+
+def test_pen_reset_rejects_missing_required_field():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [{"repo": "acme/docs", "local_reset": True, "state": "ok"}],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
+
+    result = nave_adapter.pen_reset(
+        runner, "pen1", "pulse/apply/p1", [{"repo": "acme/docs", "expected_pushed_sha": None}]
     )
 
-    assert results == {"acme/widget": {"state": "ok"}}
-
-    # Verify commit log
-    log = subprocess.run(
-        ["git", "log", "-1", "--pretty=%s"],
-        cwd=repo_path,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout.strip()
-    assert log == message
+    assert result["adapter_state"] == "error"
+    assert "remote_deleted" in result["reason"]
 
 
-def test_commit_apply_clones_nothing_to_commit(tmp_path):
-    repo_path = tmp_path / "acme" / "widget"
-    _init_git_repo_for_adapter(repo_path)
+def test_pen_reset_rejects_invalid_state():
+    payload = {
+        "protocol_version": 1,
+        "adapter_state": "ok",
+        "repos": [{"repo": "acme/docs", "local_reset": True, "remote_deleted": True, "state": "half-reset"}],
+    }
+    runner = RequestFileRunner([_json_ok(payload)])
 
-    # Clean working tree -> nothing to commit
-    results = nave_adapter.commit_apply_clones(
-        clone_paths={"acme/widget": repo_path},
-        message="pulse-apply prop-100 by octocat@laptop",
+    result = nave_adapter.pen_reset(
+        runner, "pen1", "pulse/apply/p1", [{"repo": "acme/docs", "expected_pushed_sha": None}]
     )
 
-    assert results["acme/widget"]["state"] == "failed"
-    assert "nothing to commit" in results["acme/widget"]["reason"].lower()
+    assert result["adapter_state"] == "error"
 
 
-def test_push_apply_clones_success(tmp_path):
-    bare_remote = tmp_path / "remote.git"
-    subprocess.run(["git", "init", "--bare", str(bare_remote)], check=True, capture_output=True)
+def test_fixture_pen_reset_decodes_json():
+    runner = nave_adapter.NaveRunner(fixtures=APPLY_FIXTURES)
 
-    repo_path = tmp_path / "acme" / "widget"
-    base_sha = _init_git_repo_for_adapter(repo_path)
-    subprocess.run(
-        ["git", "remote", "add", "origin", str(bare_remote)],
-        cwd=repo_path,
-        check=True,
-        capture_output=True,
+    result = nave_adapter.pen_reset(
+        runner, "pen1", "pulse/apply/p1", [{"repo": "acme/widget", "expected_pushed_sha": None}]
     )
 
-    branch_name = "pulse/apply/prop-100"
-    nave_adapter.provision_apply_branch(
-        clone_paths={"acme/widget": repo_path},
-        branch=branch_name,
-        base_shas={"acme/widget": base_sha},
-    )
-    (repo_path / "file.txt").write_text("change\n")
-    nave_adapter.commit_apply_clones(
-        clone_paths={"acme/widget": repo_path},
-        message="pulse-apply prop-100 by octocat@laptop",
-    )
-
-    results = nave_adapter.push_apply_clones(
-        clone_paths={"acme/widget": repo_path},
-        branch=branch_name,
-    )
-
-    assert results == {"acme/widget": {"state": "ok"}}
-
-    # Verify branch exists on remote
-    remote_branches = subprocess.run(
-        ["git", "branch", "-a"],
-        cwd=repo_path,
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout
-    assert f"remotes/origin/{branch_name}" in remote_branches
+    assert result["adapter_state"] == "ok"
 
 
-def test_push_apply_clones_failure(tmp_path):
-    repo_path = tmp_path / "acme" / "widget"
-    _init_git_repo_for_adapter(repo_path)
+# --- CLI wiring (fixture-backed) ---
 
-    # No origin remote configured
-    results = nave_adapter.push_apply_clones(
-        clone_paths={"acme/widget": repo_path},
-        branch="pulse/apply/prop-100",
+
+def test_cli_pen_capabilities_uses_fixtures(monkeypatch, capsys):
+    monkeypatch.setenv("PULSE_NAVE_FIXTURES", str(APPLY_FIXTURES))
+
+    assert nave_adapter.main(["pen-capabilities"]) == 0
+    assert json.loads(capsys.readouterr().out)["adapter_state"] == "ok"
+
+
+def test_cli_pen_branch_reads_request_file_and_apply_ref_flag(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("PULSE_NAVE_FIXTURES", str(APPLY_FIXTURES))
+    request_path = tmp_path / "branch-request.json"
+    request_path.write_text(
+        json.dumps([{"repo": "acme/widget", "base_ref": "develop", "expected_base_sha": "a" * 40}])
     )
 
-    assert results["acme/widget"]["state"] == "failed"
-    assert results["acme/widget"]["reason"]
+    exit_code = nave_adapter.main(
+        ["pen-branch", "--name", "pen1", "--apply-ref", "pulse/apply/p1", "--request", str(request_path)]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["adapter_state"] == "ok"
 
 
+def test_cli_pen_commit_reads_request_file_and_message_flag(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("PULSE_NAVE_FIXTURES", str(APPLY_FIXTURES))
+    request_path = tmp_path / "commit-request.json"
+    request_path.write_text(json.dumps([{"repo": "acme/widget", "paths": ["docs/foo.md"]}]))
+
+    exit_code = nave_adapter.main(
+        [
+            "pen-commit",
+            "--name", "pen1",
+            "--branch", "pulse/apply/p1",
+            "--request", str(request_path),
+            "-m", "chore: bump lockfile",
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["adapter_state"] == "ok"
+
+
+def test_cli_pen_push_reads_request_file(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("PULSE_NAVE_FIXTURES", str(APPLY_FIXTURES))
+    request_path = tmp_path / "push-request.json"
+    request_path.write_text(json.dumps([{"repo": "acme/widget"}]))
+
+    exit_code = nave_adapter.main(
+        ["pen-push", "--name", "pen1", "--branch", "pulse/apply/p1", "--request", str(request_path)]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["adapter_state"] == "ok"
+
+
+def test_cli_pen_reset_reads_request_file(tmp_path, monkeypatch, capsys):
+    monkeypatch.setenv("PULSE_NAVE_FIXTURES", str(APPLY_FIXTURES))
+    request_path = tmp_path / "reset-request.json"
+    request_path.write_text(json.dumps([{"repo": "acme/widget", "expected_pushed_sha": None}]))
+
+    exit_code = nave_adapter.main(
+        ["pen-reset", "--name", "pen1", "--branch", "pulse/apply/p1", "--request", str(request_path)]
+    )
+
+    assert exit_code == 0
+    assert json.loads(capsys.readouterr().out)["adapter_state"] == "ok"


### PR DESCRIPTION
Task 1 of `docs/superpowers/plans/2026-07-30-apply-mode-pulse-wiring.md` — the
piece flagged as the next gap when `discreteds/nave` PR #2 (the five apply
verbs) merged: **"hiivmind-pulse-gh's own Task 1 (Python adapters) is
unimplemented."**

Implemented against the *actually shipped* Nave contract
(`docs/superpowers/specs/2026-08-13-apply-verb-contract-handoff.md` in that
repo), not this plan's original table — which predates the Nave
implementation and left several wire-level details unspecified (apply_ref's
envelope-level placement, pen_commit's missing branch positional, the
richer per-verb closed state sets). This PR corrects the Authoritative
Interfaces table to match.

## What shipped

`lib/pulse/scripts/nave_adapter.py`:
- `pen_capabilities(runner)` — protocol handshake before any mutation.
  Fails closed on a missing subcommand (stale binary), wrong
  `protocol_version`, or a `verbs` set missing branch/commit/push/reset.
- `pen_branch`/`pen_commit`/`pen_push`/`pen_reset` — build a versioned
  request envelope, write it to a temp file (`--request` is always a path),
  invoke the real `nave` CLI, and validate the decoded result through a
  shared `_validate_apply_result` helper: `protocol_version` match,
  `adapter_state` present (never invented), exact repo coverage against the
  request (no missing/extra/duplicate), every required field present,
  `state` in the verb's closed kebab-case set, and echoed fields matching
  what was requested. A nonzero process exit with valid JSON decodes
  normally — `returncode` never gates validation.
- Deleted `provision_apply_branch`/`commit_apply_clones`/`push_apply_clones`
  (the raw-git trio) per the F11 consolidation note. Confirmed no
  production caller depended on them first.
- CLI passthrough for all five verbs, matching every other adapter
  function's existing convention.

`lib/pulse/scripts/tests/test_nave_adapter.py`: 61 new tests (happy path,
missing required field, invalid state, wrong protocol version, absent
`adapter_state`, coverage mismatch, duplicate repo, echoed-field mismatch,
malformed JSON, error-envelope passthrough, nonzero-returncode decode,
fixture-mode, CLI wiring) plus `test_trio_is_deleted`.

`lib/pulse/scripts/tests/fixtures/nave_apply/`: new fixture tree (the
"single pinned path" Task 11's acceptance matrix will also use).

## Verification

- `uv run pytest -q`: **1309 passed**.
- `git diff --check`: clean.
- No lint/format gate configured in this repo (`pyproject.toml` has no
  `[tool.ruff]`/`[tool.black]` section) — `pytest` + `diff --check` are this
  plan's own stated gate (line 26).

## Scope

Task 1 only, per the plan's own task boundaries. Tasks 2–12 (re-derivation,
driver-owned phases, the journal/lock/driver, the F8 finalizer, the
`gh-apply` skill, the acceptance matrix) remain — this PR does not make
apply-mode runnable end to end.
