### PR TITLE
feat(apply): neutral source kind — workspace enrollment (F11 §5F)

### DIFF
--- a/docs/superpowers/plans/2026-08-14-apply-mode-workspace-enrollment.md
+++ b/docs/superpowers/plans/2026-08-14-apply-mode-workspace-enrollment.md
@@ -1,0 +1,851 @@
+# Apply-Mode Workspace Enrollment — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the 4th `"neutral"` source kind in the apply re-derivation provider, wire the driver contract for it, and enroll the workspace with a `format-python` binding + authorization so `gh-apply` can land `ruff format .` on `hiivmind/agent-kernel`.
+
+**Architecture:** Two-repo change. pulse-gh gains a neutral provider (`apply_rederive` collect/rederive + `apply_reconcile.resolve_intended_base` + `apply_driver` contract); the workspace repo gains two config files (`apply-neutral.yaml` binding, `apply-authorization.yaml` policy). The provider is a degenerate case of the existing collect→rederive split: collect fetches the live `base_ref` HEAD via `gh_api`, rederive builds an allow-listed single-repo `Proposal` via `mutation_plan.build_proposal`. Pure-neutral → terminal at merge (no finalizer).
+
+**Tech Stack:** Python ≥3.10 (PEP 723 scripts + pyproject dev env), pytest, `gh` CLI, `uv`.
+
+## Global Constraints
+
+- **Single-mutator:** no clone-write git in Pulse — every branch/commit/push/reset is a Nave verb. Pulse orchestrates + reads.
+- **v1 single-repo-per-run:** the driver blocks `selection > 1` with "multi-repo apply is v2".
+- **Deterministic transformations only** (v1 crash-resume reset+re-exec contract).
+- **Neutral transformations are exactly** `format-python`, `refresh-node-lockfile`, `regenerate-docs-index` (the `NEUTRAL_TRANSFORMATIONS` allowlist). `regenerate-from-template` and the two F9 overlays are NOT neutral.
+- **`authorize()` always runs its full identity + scope check** — no self-elevating binding.
+- **pulse-gh flow:** `feature/* → develop → release/* → main`. Code lands on a feature branch off `develop`; PR targets `develop`.
+- **workspace flow:** `feature/* → main`.
+- **Tests:** `uv run pytest` from the repo root; `testpaths = ["lib/pulse/scripts/tests"]`, `pythonpath = ["."]`.
+- **No new dependencies** in pulse-gh — the neutral provider uses the existing `io_seams.gh_api` seam (`Callable[[str], Any]`).
+
+---
+
+### Task 1: Neutral provider interfaces — constants, dataclass, helpers
+
+**Files:**
+- Modify: `lib/pulse/scripts/apply_rederive.py` (constants ~line 44; dataclass after `MarketplaceProviderInputs` ~line 120; helpers after `RederivedProposal` ~line 141)
+- Test: `lib/pulse/scripts/tests/test_apply_rederive.py` (append a "neutral fixtures" section + helper tests)
+
+**Interfaces:**
+- Produces (used by Tasks 2–3):
+  - `SOURCE_KINDS = ("plan-sync", "generated-artifact", "marketplace-sync", "neutral")`
+  - `NEUTRAL_TRANSFORMATIONS = ("format-python", "refresh-node-lockfile", "regenerate-docs-index")`
+  - `@dataclass(frozen=True) class NeutralProviderInputs` with fields `binding: Mapping[str, Any]`, `head_sha: str | None`, `actor: Mapping[str, Any] | mutation_plan.Actor`, `registry: mutation_plan.TransformationRegistry | None = None`
+  - `ProviderInputs = PlanSyncProviderInputs | GeneratedProviderInputs | MarketplaceProviderInputs | NeutralProviderInputs`
+  - `def _validate_neutral_binding(binding: Mapping[str, Any]) -> tuple[str, str]` — returns `(owner, name)`, raises `RederiveError` on missing/slashless `repo` or missing `transformation`
+  - `def neutral_proposal_id(binding: Mapping[str, Any]) -> str` — `f"apply-{transformation}-{owner}-{name}"`
+  - `def neutral_summary(binding: Mapping[str, Any]) -> dict[str, str]` — `{binding, transformation, proposal_id}`
+
+- [ ] **Step 1: Write the failing tests** — append to `test_apply_rederive.py`:
+
+```python
+# --- neutral fixtures ---------------------------------------------------------
+
+NEUTRAL_REPO = "hiivmind/agent-kernel"
+NEUTRAL_HEAD = "d" * 40
+
+
+def neutral_binding(**overrides):
+    value = {
+        "repo": NEUTRAL_REPO,
+        "transformation": "format-python",
+        "base_ref": "main",
+        "bound_paths": ["src/**", "tests/**", "examples/**"],
+    }
+    value.update(overrides)
+    return value
+
+
+def test_neutral_proposal_id_is_deterministic():
+    assert apply_rederive.neutral_proposal_id(neutral_binding()) == (
+        "apply-format-python-hiivmind-agent-kernel"
+    )
+
+
+def test_neutral_proposal_id_rejects_missing_repo():
+    with pytest.raises(apply_rederive.RederiveError, match="repo"):
+        apply_rederive.neutral_proposal_id({"transformation": "format-python"})
+
+
+def test_neutral_proposal_id_rejects_slashless_repo():
+    with pytest.raises(apply_rederive.RederiveError, match="repo"):
+        apply_rederive.neutral_proposal_id(
+            {"repo": "agent-kernel", "transformation": "format-python"}
+        )
+
+
+def test_neutral_proposal_id_rejects_missing_transformation():
+    with pytest.raises(apply_rederive.RederiveError, match="transformation"):
+        apply_rederive.neutral_proposal_id({"repo": NEUTRAL_REPO})
+
+
+def test_neutral_summary_matches_binding_and_proposal_id():
+    summary = apply_rederive.neutral_summary(neutral_binding())
+    assert summary == {
+        "binding": NEUTRAL_REPO,
+        "transformation": "format-python",
+        "proposal_id": "apply-format-python-hiivmind-agent-kernel",
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -k neutral -v`
+Expected: FAIL — `AttributeError: module 'apply_rederive' has no attribute 'neutral_proposal_id'`
+
+- [ ] **Step 3: Write the implementation**
+
+In `apply_rederive.py`, update the constants (line 44) and add the dataclass + helpers. Replace line 44 and insert after `RederivedProposal` (line 141):
+
+```python
+SOURCE_KINDS = ("plan-sync", "generated-artifact", "marketplace-sync", "neutral")
+
+# Neutral transformations are the standalone, self-contained executable
+# entries with no propose driver. `regenerate-from-template` (a `nave
+# generate --from-template` argv) belongs to generated-artifact, not here;
+# the F9 overlays are profile:claude-plugin, never neutral.
+NEUTRAL_TRANSFORMATIONS = ("format-python", "refresh-node-lockfile", "regenerate-docs-index")
+```
+
+Insert after `MarketplaceProviderInputs` (before the `ProviderInputs` union at line 123):
+
+```python
+@dataclass(frozen=True)
+class NeutralProviderInputs:
+    """Fresh neutral evidence: `binding` is the caller-supplied `binding_ref`
+    (validated); `head_sha` is the live HEAD of the binding's `base_ref` branch."""
+
+    binding: Mapping[str, Any]
+    head_sha: str | None
+    actor: Mapping[str, Any] | mutation_plan.Actor
+    registry: mutation_plan.TransformationRegistry | None = None
+```
+
+Update the union (line 123):
+
+```python
+ProviderInputs = (
+    PlanSyncProviderInputs
+    | GeneratedProviderInputs
+    | MarketplaceProviderInputs
+    | NeutralProviderInputs
+)
+```
+
+Insert after `RederivedProposal` (after line 141):
+
+```python
+def _validate_neutral_binding(binding: Mapping[str, Any]) -> tuple[str, str]:
+    """Validate a neutral binding's `repo` + `transformation`; return (owner, name).
+
+    Raises `RederiveError` (never KeyError/ValueError) so a malformed binding
+    blocks (the driver turns it into a `blocked` result), never crashes.
+    """
+    repo = binding.get("repo")
+    if not isinstance(repo, str) or not repo or repo.count("/") != 1:
+        raise RederiveError(
+            f"apply_rederive: neutral binding requires repo 'owner/name', got {repo!r}"
+        )
+    transformation = binding.get("transformation")
+    if not isinstance(transformation, str) or not transformation:
+        raise RederiveError(
+            "apply_rederive: neutral binding requires a non-empty transformation, "
+            f"got {transformation!r}"
+        )
+    return repo.split("/", 1)
+
+
+def neutral_proposal_id(binding: Mapping[str, Any]) -> str:
+    """Deterministic neutral proposal id: `apply-{transformation}-{owner}-{name}`.
+
+    Single source of the id, shared by `neutral_summary` and `_rederive_neutral`
+    so the synthesized `recorded_summary.proposal_id` can never drift from the
+    re-derived proposal's id.
+    """
+    owner, name = _validate_neutral_binding(binding)
+    return f"apply-{binding['transformation']}-{owner}-{name}"
+
+
+def neutral_summary(binding: Mapping[str, Any]) -> dict[str, str]:
+    """Synthesize the `recorded_summary` for a neutral apply (no propose phase)."""
+    proposal_id = neutral_proposal_id(binding)  # validates repo + transformation first
+    return {
+        "binding": binding["repo"],
+        "transformation": binding["transformation"],
+        "proposal_id": proposal_id,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -k neutral -v`
+Expected: PASS (5 tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/pulse/scripts/apply_rederive.py lib/pulse/scripts/tests/test_apply_rederive.py
+git commit -m "feat(apply): add neutral provider interfaces (constants, inputs, helpers)"
+```
+
+---
+
+### Task 2: `_collect_neutral` + `collect_inputs` identity/dispatch branches
+
+**Files:**
+- Modify: `lib/pulse/scripts/apply_rederive.py` (`collect_inputs` ~line 166 and ~177; add `_collect_neutral` after `_collect_marketplace` ~line 270)
+- Test: `lib/pulse/scripts/tests/test_apply_rederive.py` (neutral collect tests)
+
+**Interfaces:**
+- Consumes: `NeutralProviderInputs`, `_validate_neutral_binding` (Task 1).
+- Produces: `def _collect_neutral(binding_ref, actor, io_seams) -> NeutralProviderInputs`; `collect_inputs("neutral", …)` returns it.
+
+- [ ] **Step 1: Write the failing tests**:
+
+```python
+def _neutral_gh_api(head_sha=NEUTRAL_HEAD):
+    def gh_api(path):
+        if path == f"repos/{NEUTRAL_REPO}/branches/main":
+            return {"commit": {"sha": head_sha}}
+        return None
+    return gh_api
+
+
+def neutral_registry():
+    return mutation_plan.load_registry({
+        "transformations": {
+            "format-python": {
+                "id": "format-python",
+                "command_argv": ["ruff", "format", "."],
+                "applies_to": ["profile:python"],
+                "validation": {"kind": "none"},
+                "allow_scheduled": True,
+            },
+        },
+    })
+
+
+def test_collect_inputs_neutral_fetches_live_head():
+    io_seams = apply_rederive.IoSeams(gh_api=_neutral_gh_api(), registry=neutral_registry())
+    inputs = apply_rederive.collect_inputs(
+        "neutral", neutral_binding(),
+        {"binding": NEUTRAL_REPO, "transformation": "format-python",
+         "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+        actor=ACTOR, io_seams=io_seams,
+    )
+    assert isinstance(inputs, apply_rederive.NeutralProviderInputs)
+    assert inputs.head_sha == NEUTRAL_HEAD
+    assert inputs.registry is io_seams.registry
+
+
+def test_collect_inputs_neutral_rejects_missing_base_ref():
+    io_seams = apply_rederive.IoSeams(gh_api=_neutral_gh_api())
+    with pytest.raises(apply_rederive.RederiveError, match="base_ref"):
+        apply_rederive.collect_inputs(
+            "neutral", {"repo": NEUTRAL_REPO, "transformation": "format-python"},
+            {"binding": NEUTRAL_REPO, "transformation": "format-python",
+             "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+            actor=ACTOR, io_seams=io_seams,
+        )
+
+
+def test_collect_inputs_neutral_rejects_missing_head_evidence():
+    io_seams = apply_rederive.IoSeams(gh_api=lambda path: None)
+    with pytest.raises(apply_rederive.RederiveError, match="HEAD"):
+        apply_rederive.collect_inputs(
+            "neutral", neutral_binding(),
+            {"binding": NEUTRAL_REPO, "transformation": "format-python",
+             "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+            actor=ACTOR, io_seams=io_seams,
+        )
+
+
+def test_collect_inputs_neutral_rejects_binding_identity_mismatch():
+    io_seams = apply_rederive.IoSeams(gh_api=_neutral_gh_api())
+    with pytest.raises(apply_rederive.RederiveError, match="binding"):
+        apply_rederive.collect_inputs(
+            "neutral", neutral_binding(),
+            {"binding": "someone/else", "transformation": "format-python",
+             "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+            actor=ACTOR, io_seams=io_seams,
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -k neutral -v`
+Expected: FAIL — `_collect_neutral` not called / `KeyError` on `base_ref` (identity mismatch test may pass already if the shared pre-check resolves `repo`; the collect-specific tests fail).
+
+- [ ] **Step 3: Write the implementation**
+
+In `collect_inputs`, change the identity resolution (lines 166–168) to add a `neutral` key:
+
+```python
+    binding_id = binding_ref.get(
+        "repo" if source_kind == "neutral"
+        else ("plugin_id" if source_kind == "marketplace-sync" else "id")
+    )
+```
+
+And add the dispatch branch before the marketplace fallthrough (lines 177–181):
+
+```python
+    if source_kind == "plan-sync":
+        return _collect_plan_sync(binding_ref, actor, io_seams)
+    if source_kind == "generated-artifact":
+        return _collect_generated(binding_ref, actor, io_seams)
+    if source_kind == "neutral":
+        return _collect_neutral(binding_ref, actor, io_seams)
+    return _collect_marketplace(binding_ref, actor, io_seams)
+```
+
+Add `_collect_neutral` after `_collect_marketplace` (after line 270):
+
+```python
+def _collect_neutral(
+    binding_ref: Mapping[str, Any],
+    actor: Mapping[str, Any] | mutation_plan.Actor,
+    io_seams: IoSeams,
+) -> NeutralProviderInputs:
+    owner, name = _validate_neutral_binding(binding_ref)  # repo + transformation
+    base_ref = binding_ref.get("base_ref")
+    if not isinstance(base_ref, str) or not base_ref:
+        raise RederiveError(
+            f"apply_rederive: neutral binding requires a non-empty base_ref, got {base_ref!r}"
+        )
+    if io_seams.gh_api is None:
+        raise RederiveError("apply_rederive: neutral requires io_seams.gh_api")
+    try:
+        payload = io_seams.gh_api(f"repos/{owner}/{name}/branches/{base_ref}")
+    except Exception as exc:
+        raise RederiveError(
+            f"apply_rederive: neutral HEAD fetch failed for {owner}/{name}: {exc}"
+        ) from exc
+    head_sha = None
+    if isinstance(payload, Mapping):
+        commit = payload.get("commit")
+        if isinstance(commit, Mapping) and isinstance(commit.get("sha"), str):
+            head_sha = commit["sha"] or None
+    if head_sha is None:
+        raise RederiveError(
+            f"apply_rederive: neutral could not resolve HEAD for {owner}/{name}@{base_ref}"
+        )
+    return NeutralProviderInputs(
+        binding=binding_ref,
+        head_sha=head_sha,
+        actor=actor,
+        registry=io_seams.registry,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -k neutral -v`
+Expected: PASS (Task 1's 5 + these 4)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/pulse/scripts/apply_rederive.py lib/pulse/scripts/tests/test_apply_rederive.py
+git commit -m "feat(apply): add neutral collection (live HEAD via gh_api) + collect_inputs dispatch"
+```
+
+---
+
+### Task 3: `_rederive_neutral` + `rederive` isinstance dispatch
+
+**Files:**
+- Modify: `lib/pulse/scripts/apply_rederive.py` (`rederive` ~line 288; add `_rederive_neutral` after `_rederive_marketplace` ~line 410)
+- Test: `lib/pulse/scripts/tests/test_apply_rederive.py` (neutral rederive tests)
+
+**Interfaces:**
+- Consumes: `NeutralProviderInputs`, `neutral_proposal_id` (Task 1).
+- Produces: `def _rederive_neutral(inputs: NeutralProviderInputs) -> RederivedProposal`; `rederive(NeutralProviderInputs)` returns it.
+
+- [ ] **Step 1: Write the failing tests**:
+
+```python
+def test_rederive_neutral_builds_allow_listed_proposal():
+    registry = neutral_registry()
+    inputs = apply_rederive.collect_inputs(
+        "neutral", neutral_binding(),
+        {"binding": NEUTRAL_REPO, "transformation": "format-python",
+         "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+        actor=ACTOR, io_seams=apply_rederive.IoSeams(gh_api=_neutral_gh_api(), registry=registry),
+    )
+    rederived = apply_rederive.rederive(inputs)
+    assert rederived.binding_id == NEUTRAL_REPO
+    assert rederived.source_kind == "neutral"
+    assert rederived.finalizer_record is None
+    assert rederived.proposal.id == "apply-format-python-hiivmind-agent-kernel"
+    assert rederived.proposal.selection == (NEUTRAL_REPO,)
+    assert rederived.proposal.transformation == "format-python"
+    assert rederived.proposal.expected_shas == {NEUTRAL_REPO: NEUTRAL_HEAD}
+    assert rederived.proposal.bound_paths == {
+        NEUTRAL_REPO: ("src/**", "tests/**", "examples/**")
+    }
+
+
+def test_rederive_neutral_rejects_non_neutral_transformation():
+    inputs = apply_rederive.NeutralProviderInputs(
+        binding=neutral_binding(transformation="plan-sync-doc-patch"),
+        head_sha=NEUTRAL_HEAD, actor=ACTOR,
+    )
+    with pytest.raises(apply_rederive.RederiveError, match="neutral transformation"):
+        apply_rederive.rederive(inputs)
+
+
+def test_rederive_neutral_rejects_unresolved_head_sha():
+    inputs = apply_rederive.NeutralProviderInputs(
+        binding=neutral_binding(), head_sha=None, actor=ACTOR,
+    )
+    with pytest.raises(apply_rederive.RederiveError, match="head_sha"):
+        apply_rederive.rederive(inputs)
+
+
+def test_rederive_neutral_rejects_empty_bound_paths():
+    inputs = apply_rederive.NeutralProviderInputs(
+        binding=neutral_binding(bound_paths=[]), head_sha=NEUTRAL_HEAD, actor=ACTOR,
+    )
+    with pytest.raises(apply_rederive.RederiveError, match="build failed"):
+        apply_rederive.rederive(inputs)
+
+
+def test_neutral_result_round_trips_through_authorization():
+    registry = neutral_registry()
+    inputs = apply_rederive.collect_inputs(
+        "neutral", neutral_binding(),
+        {"binding": NEUTRAL_REPO, "transformation": "format-python",
+         "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+        actor=ACTOR, io_seams=apply_rederive.IoSeams(gh_api=_neutral_gh_api(), registry=registry),
+    )
+    rederived = apply_rederive.rederive(inputs)
+    auth = apply_authorization.ApplyAuthorization(
+        transformation="format-python", mutation_policy="allow-listed",
+        permitted_repos=(NEUTRAL_REPO,),
+        bound_paths={NEUTRAL_REPO: ("src/**", "tests/**", "examples/**")},
+    )
+    apply_authorization.authorize(rederived, auth, {
+        "binding": NEUTRAL_REPO, "transformation": "format-python",
+        "proposal_id": "apply-format-python-hiivmind-agent-kernel",
+    })
+
+
+def test_neutral_transformations_are_self_contained_in_template_registry():
+    """The allowlist is fail-safe only if its entries are truly standalone:
+    no `nave generate` argv and no `profile:claude-plugin` predicate."""
+    template = Path(__file__).resolve().parents[4] / "templates" / "transformations.yaml.template"
+    registry = mutation_plan.load_registry(template)
+    for entry_id in apply_rederive.NEUTRAL_TRANSFORMATIONS:
+        entry = registry.get(entry_id)
+        assert not entry.command_argv[0:1] == ("nave",), (
+            f"{entry_id} argv must be self-contained (no nave generate dispatch)"
+        )
+        assert all(not p.startswith("profile:claude-plugin") for p in entry.applies_to), (
+            f"{entry_id} must not carry a profile:claude-plugin predicate"
+        )
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -k neutral -v`
+Expected: FAIL — `rederive` raises `RederiveError: unsupported provider inputs` for `NeutralProviderInputs`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add the isinstance dispatch in `rederive` (before the final raise, ~line 290):
+
+```python
+    if isinstance(inputs, MarketplaceProviderInputs):
+        return _rederive_marketplace(inputs)
+    if isinstance(inputs, NeutralProviderInputs):
+        return _rederive_neutral(inputs)
+    raise RederiveError(f"apply_rederive: unsupported provider inputs: {type(inputs)!r}")
+```
+
+Add `_rederive_neutral` after `_rederive_marketplace` (after line 410):
+
+```python
+def _rederive_neutral(inputs: NeutralProviderInputs) -> RederivedProposal:
+    binding = inputs.binding
+    transformation = binding.get("transformation")
+    if transformation not in NEUTRAL_TRANSFORMATIONS:
+        raise RederiveError(
+            f"apply_rederive: transformation {transformation!r} is not a neutral transformation"
+        )
+    head_sha = inputs.head_sha
+    if not isinstance(head_sha, str) or not head_sha:
+        raise RederiveError("apply_rederive: neutral requires a resolved head_sha")
+    try:
+        proposal = mutation_plan.build_proposal(
+            id=neutral_proposal_id(binding),
+            selection=[binding["repo"]],
+            transformation=transformation,
+            expected_shas={binding["repo"]: head_sha},
+            actor=inputs.actor,
+            mutation_policy="allow-listed",
+            bound_paths={binding["repo"]: binding["bound_paths"]},
+            registry=inputs.registry,
+        )
+    except mutation_plan.MutationPlanError as exc:
+        raise RederiveError(f"apply_rederive: neutral build failed: {exc}") from exc
+    return RederivedProposal(
+        binding_id=str(binding["repo"]),
+        proposal=proposal,
+        source_kind="neutral",
+        finalizer_record=None,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -k neutral -v`
+Expected: PASS (5 + 4 + 6)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/pulse/scripts/apply_rederive.py lib/pulse/scripts/tests/test_apply_rederive.py
+git commit -m "feat(apply): add neutral re-derivation (build_proposal degenerate case)"
+```
+
+---
+
+### Task 4: `resolve_intended_base` neutral branch
+
+**Files:**
+- Modify: `lib/pulse/scripts/apply_reconcile.py` (`resolve_intended_base` ~line 230, before the final `raise`)
+- Test: `lib/pulse/scripts/tests/test_apply_reconcile.py` (append next to the existing `test_resolve_intended_base_*` tests ~line 1196)
+
+**Interfaces:**
+- Produces: `resolve_intended_base("neutral", {"base_ref": "main"}, None) == "main"`; raises `ValueError("cannot resolve intended base for neutral: no base_ref")` on missing/non-string `base_ref`.
+
+- [ ] **Step 1: Write the failing tests**:
+
+```python
+def test_resolve_intended_base_neutral_uses_binding_base_ref():
+    assert apply_reconcile.resolve_intended_base(
+        "neutral", {"base_ref": "main"}, None
+    ) == "main"
+
+
+def test_resolve_intended_base_neutral_rejects_missing_base_ref():
+    with pytest.raises(ValueError, match="cannot resolve intended base for neutral"):
+        apply_reconcile.resolve_intended_base("neutral", {}, None)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_reconcile.py -k neutral -v`
+Expected: FAIL — `ValueError: unknown source_kind: neutral`.
+
+- [ ] **Step 3: Write the implementation**
+
+Insert before the final `raise ValueError(f"unknown source_kind: {source_kind}")` (line 237):
+
+```python
+    if source_kind == "neutral":
+        base = binding_ref.get("base_ref")
+        if not isinstance(base, str) or not base:
+            raise ValueError("cannot resolve intended base for neutral: no base_ref")
+        return base
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_reconcile.py -k neutral -v`
+Expected: PASS (2 tests). Also run the full reconcile file to confirm no regression: `uv run pytest lib/pulse/scripts/tests/test_apply_reconcile.py -q`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/pulse/scripts/apply_reconcile.py lib/pulse/scripts/tests/test_apply_reconcile.py
+git commit -m "feat(apply): resolve intended base for the neutral source kind"
+```
+
+---
+
+### Task 5: Driver contract — optional `recorded_summary`, neutral synthesis, `gh_api` seam
+
+**Files:**
+- Modify: `lib/pulse/scripts/apply_driver.py` (`run_apply` signature + top of try ~line 104–116; `IoSeams` construction ~line 115; add `_default_gh_api` helper; `main` CLI ~line 355 + call ~line 366)
+- Test: `lib/pulse/scripts/tests/test_apply_driver.py` (two new tests)
+
+**Interfaces:**
+- Consumes: `apply_rederive.neutral_summary` (Task 1).
+- Produces: `run_apply(*, …, recorded_summary: Mapping[str, Any] | None = None, gh_api: Callable[[str], Any] | None = None, …)`; `main` passes a production `gh_api` and makes `--recorded-summary` conditional.
+
+- [ ] **Step 1: Write the failing tests**:
+
+```python
+def test_run_apply_neutral_synthesizes_summary_and_threads_gh_api(tmp_path, monkeypatch):
+    from lib.pulse.scripts.apply_authorization import AuthorizationError
+
+    captured = {}
+
+    def fake_collect(source_kind, binding_ref, recorded_summary, *, actor, io_seams):
+        captured["recorded_summary"] = recorded_summary
+        captured["gh_api"] = io_seams.gh_api
+        return SimpleNamespace(registry=None)
+
+    def fake_rederive(inputs):
+        prop = mutation_plan.build_proposal(
+            id="apply-format-python-hiivmind-agent-kernel",
+            selection=["hiivmind/agent-kernel"], transformation="format-python",
+            expected_shas={"hiivmind/agent-kernel": "e" * 40},
+            actor={"gh_login": "octocat", "machine": "host", "mode": "interactive"},
+            mutation_policy="allow-listed",
+            bound_paths={"hiivmind/agent-kernel": ("src/**",)},
+        )
+        return apply_rederive.RederivedProposal("hiivmind/agent-kernel", prop, "neutral", None)
+
+    monkeypatch.setattr(apply_driver.apply_rederive, "collect_inputs", fake_collect)
+    monkeypatch.setattr(apply_driver.apply_rederive, "rederive", fake_rederive)
+    monkeypatch.setattr(apply_driver.apply_authorization, "load_authorization", lambda *a: object())
+    monkeypatch.setattr(apply_driver.apply_authorization, "authorization_digest", lambda a: "v1|" + "b" * 64)
+    monkeypatch.setattr(apply_driver.apply_authorization, "authorize",
+                        lambda *a: (_ for _ in ()).throw(AuthorizationError("stop")))
+
+    ledger = tmp_path / "ledger.yaml"
+    ledger.write_text(yaml.safe_dump({
+        "ledger_version": 1, "run_id": "r", "workflow": "w", "status": "running",
+        "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+        "actor": {"gh_login": "octocat", "machine": "host"}, "params": {},
+        "repos": ["hiivmind/agent-kernel"],
+        "steps": [{"id": "step", "repo": "hiivmind/agent-kernel", "depends_on": [],
+                   "gate": None, "status": "pending", "notes": []}],
+    }, sort_keys=False))
+    result = tmp_path / "result.yaml"
+    fake_gh_api = lambda path: {"commit": {"sha": "e" * 40}}
+
+    out = apply_driver.run_apply(
+        source_kind="neutral",
+        binding_ref={"repo": "hiivmind/agent-kernel", "transformation": "format-python",
+                     "base_ref": "main", "bound_paths": ["src/**"]},
+        recorded_summary=None,
+        authorization_path=tmp_path / "auth.yaml", ledger_path=ledger, step_id="step",
+        actor_id="octocat@host", runner=RecordingRunner(), gh_api=fake_gh_api,
+        gh_ops=FakeGhOps(), result_path=result, workspace=str(tmp_path),
+    )
+
+    assert out["state"] == "blocked"
+    assert captured["recorded_summary"] == {
+        "binding": "hiivmind/agent-kernel",
+        "transformation": "format-python",
+        "proposal_id": "apply-format-python-hiivmind-agent-kernel",
+    }
+    assert captured["gh_api"] is fake_gh_api
+
+
+def test_run_apply_rejects_missing_summary_for_non_neutral(tmp_path, monkeypatch):
+    monkeypatch.setattr(apply_driver.apply_rederive, "collect_inputs",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not collect")))
+    ledger = tmp_path / "ledger.yaml"
+    ledger.write_text(yaml.safe_dump({
+        "ledger_version": 1, "run_id": "r", "workflow": "w", "status": "running",
+        "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+        "actor": {"gh_login": "octocat", "machine": "host"}, "params": {},
+        "repos": ["acme/widget"],
+        "steps": [{"id": "step", "repo": "acme/widget", "depends_on": [],
+                   "gate": None, "status": "pending", "notes": []}],
+    }, sort_keys=False))
+    result = tmp_path / "result.yaml"
+    out = apply_driver.run_apply(
+        source_kind="generated-artifact",
+        binding_ref={"id": "binding", "branch": "main"},
+        recorded_summary=None,
+        authorization_path=tmp_path / "auth.yaml", ledger_path=ledger, step_id="step",
+        actor_id="octocat@host", runner=RecordingRunner(), gh_ops=FakeGhOps(),
+        result_path=result, workspace=str(tmp_path),
+    )
+    assert out["state"] == "blocked"
+    assert "recorded_summary" in out["reason"]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_driver.py -k "neutral_synthesizes or rejects_missing_summary" -v`
+Expected: FAIL — `TypeError: run_apply() missing 1 required keyword-only argument: 'recorded_summary'` (for the neutral test, since `gh_api` is also not yet a kwarg).
+
+- [ ] **Step 3: Write the implementation**
+
+Change `run_apply` signature (line 104) and the top of its body:
+
+```python
+def run_apply(*, source_kind, binding_ref, recorded_summary=None, authorization_path, ledger_path,
+              step_id, actor_id, runner, gh_api=None, gh_ops, result_path, workspace) -> dict:
+    """Run one single-repository apply; return apply-status or repo-mutation."""
+    proposal = None
+    proposal_digest = None
+    authorization_digest = None
+    actor = _actor(actor_id)
+
+    try:
+        if source_kind == "neutral":
+            recorded_summary = apply_rederive.neutral_summary(binding_ref)
+        elif not recorded_summary:
+            raise apply_rederive.RederiveError(
+                f"recorded_summary is required for source_kind={source_kind!r}"
+            )
+        inputs = apply_rederive.collect_inputs(
+            source_kind, binding_ref, recorded_summary, actor=actor,
+            io_seams=apply_rederive.IoSeams(runner=runner, gh_api=gh_api, registry=None),
+        )
+```
+
+Add the production `gh_api` helper near `_actor` (after line 31):
+
+```python
+def _default_gh_api(path: str):
+    """Production `gh api` seam — parsed JSON, or None on any failure."""
+    import json
+    import subprocess
+    res = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+    if res.returncode != 0:
+        return None
+    try:
+        return json.loads(res.stdout)
+    except ValueError:
+        return None
+```
+
+Update `main`: relax the `--recorded-summary` argument (line 355), add the post-parse guard, and pass `gh_api`:
+
+```python
+    parser.add_argument("--recorded-summary", required=False, default=None,
+                        help="JSON {binding, transformation, proposal_id}; omit for --source-kind neutral")
+    ...
+    if args.source_kind != "neutral" and not args.recorded_summary:
+        parser.error("--recorded-summary is required unless --source-kind is neutral")
+
+    runner = nave_adapter.NaveRunner(fixtures=args.fixtures)
+    result = run_apply(
+        source_kind=args.source_kind,
+        binding_ref=json.loads(args.binding_ref),
+        recorded_summary=json.loads(args.recorded_summary) if args.recorded_summary else None,
+        authorization_path=args.authorization,
+        ledger_path=args.ledger,
+        step_id=args.step,
+        actor_id=args.actor,
+        runner=runner,
+        gh_api=_default_gh_api,
+        gh_ops=apply_reconcile.GhCliOps(),
+        result_path=args.result,
+        workspace=args.workspace,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_driver.py -k "neutral_synthesizes or rejects_missing_summary" -v`
+Expected: PASS (2 tests). Then run the full driver suite to confirm no regression from the optional kwarg: `uv run pytest lib/pulse/scripts/tests/test_apply_driver.py -q`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/pulse/scripts/apply_driver.py lib/pulse/scripts/tests/test_apply_driver.py
+git commit -m "feat(apply): synthesize neutral recorded_summary in the driver; thread gh_api"
+```
+
+---
+
+### Task 6: Workspace config — binding + authorization (separate repo)
+
+**Files (in `~/git/hiivmind/hiivmind-workspace`):**
+- Create: `apply-neutral.yaml`
+- Create: `apply-authorization.yaml`
+
+**Interfaces:**
+- Produces: the two config files consumed by the driver/skill at apply time (`apply-authorization.yaml` shape is pinned by `apply_authorization.load_authorization`).
+
+- [ ] **Step 1: Create `apply-neutral.yaml`** (at the repo root, alongside `config.yaml`):
+
+```yaml
+# Neutral apply bindings — one entry per (repo, transformation). Each binding is
+# single-repo: a multi-repo intent is expressed as multiple list entries.
+bindings:
+  - repo: hiivmind/agent-kernel
+    transformation: format-python
+    base_ref: main
+    bound_paths:
+      - src/**
+      - tests/**
+      - examples/**
+```
+
+- [ ] **Step 2: Create `apply-authorization.yaml`** (same directory):
+
+```yaml
+# Apply-mode authorization policy — consumed verbatim by
+# apply_authorization.load_authorization (mutation_policy / permitted_repos /
+# bound_paths). The scope gate for allow-listed neutral applies.
+authorizations:
+  format-python:
+    mutation_policy: allow-listed
+    permitted_repos:
+      - hiivmind/agent-kernel
+    bound_paths:
+      hiivmind/agent-kernel:
+        - src/**
+        - tests/**
+        - examples/**
+```
+
+- [ ] **Step 3: Commit on a feature branch and open a PR**
+
+```bash
+cd ~/git/hiivmind/hiivmind-workspace
+git checkout -b feature/apply-mode-enrollment
+git add apply-neutral.yaml apply-authorization.yaml
+git commit -m "feat: enroll format-python neutral apply (binding + authorization)"
+git push -u origin feature/apply-mode-enrollment
+gh pr create --base main --title "Apply-mode workspace enrollment" \
+  --body "Adds the neutral apply binding (format-python on hiivmind/agent-kernel) and its apply-authorization policy. Gated on the installed Nave apply verbs + pulse-gh (F11 §5F)."
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `gh pr view --json state,baseRefName -q '"\(.state) \(.baseRefName)"'`
+Expected: `OPEN main`.
+
+---
+
+### Task 7: Live proof (gated on the installed engine — NOT a code deliverable)
+
+**Files:** none (verification only).
+
+**Gating:** Nave apply verbs (merged `discreteds/nave` PR #2) and pulse-gh must be `uv`-installed locally. If the capability handshake fails, the driver returns `blocked` — that is the expected fail-closed behavior, not a defect.
+
+- [ ] **Step 1: Check `hiivmind/agent-kernel` for real ruff drift.**
+
+Run (in `~/git/hiivmind/agent-kernel`):
+```bash
+ruff format --check . 2>&1 | head -20
+```
+Expected: either "would reformat N files" (real drift) or "All checks passed" (no drift).
+
+- [ ] **Step 2: If no drift, introduce a deliberate inconsistency in a scratch clone** (never committed upstream). `format-python` validates with `kind: none`, so a no-op run fails at the `commit` boundary (nothing to stage → `git commit` nonzero) and never reaches push/PR/merge-detect. The proof must land a real diff to exercise the full spine.
+
+- [ ] **Step 3: Run the apply** via the `gh-apply` skill with `source_kind=neutral`, the `apply-neutral.yaml` binding, and `authorization_path=<workspace>/apply-authorization.yaml`. Confirm the terminal `apply-status` reaches `applied` after the PR is reviewed + merged (base + head verified by the merge gate; no base advance for pure-neutral).
+
+- [ ] **Step 4: Confirm the ledger step is `done`** (no "base advance deferred" bookkeeping PR — terminal at merge).
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §4.1 interfaces → Task 1 (constants, dataclass, helpers). ✓
+- §4.2 collection → Task 2 (`_collect_neutral` + `collect_inputs` identity/dispatch). ✓
+- §4.3 re-derivation → Task 3 (`_rederive_neutral` + allowlist + head_sha + bound_paths). ✓
+- §4.4 finalizer `None` → Task 3 asserts `finalizer_record is None`. ✓
+- §4.5 recorded-summary synthesis + single-source id → Task 1 (`neutral_summary`/`neutral_proposal_id`) + Task 5 (driver synthesizes). ✓
+- §4.6 shared-dispatcher branches (C1/C2) → Task 2 (`collect_inputs`) + Task 4 (`resolve_intended_base`). ✓
+- §5 workspace config → Task 6. ✓
+- §6 installed-engine gate → Task 7 gating note. ✓
+- §7 acceptance → Tasks 1–3 unit tests (fail-closed list + the registry cross-check, added to Task 3 Step 1); Task 7 live proof. ✓
+
+**Placeholder scan:** no `TBD`/`TODO`; every code step includes actual code; every test step includes actual test code. ✓
+
+**Type consistency:** `NeutralProviderInputs` fields (`binding`, `head_sha`, `actor`, `registry`) are used consistently across Tasks 2–3; `neutral_proposal_id`/`neutral_summary`/`_validate_neutral_binding` signatures match their call sites; `run_apply`'s new kwargs (`recorded_summary=None`, `gh_api=None`) match the `main` call site. ✓

--- a/docs/superpowers/specs/2026-08-14-apply-mode-workspace-enrollment-design.md
+++ b/docs/superpowers/specs/2026-08-14-apply-mode-workspace-enrollment-design.md
@@ -1,12 +1,11 @@
 # Apply-Mode Workspace Enrollment — Design Spec
 
 **Date:** 2026-08-14
-**Status:** Approved (brainstorm) — pending implementation plan.
+**Status:** Approved (brainstorm) — revised after one adversarial design review (GLM-5.2 via
+opencode-go, REQUEST CHANGES; all 4 must-fix + 8 minors incorporated). Pending implementation plan.
 **Origin:** `docs/superpowers/specs/2026-07-30-apply-mode-production-wiring-design.md` § 5F
 ("Workspace enrollment (`hiivmind/hiivmind-workspace`) — gated on an installed engine"), and the
-plan follow-up of `docs/superpowers/plans/2026-07-30-apply-mode-pulse-wiring.md` ("Workspace
-enrollment PR: `ApplyAuthorization` policy + a real neutral proposal source, gated on the
-installed engine").
+plan follow-up of `docs/superpowers/plans/2026-07-30-apply-mode-pulse-wiring.md`.
 
 **Read alongside:** the production-wiring spec (§ 4 authorization model, § 5A–E components),
 `lib/pulse/scripts/apply_rederive.py` (the re-derivation provider registry), and
@@ -23,45 +22,63 @@ through `apply_rederive` before it authorizes or mutates. But `apply_rederive.SO
 ("plan-sync", "generated-artifact", "marketplace-sync")
 ```
 
-There is **no neutral source kind**. The neutral transformations in the registry
-(`format-python`, `refresh-node-lockfile`, `regenerate-docs-index`, `regenerate-from-template`)
-are executable entries with no propose driver and no re-derivation provider, so `run_apply`
-cannot mint an allow-listed proposal for any of them today. The workspace
-(`hiivmind/hiivmind-workspace`, a.k.a. `~/git/hiivmind/.hiivmind/github/`) also carries **no**
-`ApplyAuthorization` policy and **no** binding files of any kind.
+There is **no neutral source kind**. The standalone neutral transformations in the registry
+(`format-python`, `refresh-node-lockfile`, `regenerate-docs-index`) are executable entries with no
+propose driver and no re-derivation provider, so `run_apply` cannot mint an allow-listed proposal
+for any of them today. The workspace (`hiivmind/hiivmind-workspace`, a.k.a.
+`~/git/hiivmind/.hiivmind/github/`) also carries **no** `ApplyAuthorization` policy and **no**
+binding files of any kind.
 
 F11's "production wiring" therefore stalls one step short of runnable: the driver and the Nave
 verbs are merged, but nothing tells apply-mode *what* to land. This closes that gap with the
 flagship neutral use case.
 
-## 2. Decisions (settled in brainstorm)
+## 2. Decisions (settled in brainstorm + review)
 
 1. **New neutral provider** — a 4th source kind (`"neutral"`) in `apply_rederive`, not a reuse of
-   `generated-artifact` and not a hand-minted proposal. It is complete and reusable for every
-   neutral transformation.
-2. **Proof transformation** — `format-python` (`ruff format .`). It is deterministic (same base +
+   `generated-artifact` and not a hand-minted proposal.
+2. **Neutral transformation set** — exactly the three standalone, self-contained neutral
+   transformations: `format-python`, `refresh-node-lockfile`, `regenerate-docs-index`. The
+   generator-based `regenerate-from-template` (argv `nave generate --from-template`) routes through
+   the F7 `generated-artifact` source, not the neutral provider; the two F9 overlays
+   (`regenerate-corpus-navigate-skill`, `marketplace-entry-update`) are `profile:claude-plugin`
+   and are **not** neutral. (Review M3.)
+3. **Proof transformation** — `format-python` (`ruff format .`). It is deterministic (same base +
    ruff version → same output), which satisfies the v1 crash-resume "reset + re-exec" contract,
    and it is genuinely neutral (`applies_to: profile:python`, no `profile:claude-plugin`
    predicate).
-3. **Proof repo** — `hiivmind/agent-kernel` (an external Python app repo: `src/ tests/ examples/`,
-   `pyproject.toml`). External to both the corpus and the plugin, so the neutrality proof is not
-   self-referential. `hiivmind/agno-oracle-demo` is the fallback (same shape).
-4. **Pure-neutral → terminal at merge.** `format-python` has no base to advance; the merge gate is
+4. **Proof repo** — `hiivmind/agent-kernel` (an external Python app repo: `src/ tests/ examples/`,
+   `pyproject.toml`). `hiivmind/agno-oracle-demo` is the fallback (same shape).
+5. **Pure-neutral → terminal at merge.** `format-python` has no base to advance; the merge gate is
    the end of the run (`applied`), no F8 bookkeeping PR.
-5. **`mutation_plan.build_proposal` is the neutral builder.** Neutral transformations have no
+6. **`mutation_plan.build_proposal` is the neutral builder.** Neutral transformations have no
    source-specific decision logic (that is the point); the proposal is "binding + live HEAD".
    The other three sources keep their real, source-specific builders untouched.
 
-## 3. Architecture — two repos
+## 3. Architecture — two repos, six touch points
 
 ```
-pulse-gh (code):     apply_rederive gains SOURCE_KINDS "neutral" + provider
+pulse-gh (code):     apply_rederive (4th source kind + helpers) + apply_reconcile (one branch)
 workspace (config):  apply-neutral.yaml (binding) + apply-authorization.yaml (policy)
 ```
 
-The re-derivation registry already separates *collection* (`collect_inputs` → a typed provider
-inputs dataclass) from *re-derivation* (`rederive` → the real builder). The neutral provider
-follows that exact shape; no new machinery.
+The re-derivation registry separates *collection* (`collect_inputs` → a typed provider inputs
+dataclass) from *re-derivation* (`rederive` → the real builder). The neutral provider follows that
+split, but it is **not** zero-touch: two shared dispatchers need source-kind branches. The complete
+pulse-gh touch-point list (review C1/C2/M4):
+
+1. `apply_rederive.SOURCE_KINDS` — add `"neutral"`.
+2. `apply_rederive.ProviderInputs` union — add `NeutralProviderInputs`.
+3. `apply_rederive.collect_inputs` — **identity resolution** (neutral uses `repo`, not `id`) and
+   the **dispatch** (`if source_kind == "neutral": return _collect_neutral(...)`).
+4. `apply_rederive.rederive` — `isinstance` dispatch to `_rederive_neutral`.
+5. `apply_reconcile.resolve_intended_base` — add a `"neutral"` branch reading
+   `binding_ref["base_ref"]`.
+6. `apply_rederive._collect_neutral` / `_rederive_neutral` / `neutral_summary` /
+   `neutral_proposal_id` — the provider itself.
+
+`apply_authorization.py` is **unchanged** — its `load_authorization`/`authorize` already consume
+the neutral authorization shape verbatim.
 
 ## 4. pulse-gh — the neutral provider
 
@@ -70,10 +87,11 @@ follows that exact shape; no new machinery.
 ```python
 # apply_rederive.py
 SOURCE_KINDS = ("plan-sync", "generated-artifact", "marketplace-sync", "neutral")
+NEUTRAL_TRANSFORMATIONS = ("format-python", "refresh-node-lockfile", "regenerate-docs-index")
 
 @dataclass(frozen=True)
 class NeutralProviderInputs:
-    binding: Mapping[str, Any]        # the neutral binding (repo, transformation, bound_paths, base_ref)
+    binding: Mapping[str, Any]        # {repo, transformation, base_ref, bound_paths}
     head_sha: str | None              # live HEAD of the binding's base_ref branch
     actor: Mapping[str, Any] | mutation_plan.Actor
     registry: mutation_plan.TransformationRegistry | None = None
@@ -81,6 +99,8 @@ class NeutralProviderInputs:
 ProviderInputs = (PlanSyncProviderInputs | GeneratedProviderInputs
                   | MarketplaceProviderInputs | NeutralProviderInputs)
 
+def neutral_proposal_id(binding) -> str            # single source of the deterministic id
+def neutral_summary(binding) -> dict[str, str]     # the synthesized recorded_summary
 def _collect_neutral(binding_ref, actor, io_seams) -> NeutralProviderInputs
 def _rederive_neutral(inputs: NeutralProviderInputs) -> RederivedProposal
 ```
@@ -88,19 +108,21 @@ def _rederive_neutral(inputs: NeutralProviderInputs) -> RederivedProposal
 ### 4.2 Collection (fresh state, no pen)
 
 `_collect_neutral` resolves the target repo's **live `base_ref` HEAD** via the existing
-`io_seams.runner` seam (the same `(argv, cwd) -> CompletedProcess` shape every source uses). It
-makes a direct `gh api repos/{owner}/{name}/branches/{base_ref}` call for that branch's `sha` —
-it does **not** reuse `marketplace_sync_run.fetch_remote_evidence` (that fetches marketplace
-releases/docs, not a neutral repo's HEAD). It **never** reads SHAs from the caller-supplied
-`binding_ref`, and it fails closed (`RederiveError`) when the HEAD evidence is missing.
+`io_seams.gh_api` seam (`(endpoint) -> parsed JSON`, already used by plan-sync — review M5): it
+calls `gh_api(f"repos/{owner}/{name}/branches/{base_ref}")["commit"]["sha"]`. It fails closed
+(`RederiveError`) when `base_ref` is missing/non-string (review M6) or when the HEAD evidence is
+missing. It **never** reads SHAs from the caller-supplied `binding_ref`; `base_ref` is read from the
+binding, the SHA from the live API.
 
 ### 4.3 Re-derivation
 
 `_rederive_neutral` builds the proposal from the binding + fresh HEAD:
 
 ```python
+owner, name = binding["repo"].split("/", 1)
+id = neutral_proposal_id(binding)          # f"apply-{transformation}-{owner}-{name}"
 mutation_plan.build_proposal(
-    id=f"apply-{transformation}-{owner}-{name}",  # deterministic from (repo, transformation)
+    id=id,
     selection=[binding["repo"]],
     transformation=binding["transformation"],
     expected_shas={binding["repo"]: head_sha},
@@ -112,30 +134,53 @@ mutation_plan.build_proposal(
 
 Gating that fires inside this path (all fail-closed):
 
-- the transformation id must exist in the registry and be **neutral** (reject plan-sync,
-  generated, marketplace, and the F9 overlay ids);
+- `binding["transformation"]` must be in `NEUTRAL_TRANSFORMATIONS` — the explicit allowlist
+  **is** the "transformation must be neutral" gate (review I1). This rejects `plan-sync-doc-patch`
+  (which is `applies_to: always` and would pass a naive "no claude-plugin predicate" test), the F9
+  overlays, and any unknown id, with `RederiveError`.
 - `build_proposal` already enforces exact, non-empty `bound_paths` coverage for allow-listed
-  (Task 2) — the binding supplies them;
-- `allow_scheduled` gating is left to `build_proposal`/the registry, as for the other sources.
+  (Task 2) — the binding supplies them.
+- `allow_scheduled` is **not** gated here: `apply_driver._actor` hardcodes `mode="interactive"`,
+  so scheduled-neutral gating is out of the re-derivation path (consistent with the other three
+  sources — review M7). Scheduled neutral apply is v2.
 
 ### 4.4 `finalizer_record`
 
 Neutral transformations have no F8 doc-blob base to advance, so `finalizer_record` is `None`
-(exactly as the existing generated/marketplace providers emit). No change to the driver's
-finalizer-persistence path (it already skips a `None` record).
+(only the generated-artifact provider emits `None` today; marketplace emits `{"base_ref": …}` —
+review M1). The driver's finalizer-persistence path already skips a `None` record; the intended
+base for neutral comes from `binding_ref["base_ref"]` via `resolve_intended_base`, not from a
+finalizer.
 
 ### 4.5 Recorded-summary identity (no propose phase)
 
 Neutral transformations have no F10 propose run to persist a `{binding, transformation,
 proposal_id}` summary. The apply driver still requires `recorded_summary` so `authorize()` can run
-its full identity + scope check. For neutral, `recorded_summary` is **synthesized from the
-binding**: `{binding: binding["repo"], transformation: binding["transformation"], proposal_id:
-<the deterministic id above>}`. `_rederive_neutral` returns `RederivedProposal(binding_id=
-binding["repo"], ...)` so the `authorize()` binding-match (`recorded_binding ==
-rederived.binding_id`) holds, and the deterministic id makes `proposal_id` stable across
-re-derivation. The scope half of `authorize()` (transformation authorized, `selection ⊆
-permitted_repos`, `bound_paths` within authorization) still applies unchanged — the binding is not
-self-elevating.
+its full identity + scope check. For neutral, **`run_apply` synthesizes it internally** (review I2):
+when `source_kind == "neutral"` it computes `recorded_summary = neutral_summary(binding_ref)` =
+`{binding: binding["repo"], transformation: binding["transformation"], proposal_id:
+neutral_proposal_id(binding_ref)}` and ignores the `recorded_summary` CLI/kwarg (which is
+meaningful only for the three propose-backed sources).
+
+The id formula lives in **one** place — `neutral_proposal_id` — used by both `neutral_summary` and
+`_rederive_neutral`, so the synthesized summary's `proposal_id` can never drift from the
+re-derived proposal's `id`. `_rederive_neutral` returns `RederivedProposal(binding_id=
+binding["repo"], …)` so the `authorize()` binding-match (`recorded_binding == rederived.binding_id`)
+holds. The scope half of `authorize()` (transformation authorized, `selection ⊆ permitted_repos`,
+`bound_paths` within authorization) still applies unchanged — the binding is not self-elevating.
+
+### 4.6 Shared-dispatcher branches (review C1/C2)
+
+- **`collect_inputs` identity** — the existing pre-check resolves `binding_id =
+  binding_ref.get("plugin_id" if source_kind == "marketplace-sync" else "id")`. For neutral the
+  binding is `repo`-keyed, so add: `binding_id = binding_ref.get("repo" if source_kind ==
+  "neutral" else ("plugin_id" if source_kind == "marketplace-sync" else "id"))`. This makes the
+  § 4.5 identity match (`binding_id == "hiivmind/agent-kernel"`) hold instead of raising.
+- **`collect_inputs` dispatch** — add `if source_kind == "neutral": return _collect_neutral(...)`
+  before the existing fallthrough.
+- **`resolve_intended_base`** — add `if source_kind == "neutral": return _required(binding_ref
+  ["base_ref"])` (mirroring the plan-sync fallback), before the final
+  `raise ValueError(f"unknown source_kind: {source_kind}")`.
 
 ## 5. workspace — binding + authorization
 
@@ -144,7 +189,7 @@ Two new config files in the workspace repo (`hiivmind/hiivmind-workspace`, flow 
 ```yaml
 # apply-neutral.yaml
 bindings:
-  - repo: hiivmind/agent-kernel
+  - repo: hiivmind/agent-kernel        # single-repo scalar; multi-repo is N bindings (v1)
     transformation: format-python
     base_ref: main
     bound_paths:
@@ -168,8 +213,10 @@ authorizations:
 ```
 
 `apply-authorization.yaml` is consumed verbatim by `apply_authorization.load_authorization` — the
-shape is already pinned by that loader (`authorizations.<id> = {mutation_policy, permitted_repos,
-bound_paths}`). The `apply-neutral.yaml` binding is consumed by the new `_collect_neutral`.
+shape is already pinned by that loader. The `apply-neutral.yaml` binding is consumed by
+`_collect_neutral`; its `repo` is a **single-repo scalar** (review M8): a multi-repo intent is
+expressed as multiple bindings in the list, each applied by a separate single-repo run (the
+driver's `selection > 1` guard is the backstop, not the schema).
 
 ## 6. Determinism & installed-engine gate
 
@@ -185,28 +232,36 @@ bound_paths}`). The `apply-neutral.yaml` binding is consumed by the new `_collec
 ## 7. Acceptance
 
 1. **pulse-gh unit tests** (new `test_apply_rederive_neutral` cases):
-   - `_collect_neutral` returns `NeutralProviderInputs` with live HEAD for a bound repo;
-   - `_rederive_neutral` returns an allow-listed `RederivedProposal` whose `selection`,
-     `expected_shas`, `bound_paths`, and `mutation_policy` match the binding + HEAD;
-   - fail-closed: missing HEAD evidence → `RederiveError`; a non-neutral transformation id
-     (e.g. `plan-sync-doc-patch`) → `RederiveError`; empty/missing `bound_paths` →
-     `MutationPlanError` (from `build_proposal`).
+   - `collect_inputs("neutral", …)` returns `NeutralProviderInputs` with live HEAD for a bound
+     repo, and passes the § 4.6 identity pre-check (no `RederiveError` on a `repo`-keyed binding);
+   - `_rederive_neutral` returns an allow-listed `RederivedProposal` whose `id`, `selection`,
+     `expected_shas`, `bound_paths`, and `mutation_policy` match the binding + HEAD, and whose
+     `id == neutral_proposal_id(binding)` (single-source id);
+   - `resolve_intended_base("neutral", {"base_ref": "main"}, None) == "main"`;
+   - fail-closed: missing HEAD evidence → `RederiveError`; missing `base_ref` → `RederiveError`;
+     a non-neutral transformation id (`plan-sync-doc-patch`, `regenerate-corpus-navigate-skill`)
+     → `RederiveError`; empty/missing `bound_paths` → `MutationPlanError` (from `build_proposal`).
 2. **Live proof** (not fixture): `gh-apply` on `hiivmind/agent-kernel` drives the real
    `apply_driver` → `pen_create` → `preflight` → `provision` (remote-base CAS) → `format-python`
    exec → validate → commit → push `pulse/apply/{id}` → open PR → merge-detect (base + head
    verified) → terminal `applied`. Pure-neutral, no base advance.
-3. **Format-drift note.** `format-python` validates with `kind: none`, so a repo already
-   ruff-formatted yields a zero-diff branch (the wiring still proves, but lands nothing). During
-   implementation, check `agent-kernel` for real drift; if none, introduce a deliberate
-   formatting inconsistency in a scratch clone for the proof (never committed to `agent-kernel`).
+3. **Format-drift is a hard requirement** (review M2). `format-python` validates with `kind:
+   none`, but a no-op run (repo already ruff-formatted) fails at the **commit** boundary — nothing
+   to stage → `git commit` nonzero — so it never reaches push/PR/merge-detect and only proves
+   collect→provision. To exercise the full spine, the proof **must** land a real diff: check
+   `agent-kernel` for genuine ruff drift, and if none, introduce a deliberate formatting
+   inconsistency in a scratch clone for the proof (never committed upstream to `agent-kernel`).
 
 ## 8. Scope notes & deferrals
 
-- **Multi-repo apply** stays v2 — the binding is a list for shape symmetry, but v1 applies one
-  repo per run (the driver already blocks `selection > 1` with "multi-repo apply is v2").
-- **`refresh-node-lockfile` / `regenerate-docs-index` / `regenerate-from-template`** become
-  available through the same `neutral` provider with no further code — only a binding + an
-  `apply-authorization` entry each. Out of this PR's proof scope.
+- **Multi-repo apply** stays v2 — `apply-neutral.yaml` is a list of single-repo bindings; v1
+  applies one repo per run (the driver blocks `selection > 1` with "multi-repo apply is v2").
+- **`refresh-node-lockfile` / `regenerate-docs-index`** become available through the same `neutral`
+  provider with no further code — only a binding + an `apply-authorization` entry each. Out of
+  this PR's proof scope.
+- **`regenerate-from-template`** is **not** a neutral-provider transformation: its argv runs
+  `nave generate --from-template` under the F7 generator-dispatch machinery, so it belongs to the
+  `generated-artifact` source (review M3). Excluded from `NEUTRAL_TRANSFORMATIONS`.
 - **F4 fleet-wide dependency-coherence apply** remains out of scope (unchanged from the wiring
   spec); `format-python` is the neutral proof, not the coherence use case.
 - **Tool-version pinning** (a ruff/npm/mkdocs version field on the binding) is a follow-up if a

--- a/docs/superpowers/specs/2026-08-14-apply-mode-workspace-enrollment-design.md
+++ b/docs/superpowers/specs/2026-08-14-apply-mode-workspace-enrollment-design.md
@@ -1,8 +1,11 @@
 # Apply-Mode Workspace Enrollment — Design Spec
 
 **Date:** 2026-08-14
-**Status:** Approved (brainstorm) — revised after one adversarial design review (GLM-5.2 via
-opencode-go, REQUEST CHANGES; all 4 must-fix + 8 minors incorporated). Pending implementation plan.
+**Status:** Approved (brainstorm) — revised after two adversarial design reviews (GLM-5.2 via
+opencode-go). Review 1: REQUEST CHANGES (4 must-fix + 8 minors, all incorporated). Review 2
+(re-review of the amendments): REQUEST CHANGES (2 must-fix + 6 minors — C1/C2/I1 confirmed
+resolved, I2 partial, one new fail-closed gap); all incorporated here. Pending implementation
+plan.
 **Origin:** `docs/superpowers/specs/2026-07-30-apply-mode-production-wiring-design.md` § 5F
 ("Workspace enrollment (`hiivmind/hiivmind-workspace`) — gated on an installed engine"), and the
 plan follow-up of `docs/superpowers/plans/2026-07-30-apply-mode-pulse-wiring.md`.
@@ -42,7 +45,7 @@ flagship neutral use case.
    generator-based `regenerate-from-template` (argv `nave generate --from-template`) routes through
    the F7 `generated-artifact` source, not the neutral provider; the two F9 overlays
    (`regenerate-corpus-navigate-skill`, `marketplace-entry-update`) are `profile:claude-plugin`
-   and are **not** neutral. (Review M3.)
+   and are **not** neutral.
 3. **Proof transformation** — `format-python` (`ruff format .`). It is deterministic (same base +
    ruff version → same output), which satisfies the v1 crash-resume "reset + re-exec" contract,
    and it is genuinely neutral (`applies_to: profile:python`, no `profile:claude-plugin`
@@ -72,7 +75,7 @@ pulse-gh touch-point list (review C1/C2/M4):
 3. `apply_rederive.collect_inputs` — **identity resolution** (neutral uses `repo`, not `id`) and
    the **dispatch** (`if source_kind == "neutral": return _collect_neutral(...)`).
 4. `apply_rederive.rederive` — `isinstance` dispatch to `_rederive_neutral`.
-5. `apply_reconcile.resolve_intended_base` — add a `"neutral"` branch reading
+5. `apply_reconcile.resolve_intended_base` — add a `"neutral"` branch returning
    `binding_ref["base_ref"]`.
 6. `apply_rederive._collect_neutral` / `_rederive_neutral` / `neutral_summary` /
    `neutral_proposal_id` — the provider itself.
@@ -94,7 +97,7 @@ class NeutralProviderInputs:
     binding: Mapping[str, Any]        # {repo, transformation, base_ref, bound_paths}
     head_sha: str | None              # live HEAD of the binding's base_ref branch
     actor: Mapping[str, Any] | mutation_plan.Actor
-    registry: mutation_plan.TransformationRegistry | None = None
+    registry: mutation_plan.TransformationRegistry | None = None   # populated like the other 3
 
 ProviderInputs = (PlanSyncProviderInputs | GeneratedProviderInputs
                   | MarketplaceProviderInputs | NeutralProviderInputs)
@@ -107,28 +110,34 @@ def _rederive_neutral(inputs: NeutralProviderInputs) -> RederivedProposal
 
 ### 4.2 Collection (fresh state, no pen)
 
-`_collect_neutral` resolves the target repo's **live `base_ref` HEAD** via the existing
+`_collect_neutral` first validates the binding shape **fail-closed** (`RederiveError`), before any
+subscripting (review F-B): `repo` must be a non-empty string containing exactly one `/` (missing →
+`KeyError`, slashless → unpack `ValueError` — both normalized to `RederiveError`),
+`transformation` must be a non-empty string (missing → `KeyError`), and `base_ref` must be a
+non-empty string. It then resolves the target repo's **live `base_ref` HEAD** via the existing
 `io_seams.gh_api` seam (`(endpoint) -> parsed JSON`, already used by plan-sync — review M5): it
-calls `gh_api(f"repos/{owner}/{name}/branches/{base_ref}")["commit"]["sha"]`. It fails closed
-(`RederiveError`) when `base_ref` is missing/non-string (review M6) or when the HEAD evidence is
-missing. It **never** reads SHAs from the caller-supplied `binding_ref`; `base_ref` is read from the
-binding, the SHA from the live API.
+calls `gh_api(f"repos/{owner}/{name}/branches/{base_ref}")["commit"]["sha"]`, failing closed
+(`RederiveError`) when the HEAD evidence is missing. It **never** reads SHAs from the
+caller-supplied `binding_ref`; `base_ref` is read from the binding, the SHA from the live API.
+Like the other three providers, it also sets `registry=io_seams.registry` on the returned inputs
+(review M2).
 
 ### 4.3 Re-derivation
 
 `_rederive_neutral` builds the proposal from the binding + fresh HEAD:
 
 ```python
-owner, name = binding["repo"].split("/", 1)
+owner, name = binding["repo"].split("/", 1)          # safe: § 4.2 validated repo shape
 id = neutral_proposal_id(binding)          # f"apply-{transformation}-{owner}-{name}"
 mutation_plan.build_proposal(
     id=id,
     selection=[binding["repo"]],
-    transformation=binding["transformation"],
+    transformation=binding["transformation"],        # safe: § 4.2 validated presence
     expected_shas={binding["repo"]: head_sha},
     bound_paths={binding["repo"]: binding["bound_paths"]},
     mutation_policy="allow-listed",
     actor=actor,
+    registry=inputs.registry,                        # threaded like the other 3 (review M2)
 )
 ```
 
@@ -142,32 +151,49 @@ Gating that fires inside this path (all fail-closed):
   (Task 2) — the binding supplies them.
 - `allow_scheduled` is **not** gated here: `apply_driver._actor` hardcodes `mode="interactive"`,
   so scheduled-neutral gating is out of the re-derivation path (consistent with the other three
-  sources — review M7). Scheduled neutral apply is v2.
+  sources). Scheduled neutral apply is v2.
 
 ### 4.4 `finalizer_record`
 
 Neutral transformations have no F8 doc-blob base to advance, so `finalizer_record` is `None`
-(only the generated-artifact provider emits `None` today; marketplace emits `{"base_ref": …}` —
-review M1). The driver's finalizer-persistence path already skips a `None` record; the intended
-base for neutral comes from `binding_ref["base_ref"]` via `resolve_intended_base`, not from a
-finalizer.
+(only the generated-artifact provider emits `None` today; marketplace emits `{"base_ref": …}`).
+The driver's finalizer-persistence path already skips a `None` record; the intended base for
+neutral comes from `binding_ref["base_ref"]` via `resolve_intended_base`, not from a finalizer.
+One cosmetic caveat (review M4): `reconcile_apply`'s `advance_base is None` branch records the
+note "Merge detected; base advance deferred to caller driver" — for pure-neutral there is no such
+caller. The `applied` state is still written correctly; the note text is merely misleading and
+is left as-is (no code change) for the record.
 
 ### 4.5 Recorded-summary identity (no propose phase)
 
 Neutral transformations have no F10 propose run to persist a `{binding, transformation,
-proposal_id}` summary. The apply driver still requires `recorded_summary` so `authorize()` can run
-its full identity + scope check. For neutral, **`run_apply` synthesizes it internally** (review I2):
-when `source_kind == "neutral"` it computes `recorded_summary = neutral_summary(binding_ref)` =
-`{binding: binding["repo"], transformation: binding["transformation"], proposal_id:
-neutral_proposal_id(binding_ref)}` and ignores the `recorded_summary` CLI/kwarg (which is
-meaningful only for the three propose-backed sources).
+proposal_id}` summary. The apply driver still needs a `recorded_summary` so `authorize()` can run
+its full identity + scope check. For neutral, **`run_apply` synthesizes it internally** (review
+I2/F-A), with the contract surface pinned as follows:
+
+- `run_apply`'s `recorded_summary` kwarg becomes optional (`Mapping | None = None`). For the three
+  propose-backed sources it remains effectively required — a `None` summary is rejected by the
+  existing identity/authorize validation before collection. For `source_kind == "neutral"`, the
+  driver computes `recorded_summary = neutral_summary(binding_ref)` =
+  `{binding: binding["repo"], transformation: binding["transformation"], proposal_id:
+  neutral_proposal_id(binding_ref)}` and **ignores any passed value** (a disagreeing passed
+  summary is never read, so disagreement is impossible).
+- **Ordering:** the synthesis happens at the top of `run_apply`, **before** `collect_inputs`,
+  because `collect_inputs` consumes `recorded_summary` for its identity pre-check.
+- **CLI surface:** `--recorded-summary` becomes conditionally required — `required=True` for
+  `plan-sync`/`generated-artifact`/`marketplace-sync`, omitted entirely for `--source-kind
+  neutral` (the driver synthesizes it; the skill passes nothing).
 
 The id formula lives in **one** place — `neutral_proposal_id` — used by both `neutral_summary` and
 `_rederive_neutral`, so the synthesized summary's `proposal_id` can never drift from the
 re-derived proposal's `id`. `_rederive_neutral` returns `RederivedProposal(binding_id=
 binding["repo"], …)` so the `authorize()` binding-match (`recorded_binding == rederived.binding_id`)
-holds. The scope half of `authorize()` (transformation authorized, `selection ⊆ permitted_repos`,
-`bound_paths` within authorization) still applies unchanged — the binding is not self-elevating.
+holds. Because the summary is synthesized at apply time from the same binding the re-derivation
+reads, the **identity half of `authorize()` is a forensic self-consistency check for neutral —
+never a gate** (review M3); only the **scope half** (transformation authorized,
+`selection ⊆ permitted_repos`, `bound_paths` within authorization, `mutation_policy`) is
+load-bearing, and the operator-authored `apply-authorization.yaml` is the real scope gate. The
+binding is not self-elevating.
 
 ### 4.6 Shared-dispatcher branches (review C1/C2)
 
@@ -178,9 +204,17 @@ holds. The scope half of `authorize()` (transformation authorized, `selection �
   § 4.5 identity match (`binding_id == "hiivmind/agent-kernel"`) hold instead of raising.
 - **`collect_inputs` dispatch** — add `if source_kind == "neutral": return _collect_neutral(...)`
   before the existing fallthrough.
-- **`resolve_intended_base`** — add `if source_kind == "neutral": return _required(binding_ref
-  ["base_ref"])` (mirroring the plan-sync fallback), before the final
-  `raise ValueError(f"unknown source_kind: {source_kind}")`.
+- **`resolve_intended_base`** — add a `"neutral"` branch that mirrors the plan-sync fallback's
+  `get`-and-raise shape (review M1: no `_required` helper exists; no bare subscript), before the
+  final `raise ValueError(f"unknown source_kind: {source_kind}")`:
+
+  ```python
+  if source_kind == "neutral":
+      base = binding_ref.get("base_ref")
+      if not isinstance(base, str) or not base:
+          raise ValueError("neutral apply requires a non-empty base_ref")
+      return base
+  ```
 
 ## 5. workspace — binding + authorization
 
@@ -213,10 +247,15 @@ authorizations:
 ```
 
 `apply-authorization.yaml` is consumed verbatim by `apply_authorization.load_authorization` — the
-shape is already pinned by that loader. The `apply-neutral.yaml` binding is consumed by
-`_collect_neutral`; its `repo` is a **single-repo scalar** (review M8): a multi-repo intent is
+shape is already pinned by that loader's typed validation. The `apply-neutral.yaml` binding is
+consumed by `_collect_neutral`; its `repo` is a **single-repo scalar**: a multi-repo intent is
 expressed as multiple bindings in the list, each applied by a separate single-repo run (the
-driver's `selection > 1` guard is the backstop, not the schema).
+driver's `selection > 1` guard is the backstop, not the schema). Unlike `apply-authorization.yaml`,
+`apply-neutral.yaml` has **no dedicated typed loader in v1** (review M6) — the four required keys
+(`repo`, `transformation`, `base_ref`, `bound_paths`) are enforced by `_collect_neutral`'s
+fail-closed gates (§ 4.2) and `build_proposal`'s `bound_paths` check, consistent with how the
+other three providers receive a caller-supplied `binding_ref`. A typed loader is a follow-up if
+the binding shape grows.
 
 ## 6. Determinism & installed-engine gate
 
@@ -237,17 +276,25 @@ driver's `selection > 1` guard is the backstop, not the schema).
    - `_rederive_neutral` returns an allow-listed `RederivedProposal` whose `id`, `selection`,
      `expected_shas`, `bound_paths`, and `mutation_policy` match the binding + HEAD, and whose
      `id == neutral_proposal_id(binding)` (single-source id);
-   - `resolve_intended_base("neutral", {"base_ref": "main"}, None) == "main"`;
-   - fail-closed: missing HEAD evidence → `RederiveError`; missing `base_ref` → `RederiveError`;
-     a non-neutral transformation id (`plan-sync-doc-patch`, `regenerate-corpus-navigate-skill`)
-     → `RederiveError`; empty/missing `bound_paths` → `MutationPlanError` (from `build_proposal`).
+   - `resolve_intended_base("neutral", {"base_ref": "main"}, None) == "main"`, and
+     `resolve_intended_base("neutral", {"base_ref": None}, None)` raises `ValueError`;
+   - fail-closed (each → `RederiveError` unless noted): missing `repo`; slashless `repo`
+     (`"agent-kernel"`); missing `transformation`; missing/non-string `base_ref`; missing HEAD
+     evidence; a non-neutral transformation id (`plan-sync-doc-patch`,
+     `regenerate-corpus-navigate-skill`); empty/missing `bound_paths` → `MutationPlanError` (from
+     `build_proposal`).
+   - a **registry cross-check** (review M5): each id in `NEUTRAL_TRANSFORMATIONS` resolves to a
+     registry entry whose `command_argv` is self-contained (no `nave generate` prefix) and whose
+     `applies_to` carries no `profile:claude-plugin` predicate — so a future mis-classification
+     (e.g. `regenerate-from-template` added to the allowlist) fails the test, not silently at
+     runtime.
 2. **Live proof** (not fixture): `gh-apply` on `hiivmind/agent-kernel` drives the real
    `apply_driver` → `pen_create` → `preflight` → `provision` (remote-base CAS) → `format-python`
    exec → validate → commit → push `pulse/apply/{id}` → open PR → merge-detect (base + head
    verified) → terminal `applied`. Pure-neutral, no base advance.
-3. **Format-drift is a hard requirement** (review M2). `format-python` validates with `kind:
-   none`, but a no-op run (repo already ruff-formatted) fails at the **commit** boundary — nothing
-   to stage → `git commit` nonzero — so it never reaches push/PR/merge-detect and only proves
+3. **Format-drift is a hard requirement.** `format-python` validates with `kind: none`, but a
+   no-op run (repo already ruff-formatted) fails at the **commit** boundary — nothing to stage →
+   `git commit` nonzero — so it never reaches push/PR/merge-detect and only proves
    collect→provision. To exercise the full spine, the proof **must** land a real diff: check
    `agent-kernel` for genuine ruff drift, and if none, introduce a deliberate formatting
    inconsistency in a scratch clone for the proof (never committed upstream to `agent-kernel`).
@@ -261,8 +308,10 @@ driver's `selection > 1` guard is the backstop, not the schema).
   this PR's proof scope.
 - **`regenerate-from-template`** is **not** a neutral-provider transformation: its argv runs
   `nave generate --from-template` under the F7 generator-dispatch machinery, so it belongs to the
-  `generated-artifact` source (review M3). Excluded from `NEUTRAL_TRANSFORMATIONS`.
+  `generated-artifact` source. Excluded from `NEUTRAL_TRANSFORMATIONS`.
 - **F4 fleet-wide dependency-coherence apply** remains out of scope (unchanged from the wiring
   spec); `format-python` is the neutral proof, not the coherence use case.
 - **Tool-version pinning** (a ruff/npm/mkdocs version field on the binding) is a follow-up if a
   real non-determinism shows up; v1 relies on the pen's installed tool.
+- **Typed loader for `apply-neutral.yaml`** is a follow-up (§ 5); v1 enforces the four keys via
+  fail-closed gates.

--- a/docs/superpowers/specs/2026-08-14-apply-mode-workspace-enrollment-design.md
+++ b/docs/superpowers/specs/2026-08-14-apply-mode-workspace-enrollment-design.md
@@ -1,0 +1,213 @@
+# Apply-Mode Workspace Enrollment — Design Spec
+
+**Date:** 2026-08-14
+**Status:** Approved (brainstorm) — pending implementation plan.
+**Origin:** `docs/superpowers/specs/2026-07-30-apply-mode-production-wiring-design.md` § 5F
+("Workspace enrollment (`hiivmind/hiivmind-workspace`) — gated on an installed engine"), and the
+plan follow-up of `docs/superpowers/plans/2026-07-30-apply-mode-pulse-wiring.md` ("Workspace
+enrollment PR: `ApplyAuthorization` policy + a real neutral proposal source, gated on the
+installed engine").
+
+**Read alongside:** the production-wiring spec (§ 4 authorization model, § 5A–E components),
+`lib/pulse/scripts/apply_rederive.py` (the re-derivation provider registry), and
+`docs/backlogs/README.md` (the cross-repo dependency map — this is a two-repo item).
+
+---
+
+## 1. Problem — the neutral source gap
+
+The apply driver (`apply_driver.run_apply`) re-derives a proposal from **fresh source state**
+through `apply_rederive` before it authorizes or mutates. But `apply_rederive.SOURCE_KINDS` is:
+
+```
+("plan-sync", "generated-artifact", "marketplace-sync")
+```
+
+There is **no neutral source kind**. The neutral transformations in the registry
+(`format-python`, `refresh-node-lockfile`, `regenerate-docs-index`, `regenerate-from-template`)
+are executable entries with no propose driver and no re-derivation provider, so `run_apply`
+cannot mint an allow-listed proposal for any of them today. The workspace
+(`hiivmind/hiivmind-workspace`, a.k.a. `~/git/hiivmind/.hiivmind/github/`) also carries **no**
+`ApplyAuthorization` policy and **no** binding files of any kind.
+
+F11's "production wiring" therefore stalls one step short of runnable: the driver and the Nave
+verbs are merged, but nothing tells apply-mode *what* to land. This closes that gap with the
+flagship neutral use case.
+
+## 2. Decisions (settled in brainstorm)
+
+1. **New neutral provider** — a 4th source kind (`"neutral"`) in `apply_rederive`, not a reuse of
+   `generated-artifact` and not a hand-minted proposal. It is complete and reusable for every
+   neutral transformation.
+2. **Proof transformation** — `format-python` (`ruff format .`). It is deterministic (same base +
+   ruff version → same output), which satisfies the v1 crash-resume "reset + re-exec" contract,
+   and it is genuinely neutral (`applies_to: profile:python`, no `profile:claude-plugin`
+   predicate).
+3. **Proof repo** — `hiivmind/agent-kernel` (an external Python app repo: `src/ tests/ examples/`,
+   `pyproject.toml`). External to both the corpus and the plugin, so the neutrality proof is not
+   self-referential. `hiivmind/agno-oracle-demo` is the fallback (same shape).
+4. **Pure-neutral → terminal at merge.** `format-python` has no base to advance; the merge gate is
+   the end of the run (`applied`), no F8 bookkeeping PR.
+5. **`mutation_plan.build_proposal` is the neutral builder.** Neutral transformations have no
+   source-specific decision logic (that is the point); the proposal is "binding + live HEAD".
+   The other three sources keep their real, source-specific builders untouched.
+
+## 3. Architecture — two repos
+
+```
+pulse-gh (code):     apply_rederive gains SOURCE_KINDS "neutral" + provider
+workspace (config):  apply-neutral.yaml (binding) + apply-authorization.yaml (policy)
+```
+
+The re-derivation registry already separates *collection* (`collect_inputs` → a typed provider
+inputs dataclass) from *re-derivation* (`rederive` → the real builder). The neutral provider
+follows that exact shape; no new machinery.
+
+## 4. pulse-gh — the neutral provider
+
+### 4.1 Interfaces
+
+```python
+# apply_rederive.py
+SOURCE_KINDS = ("plan-sync", "generated-artifact", "marketplace-sync", "neutral")
+
+@dataclass(frozen=True)
+class NeutralProviderInputs:
+    binding: Mapping[str, Any]        # the neutral binding (repo, transformation, bound_paths, base_ref)
+    head_sha: str | None              # live HEAD of the binding's base_ref branch
+    actor: Mapping[str, Any] | mutation_plan.Actor
+    registry: mutation_plan.TransformationRegistry | None = None
+
+ProviderInputs = (PlanSyncProviderInputs | GeneratedProviderInputs
+                  | MarketplaceProviderInputs | NeutralProviderInputs)
+
+def _collect_neutral(binding_ref, actor, io_seams) -> NeutralProviderInputs
+def _rederive_neutral(inputs: NeutralProviderInputs) -> RederivedProposal
+```
+
+### 4.2 Collection (fresh state, no pen)
+
+`_collect_neutral` resolves the target repo's **live `base_ref` HEAD** via the existing
+`io_seams.runner` seam (the same `(argv, cwd) -> CompletedProcess` shape every source uses). It
+makes a direct `gh api repos/{owner}/{name}/branches/{base_ref}` call for that branch's `sha` —
+it does **not** reuse `marketplace_sync_run.fetch_remote_evidence` (that fetches marketplace
+releases/docs, not a neutral repo's HEAD). It **never** reads SHAs from the caller-supplied
+`binding_ref`, and it fails closed (`RederiveError`) when the HEAD evidence is missing.
+
+### 4.3 Re-derivation
+
+`_rederive_neutral` builds the proposal from the binding + fresh HEAD:
+
+```python
+mutation_plan.build_proposal(
+    id=f"apply-{transformation}-{owner}-{name}",  # deterministic from (repo, transformation)
+    selection=[binding["repo"]],
+    transformation=binding["transformation"],
+    expected_shas={binding["repo"]: head_sha},
+    bound_paths={binding["repo"]: binding["bound_paths"]},
+    mutation_policy="allow-listed",
+    actor=actor,
+)
+```
+
+Gating that fires inside this path (all fail-closed):
+
+- the transformation id must exist in the registry and be **neutral** (reject plan-sync,
+  generated, marketplace, and the F9 overlay ids);
+- `build_proposal` already enforces exact, non-empty `bound_paths` coverage for allow-listed
+  (Task 2) — the binding supplies them;
+- `allow_scheduled` gating is left to `build_proposal`/the registry, as for the other sources.
+
+### 4.4 `finalizer_record`
+
+Neutral transformations have no F8 doc-blob base to advance, so `finalizer_record` is `None`
+(exactly as the existing generated/marketplace providers emit). No change to the driver's
+finalizer-persistence path (it already skips a `None` record).
+
+### 4.5 Recorded-summary identity (no propose phase)
+
+Neutral transformations have no F10 propose run to persist a `{binding, transformation,
+proposal_id}` summary. The apply driver still requires `recorded_summary` so `authorize()` can run
+its full identity + scope check. For neutral, `recorded_summary` is **synthesized from the
+binding**: `{binding: binding["repo"], transformation: binding["transformation"], proposal_id:
+<the deterministic id above>}`. `_rederive_neutral` returns `RederivedProposal(binding_id=
+binding["repo"], ...)` so the `authorize()` binding-match (`recorded_binding ==
+rederived.binding_id`) holds, and the deterministic id makes `proposal_id` stable across
+re-derivation. The scope half of `authorize()` (transformation authorized, `selection ⊆
+permitted_repos`, `bound_paths` within authorization) still applies unchanged — the binding is not
+self-elevating.
+
+## 5. workspace — binding + authorization
+
+Two new config files in the workspace repo (`hiivmind/hiivmind-workspace`, flow `feature → main`):
+
+```yaml
+# apply-neutral.yaml
+bindings:
+  - repo: hiivmind/agent-kernel
+    transformation: format-python
+    base_ref: main
+    bound_paths:
+      - src/**
+      - tests/**
+      - examples/**
+```
+
+```yaml
+# apply-authorization.yaml
+authorizations:
+  format-python:
+    mutation_policy: allow-listed
+    permitted_repos:
+      - hiivmind/agent-kernel
+    bound_paths:
+      hiivmind/agent-kernel:
+        - src/**
+        - tests/**
+        - examples/**
+```
+
+`apply-authorization.yaml` is consumed verbatim by `apply_authorization.load_authorization` — the
+shape is already pinned by that loader (`authorizations.<id> = {mutation_policy, permitted_repos,
+bound_paths}`). The `apply-neutral.yaml` binding is consumed by the new `_collect_neutral`.
+
+## 6. Determinism & installed-engine gate
+
+- **Determinism.** `ruff format .` is deterministic given a pinned ruff version, so a crash
+  between `pen_exec` and the journal's completion receipt recovers by reset + re-exec (v1
+  contract). The neutral binding does **not** carry a tool version pin; the pen's installed ruff
+  version is the operative pin (same stance as `refresh-node-lockfile`'s npm).
+- **Installed-engine gate.** The enrollment PR is gated on the § 3 Nave verbs **and** pulse-gh
+  being locally installed (`uv`-installed, per the single-developer context). This is a
+  **deployment precondition**, verified before the live proof run — not a code deliverable. The
+  live proof fails closed at the capability handshake if Nave is stale/absent.
+
+## 7. Acceptance
+
+1. **pulse-gh unit tests** (new `test_apply_rederive_neutral` cases):
+   - `_collect_neutral` returns `NeutralProviderInputs` with live HEAD for a bound repo;
+   - `_rederive_neutral` returns an allow-listed `RederivedProposal` whose `selection`,
+     `expected_shas`, `bound_paths`, and `mutation_policy` match the binding + HEAD;
+   - fail-closed: missing HEAD evidence → `RederiveError`; a non-neutral transformation id
+     (e.g. `plan-sync-doc-patch`) → `RederiveError`; empty/missing `bound_paths` →
+     `MutationPlanError` (from `build_proposal`).
+2. **Live proof** (not fixture): `gh-apply` on `hiivmind/agent-kernel` drives the real
+   `apply_driver` → `pen_create` → `preflight` → `provision` (remote-base CAS) → `format-python`
+   exec → validate → commit → push `pulse/apply/{id}` → open PR → merge-detect (base + head
+   verified) → terminal `applied`. Pure-neutral, no base advance.
+3. **Format-drift note.** `format-python` validates with `kind: none`, so a repo already
+   ruff-formatted yields a zero-diff branch (the wiring still proves, but lands nothing). During
+   implementation, check `agent-kernel` for real drift; if none, introduce a deliberate
+   formatting inconsistency in a scratch clone for the proof (never committed to `agent-kernel`).
+
+## 8. Scope notes & deferrals
+
+- **Multi-repo apply** stays v2 — the binding is a list for shape symmetry, but v1 applies one
+  repo per run (the driver already blocks `selection > 1` with "multi-repo apply is v2").
+- **`refresh-node-lockfile` / `regenerate-docs-index` / `regenerate-from-template`** become
+  available through the same `neutral` provider with no further code — only a binding + an
+  `apply-authorization` entry each. Out of this PR's proof scope.
+- **F4 fleet-wide dependency-coherence apply** remains out of scope (unchanged from the wiring
+  spec); `format-python` is the neutral proof, not the coherence use case.
+- **Tool-version pinning** (a ruff/npm/mkdocs version field on the binding) is a follow-up if a
+  real non-determinism shows up; v1 relies on the pen's installed tool.

--- a/lib/pulse/scripts/apply_driver.py
+++ b/lib/pulse/scripts/apply_driver.py
@@ -45,6 +45,38 @@ def _default_gh_api(path: str):
         return None
 
 
+def _expand_bound_globs(clone_dir: str, patterns: tuple[str, ...]) -> tuple[str, ...]:
+    """Expand glob `bound_paths` to the concrete repo-relative paths they cover.
+
+    Nave's commit gate is exact-path: a dirty path must literally appear in the
+    request's `paths`. The proposal carries glob patterns (`src/**`); expanding
+    them here (with the same fnmatch semantics as the paths_changed validator)
+    yields the concrete allow-list the commit request needs. Tracked + untracked
+    non-ignored files only — the same surface `git status --porcelain` reports
+    dirty, so anything Nave can flag is either covered by a pattern or fails
+    closed.
+    """
+    from fnmatch import fnmatchcase
+    import subprocess
+
+    root = Path(clone_dir)
+    listed: set[str] = set()
+    for args in (["ls-files"], ["ls-files", "--others", "--exclude-standard"]):
+        res = subprocess.run(
+            ["git", "-C", str(root), *args], capture_output=True, text=True
+        )
+        if res.returncode == 0:
+            listed.update(res.stdout.splitlines())
+    matched = []
+    for path in sorted(listed):
+        if any(
+            fnmatchcase(path, pattern) if "*" in pattern else path == pattern
+            for pattern in patterns
+        ):
+            matched.append(path)
+    return tuple(matched)
+
+
 def _entry(inputs: apply_rederive.ProviderInputs, workspace: str, transformation: str):
     """Use the provider's registry, then the same workspace/template fallback as run callers."""
     registry = getattr(inputs, "registry", None)
@@ -338,8 +370,13 @@ def run_apply(*, source_kind, binding_ref, recorded_summary=None, authorization_
 
             resolve_run.renew_lease(ledger_path, step_id, actor_id, token)
             journal.begin(repo, "committed", token)
+            bound_paths = {
+                r: _expand_bound_globs(clone_paths[r], proposal.bound_paths.get(r, ()))
+                for r in proposal.selection
+            }
             outcomes = apply_phases.commit_phase(
-                ops, proposal, f"pulse-apply {proposal.id} by {actor.gh_login}@{actor.machine}"
+                ops, proposal, f"pulse-apply {proposal.id} by {actor.gh_login}@{actor.machine}",
+                bound_paths=bound_paths,
             )
             if outcomes[repo].get("state") != "ok":
                 resolve_run.renew_lease(ledger_path, step_id, actor_id, token)

--- a/lib/pulse/scripts/apply_driver.py
+++ b/lib/pulse/scripts/apply_driver.py
@@ -31,6 +31,20 @@ def _actor(actor_id: str) -> mutation_plan.Actor:
     return mutation_plan.Actor(login, machine, "interactive")
 
 
+def _default_gh_api(path: str):
+    """Production `gh api` seam — parsed JSON, or None on any failure."""
+    import json
+    import subprocess
+
+    res = subprocess.run(["gh", "api", path], capture_output=True, text=True)
+    if res.returncode != 0:
+        return None
+    try:
+        return json.loads(res.stdout)
+    except ValueError:
+        return None
+
+
 def _entry(inputs: apply_rederive.ProviderInputs, workspace: str, transformation: str):
     """Use the provider's registry, then the same workspace/template fallback as run callers."""
     registry = getattr(inputs, "registry", None)
@@ -101,8 +115,8 @@ def _persist_finalizer(result_path, finalizer_record) -> None:
     path.write_text(yaml.safe_dump(finalizer_record, sort_keys=False))
 
 
-def run_apply(*, source_kind, binding_ref, recorded_summary, authorization_path, ledger_path,
-              step_id, actor_id, runner, gh_ops, result_path, workspace) -> dict:
+def run_apply(*, source_kind, binding_ref, recorded_summary=None, authorization_path, ledger_path,
+              step_id, actor_id, runner, gh_api=None, gh_ops, result_path, workspace) -> dict:
     """Run one single-repository apply; return apply-status or repo-mutation."""
     proposal = None
     proposal_digest = None
@@ -110,9 +124,15 @@ def run_apply(*, source_kind, binding_ref, recorded_summary, authorization_path,
     actor = _actor(actor_id)
 
     try:
+        if source_kind == "neutral":
+            recorded_summary = apply_rederive.neutral_summary(binding_ref)
+        elif not recorded_summary:
+            raise apply_rederive.RederiveError(
+                f"recorded_summary is required for source_kind={source_kind!r}"
+            )
         inputs = apply_rederive.collect_inputs(
             source_kind, binding_ref, recorded_summary, actor=actor,
-            io_seams=apply_rederive.IoSeams(runner=runner, registry=None),
+            io_seams=apply_rederive.IoSeams(runner=runner, gh_api=gh_api, registry=None),
         )
         rederived = apply_rederive.rederive(inputs)
         proposal = rederived.proposal
@@ -352,7 +372,8 @@ def main(argv=None):
     parser = argparse.ArgumentParser(description="Run one apply-mode proposal")
     parser.add_argument("--source-kind", required=True)
     parser.add_argument("--binding-ref", required=True, help="JSON object")
-    parser.add_argument("--recorded-summary", required=True, help="JSON {binding, transformation, proposal_id}")
+    parser.add_argument("--recorded-summary", required=False, default=None,
+                        help="JSON {binding, transformation, proposal_id}; omit for --source-kind neutral")
     parser.add_argument("--authorization", required=True)
     parser.add_argument("--ledger", required=True)
     parser.add_argument("--step", required=True)
@@ -362,16 +383,20 @@ def main(argv=None):
     parser.add_argument("--fixtures", default=None, help="optional PULSE_NAVE_FIXTURES root")
     args = parser.parse_args(argv)
 
+    if args.source_kind != "neutral" and not args.recorded_summary:
+        parser.error("--recorded-summary is required unless --source-kind is neutral")
+
     runner = nave_adapter.NaveRunner(fixtures=args.fixtures)
     result = run_apply(
         source_kind=args.source_kind,
         binding_ref=json.loads(args.binding_ref),
-        recorded_summary=json.loads(args.recorded_summary),
+        recorded_summary=json.loads(args.recorded_summary) if args.recorded_summary else None,
         authorization_path=args.authorization,
         ledger_path=args.ledger,
         step_id=args.step,
         actor_id=args.actor,
         runner=runner,
+        gh_api=_default_gh_api,
         gh_ops=apply_reconcile.GhCliOps(),
         result_path=args.result,
         workspace=args.workspace,

--- a/lib/pulse/scripts/apply_phases.py
+++ b/lib/pulse/scripts/apply_phases.py
@@ -112,8 +112,10 @@ def validate_phase(entry, reader, proposal) -> dict[str, dict]:
     }
 
 
-def commit_phase(apply_ops, proposal, message) -> dict[str, dict]:
-    raw = _by_repo(apply_ops.commit_repos(message, proposal.bound_paths))
+def commit_phase(apply_ops, proposal, message, bound_paths=None) -> dict[str, dict]:
+    if bound_paths is None:
+        bound_paths = proposal.bound_paths
+    raw = _by_repo(apply_ops.commit_repos(message, bound_paths))
     outcomes = {}
     for repo in proposal.selection:
         item = raw.get(repo)

--- a/lib/pulse/scripts/apply_reconcile.py
+++ b/lib/pulse/scripts/apply_reconcile.py
@@ -234,6 +234,12 @@ def resolve_intended_base(
             "cannot resolve intended base for generated-artifact: no branch"
         )
 
+    if source_kind == "neutral":
+        base = binding_ref.get("base_ref")
+        if not isinstance(base, str) or not base:
+            raise ValueError("cannot resolve intended base for neutral: no base_ref")
+        return base
+
     raise ValueError(f"unknown source_kind: {source_kind}")
 
 

--- a/lib/pulse/scripts/apply_rederive.py
+++ b/lib/pulse/scripts/apply_rederive.py
@@ -41,7 +41,13 @@ from lib.pulse.scripts import (
     plan_sync_snapshot,
 )
 
-SOURCE_KINDS = ("plan-sync", "generated-artifact", "marketplace-sync")
+SOURCE_KINDS = ("plan-sync", "generated-artifact", "marketplace-sync", "neutral")
+
+# Neutral transformations are the standalone, self-contained executable
+# entries with no propose driver. `regenerate-from-template` (a `nave
+# generate --from-template` argv) belongs to generated-artifact, not here;
+# the F9 overlays are profile:claude-plugin, never neutral.
+NEUTRAL_TRANSFORMATIONS = ("format-python", "refresh-node-lockfile", "regenerate-docs-index")
 
 
 class RederiveError(ValueError):
@@ -120,7 +126,23 @@ class MarketplaceProviderInputs:
     registry: mutation_plan.TransformationRegistry | None = None
 
 
-ProviderInputs = PlanSyncProviderInputs | GeneratedProviderInputs | MarketplaceProviderInputs
+@dataclass(frozen=True)
+class NeutralProviderInputs:
+    """Fresh neutral evidence: `binding` is the caller-supplied `binding_ref`
+    (validated); `head_sha` is the live HEAD of the binding's `base_ref` branch."""
+
+    binding: Mapping[str, Any]
+    head_sha: str | None
+    actor: Mapping[str, Any] | mutation_plan.Actor
+    registry: mutation_plan.TransformationRegistry | None = None
+
+
+ProviderInputs = (
+    PlanSyncProviderInputs
+    | GeneratedProviderInputs
+    | MarketplaceProviderInputs
+    | NeutralProviderInputs
+)
 
 
 @dataclass(frozen=True)
@@ -138,6 +160,47 @@ class RederivedProposal:
     proposal: mutation_plan.Proposal
     source_kind: str
     finalizer_record: dict[str, Any] | None
+
+
+def _validate_neutral_binding(binding: Mapping[str, Any]) -> tuple[str, str]:
+    """Validate a neutral binding's `repo` + `transformation`; return (owner, name).
+
+    Raises `RederiveError` (never KeyError/ValueError) so a malformed binding
+    blocks (the driver turns it into a `blocked` result), never crashes.
+    """
+    repo = binding.get("repo")
+    if not isinstance(repo, str) or not repo or repo.count("/") != 1:
+        raise RederiveError(
+            f"apply_rederive: neutral binding requires repo 'owner/name', got {repo!r}"
+        )
+    transformation = binding.get("transformation")
+    if not isinstance(transformation, str) or not transformation:
+        raise RederiveError(
+            "apply_rederive: neutral binding requires a non-empty transformation, "
+            f"got {transformation!r}"
+        )
+    return repo.split("/", 1)
+
+
+def neutral_proposal_id(binding: Mapping[str, Any]) -> str:
+    """Deterministic neutral proposal id: `apply-{transformation}-{owner}-{name}`.
+
+    Single source of the id, shared by `neutral_summary` and `_rederive_neutral`
+    so the synthesized `recorded_summary.proposal_id` can never drift from the
+    re-derived proposal's id.
+    """
+    owner, name = _validate_neutral_binding(binding)
+    return f"apply-{binding['transformation']}-{owner}-{name}"
+
+
+def neutral_summary(binding: Mapping[str, Any]) -> dict[str, str]:
+    """Synthesize the `recorded_summary` for a neutral apply (no propose phase)."""
+    proposal_id = neutral_proposal_id(binding)  # validates repo + transformation first
+    return {
+        "binding": binding["repo"],
+        "transformation": binding["transformation"],
+        "proposal_id": proposal_id,
+    }
 
 
 def collect_inputs(

--- a/lib/pulse/scripts/apply_rederive.py
+++ b/lib/pulse/scripts/apply_rederive.py
@@ -390,6 +390,8 @@ def rederive(inputs: ProviderInputs) -> RederivedProposal:
         return _rederive_generated(inputs)
     if isinstance(inputs, MarketplaceProviderInputs):
         return _rederive_marketplace(inputs)
+    if isinstance(inputs, NeutralProviderInputs):
+        return _rederive_neutral(inputs)
     raise RederiveError(f"apply_rederive: unsupported provider inputs: {type(inputs)!r}")
 
 
@@ -510,4 +512,35 @@ def _rederive_marketplace(inputs: MarketplaceProviderInputs) -> RederivedProposa
         proposal=proposal,
         source_kind="marketplace-sync",
         finalizer_record={"base_ref": inputs.default_branch},
+    )
+
+
+def _rederive_neutral(inputs: NeutralProviderInputs) -> RederivedProposal:
+    binding = inputs.binding
+    transformation = binding.get("transformation")
+    if transformation not in NEUTRAL_TRANSFORMATIONS:
+        raise RederiveError(
+            f"apply_rederive: transformation {transformation!r} is not a neutral transformation"
+        )
+    head_sha = inputs.head_sha
+    if not isinstance(head_sha, str) or not head_sha:
+        raise RederiveError("apply_rederive: neutral requires a resolved head_sha")
+    try:
+        proposal = mutation_plan.build_proposal(
+            id=neutral_proposal_id(binding),
+            selection=[binding["repo"]],
+            transformation=transformation,
+            expected_shas={binding["repo"]: head_sha},
+            actor=inputs.actor,
+            mutation_policy="allow-listed",
+            bound_paths={binding["repo"]: binding["bound_paths"]},
+            registry=inputs.registry,
+        )
+    except mutation_plan.MutationPlanError as exc:
+        raise RederiveError(f"apply_rederive: neutral build failed: {exc}") from exc
+    return RederivedProposal(
+        binding_id=str(binding["repo"]),
+        proposal=proposal,
+        source_kind="neutral",
+        finalizer_record=None,
     )

--- a/lib/pulse/scripts/apply_rederive.py
+++ b/lib/pulse/scripts/apply_rederive.py
@@ -227,7 +227,9 @@ def collect_inputs(
         raise RederiveError(f"apply_rederive: unknown source_kind: {source_kind!r}")
 
     binding_id = binding_ref.get(
-        "plugin_id" if source_kind == "marketplace-sync" else "id"
+        "repo"
+        if source_kind == "neutral"
+        else ("plugin_id" if source_kind == "marketplace-sync" else "id")
     )
     recorded_binding = recorded_summary.get("binding")
     if recorded_binding is not None and binding_id != recorded_binding:
@@ -241,6 +243,8 @@ def collect_inputs(
         return _collect_plan_sync(binding_ref, actor, io_seams)
     if source_kind == "generated-artifact":
         return _collect_generated(binding_ref, actor, io_seams)
+    if source_kind == "neutral":
+        return _collect_neutral(binding_ref, actor, io_seams)
     return _collect_marketplace(binding_ref, actor, io_seams)
 
 
@@ -328,6 +332,42 @@ def _collect_marketplace(
         drift=drift,
         head_sha=head_sha,
         default_branch=default_branch,
+        actor=actor,
+        registry=io_seams.registry,
+    )
+
+
+def _collect_neutral(
+    binding_ref: Mapping[str, Any],
+    actor: Mapping[str, Any] | mutation_plan.Actor,
+    io_seams: IoSeams,
+) -> NeutralProviderInputs:
+    owner, name = _validate_neutral_binding(binding_ref)  # repo + transformation
+    base_ref = binding_ref.get("base_ref")
+    if not isinstance(base_ref, str) or not base_ref:
+        raise RederiveError(
+            f"apply_rederive: neutral binding requires a non-empty base_ref, got {base_ref!r}"
+        )
+    if io_seams.gh_api is None:
+        raise RederiveError("apply_rederive: neutral requires io_seams.gh_api")
+    try:
+        payload = io_seams.gh_api(f"repos/{owner}/{name}/branches/{base_ref}")
+    except Exception as exc:
+        raise RederiveError(
+            f"apply_rederive: neutral HEAD fetch failed for {owner}/{name}: {exc}"
+        ) from exc
+    head_sha = None
+    if isinstance(payload, Mapping):
+        commit = payload.get("commit")
+        if isinstance(commit, Mapping) and isinstance(commit.get("sha"), str):
+            head_sha = commit["sha"] or None
+    if head_sha is None:
+        raise RederiveError(
+            f"apply_rederive: neutral could not resolve HEAD for {owner}/{name}@{base_ref}"
+        )
+    return NeutralProviderInputs(
+        binding=binding_ref,
+        head_sha=head_sha,
         actor=actor,
         registry=io_seams.registry,
     )

--- a/lib/pulse/scripts/tests/test_apply_driver.py
+++ b/lib/pulse/scripts/tests/test_apply_driver.py
@@ -298,3 +298,31 @@ def test_run_apply_rejects_missing_summary_for_non_neutral(tmp_path, monkeypatch
     )
     assert out["state"] == "blocked"
     assert "recorded_summary" in out["reason"]
+
+
+def test_expand_bound_globs_matches_tracked_and_untracked(tmp_path):
+    (tmp_path / "src").mkdir()
+    (tmp_path / "examples").mkdir()
+    (tmp_path / "src").joinpath("a.py").write_text("x")
+    (tmp_path / "src").joinpath("b.py").write_text("y")
+    (tmp_path / "examples").joinpath("spinner.py").write_text("z")
+    (tmp_path / "src").joinpath("ignored.txt").write_text("i")
+    (tmp_path / ".gitignore").write_text("src/ignored.txt\n")
+    import subprocess
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "add", "src", "examples", ".gitignore"], check=True)
+    subprocess.run(["git", "-C", str(tmp_path), "commit", "-q", "-m", "seed", "--no-verify"],
+                   check=True, env={**__import__("os").environ,
+                                    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+                                    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"})
+    subprocess.run(["git", "-C", str(tmp_path), "check-ignore", "-q", "src/ignored.txt"], check=False)
+    (tmp_path / "src").joinpath("untracked.py").write_text("u")
+
+    expanded = apply_driver._expand_bound_globs(
+        str(tmp_path), ("src/**", "examples/**")
+    )
+    assert "src/a.py" in expanded
+    assert "src/b.py" in expanded
+    assert "src/untracked.py" in expanded
+    assert "examples/spinner.py" in expanded
+    assert not any("ignored" in p for p in expanded)

--- a/lib/pulse/scripts/tests/test_apply_driver.py
+++ b/lib/pulse/scripts/tests/test_apply_driver.py
@@ -214,3 +214,87 @@ def test_resume_from_completed_push_reopens_pr_from_durable_evidence(tmp_path, m
     assert result["state"] == "pr_opened"
     assert result["pushed_sha"] == "commit"
     assert "commit" not in ops.calls and "push" not in ops.calls
+
+
+def test_run_apply_neutral_synthesizes_summary_and_threads_gh_api(tmp_path, monkeypatch):
+    from lib.pulse.scripts.apply_authorization import AuthorizationError
+
+    captured = {}
+
+    def fake_collect(source_kind, binding_ref, recorded_summary, *, actor, io_seams):
+        captured["recorded_summary"] = recorded_summary
+        captured["gh_api"] = io_seams.gh_api
+        return SimpleNamespace(registry=None)
+
+    def fake_rederive(inputs):
+        prop = mutation_plan.build_proposal(
+            id="apply-format-python-hiivmind-agent-kernel",
+            selection=["hiivmind/agent-kernel"], transformation="format-python",
+            expected_shas={"hiivmind/agent-kernel": "e" * 40},
+            actor={"gh_login": "octocat", "machine": "host", "mode": "interactive"},
+            mutation_policy="allow-listed",
+            bound_paths={"hiivmind/agent-kernel": ("src/**",)},
+        )
+        return apply_rederive.RederivedProposal("hiivmind/agent-kernel", prop, "neutral", None)
+
+    monkeypatch.setattr(apply_driver.apply_rederive, "collect_inputs", fake_collect)
+    monkeypatch.setattr(apply_driver.apply_rederive, "rederive", fake_rederive)
+    monkeypatch.setattr(apply_driver.apply_authorization, "load_authorization", lambda *a: object())
+    monkeypatch.setattr(apply_driver.apply_authorization, "authorization_digest", lambda a: "v1|" + "b" * 64)
+    monkeypatch.setattr(apply_driver.apply_authorization, "authorize",
+                        lambda *a: (_ for _ in ()).throw(AuthorizationError("stop")))
+
+    ledger = tmp_path / "ledger.yaml"
+    ledger.write_text(yaml.safe_dump({
+        "ledger_version": 1, "run_id": "r", "workflow": "w", "status": "running",
+        "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+        "actor": {"gh_login": "octocat", "machine": "host"}, "params": {},
+        "repos": ["hiivmind/agent-kernel"],
+        "steps": [{"id": "step", "repo": "hiivmind/agent-kernel", "depends_on": [],
+                   "gate": None, "status": "pending", "notes": []}],
+    }, sort_keys=False))
+    result = tmp_path / "result.yaml"
+    fake_gh_api = lambda path: {"commit": {"sha": "e" * 40}}
+
+    out = apply_driver.run_apply(
+        source_kind="neutral",
+        binding_ref={"repo": "hiivmind/agent-kernel", "transformation": "format-python",
+                     "base_ref": "main", "bound_paths": ["src/**"]},
+        recorded_summary=None,
+        authorization_path=tmp_path / "auth.yaml", ledger_path=ledger, step_id="step",
+        actor_id="octocat@host", runner=RecordingRunner(), gh_api=fake_gh_api,
+        gh_ops=FakeGhOps(), result_path=result, workspace=str(tmp_path),
+    )
+
+    assert out["state"] == "blocked"
+    assert captured["recorded_summary"] == {
+        "binding": "hiivmind/agent-kernel",
+        "transformation": "format-python",
+        "proposal_id": "apply-format-python-hiivmind-agent-kernel",
+    }
+    assert captured["gh_api"] is fake_gh_api
+
+
+def test_run_apply_rejects_missing_summary_for_non_neutral(tmp_path, monkeypatch):
+    monkeypatch.setattr(apply_driver.apply_rederive, "collect_inputs",
+                        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not collect")))
+    ledger = tmp_path / "ledger.yaml"
+    ledger.write_text(yaml.safe_dump({
+        "ledger_version": 1, "run_id": "r", "workflow": "w", "status": "running",
+        "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
+        "actor": {"gh_login": "octocat", "machine": "host"}, "params": {},
+        "repos": ["acme/widget"],
+        "steps": [{"id": "step", "repo": "acme/widget", "depends_on": [],
+                   "gate": None, "status": "pending", "notes": []}],
+    }, sort_keys=False))
+    result = tmp_path / "result.yaml"
+    out = apply_driver.run_apply(
+        source_kind="generated-artifact",
+        binding_ref={"id": "binding", "branch": "main"},
+        recorded_summary=None,
+        authorization_path=tmp_path / "auth.yaml", ledger_path=ledger, step_id="step",
+        actor_id="octocat@host", runner=RecordingRunner(), gh_ops=FakeGhOps(),
+        result_path=result, workspace=str(tmp_path),
+    )
+    assert out["state"] == "blocked"
+    assert "recorded_summary" in out["reason"]

--- a/lib/pulse/scripts/tests/test_apply_phases.py
+++ b/lib/pulse/scripts/tests/test_apply_phases.py
@@ -45,8 +45,28 @@ def test_exec_blocks_missing_tool_before_exec(monkeypatch):
 class Ops:
     def __init__(self, result): self.result, self.calls = result, []
     def provision_branch(self, branch, bases): self.calls.append((branch, bases)); return self.result
+    def commit_repos(self, message, bound_paths): self.calls.append((message, bound_paths)); return self.result
     def push_repos(self, branch): self.calls.append(branch); return self.result
     def reset_repos(self, branch, shas): self.calls.append((branch, shas)); return {}
+
+
+def test_commit_phase_passes_expanded_bound_paths():
+    ops = Ops({"acme/api": {"state": "ok", "local_commit_sha": "c1"}, "acme/web": {"state": "ok", "local_commit_sha": "c2"}})
+    result = apply_phases.commit_phase(
+        ops, proposal(), "msg",
+        bound_paths={"acme/api": ("src/a.py", "src/b.py"), "acme/web": ("src/c.py",)},
+    )
+    assert result["acme/api"]["state"] == "ok"
+    message, passed = ops.calls[0]
+    assert message == "msg"
+    assert passed == {"acme/api": ("src/a.py", "src/b.py"), "acme/web": ("src/c.py",)}
+
+
+def test_commit_phase_defaults_to_proposal_bound_paths():
+    ops = Ops({"acme/api": {"state": "ok", "local_commit_sha": "c1"}, "acme/web": {"state": "ok", "local_commit_sha": "c2"}})
+    apply_phases.commit_phase(ops, proposal(), "msg")
+    message, passed = ops.calls[0]
+    assert passed == proposal().bound_paths
 
 
 def provision_item(repo, **changes):

--- a/lib/pulse/scripts/tests/test_apply_reconcile.py
+++ b/lib/pulse/scripts/tests/test_apply_reconcile.py
@@ -1421,3 +1421,14 @@ def test_merge_detected_gate_evaluator_fail_closed(tmp_path):
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
     assert satisfied is False
     assert "observed_head_sha" in detail
+
+
+def test_resolve_intended_base_neutral_uses_binding_base_ref():
+    assert apply_reconcile.resolve_intended_base(
+        "neutral", {"base_ref": "main"}, None
+    ) == "main"
+
+
+def test_resolve_intended_base_neutral_rejects_missing_base_ref():
+    with pytest.raises(ValueError, match="cannot resolve intended base for neutral"):
+        apply_reconcile.resolve_intended_base("neutral", {}, None)

--- a/lib/pulse/scripts/tests/test_apply_rederive.py
+++ b/lib/pulse/scripts/tests/test_apply_rederive.py
@@ -785,3 +785,52 @@ def test_marketplace_real_result_summary_round_trips_through_authorization():
 def test_rederive_unsupported_inputs_type_raises():
     with pytest.raises(apply_rederive.RederiveError):
         apply_rederive.rederive(object())
+
+
+# --- neutral fixtures ---------------------------------------------------------
+
+NEUTRAL_REPO = "hiivmind/agent-kernel"
+NEUTRAL_HEAD = "d" * 40
+
+
+def neutral_binding(**overrides):
+    value = {
+        "repo": NEUTRAL_REPO,
+        "transformation": "format-python",
+        "base_ref": "main",
+        "bound_paths": ["src/**", "tests/**", "examples/**"],
+    }
+    value.update(overrides)
+    return value
+
+
+def test_neutral_proposal_id_is_deterministic():
+    assert apply_rederive.neutral_proposal_id(neutral_binding()) == (
+        "apply-format-python-hiivmind-agent-kernel"
+    )
+
+
+def test_neutral_proposal_id_rejects_missing_repo():
+    with pytest.raises(apply_rederive.RederiveError, match="repo"):
+        apply_rederive.neutral_proposal_id({"transformation": "format-python"})
+
+
+def test_neutral_proposal_id_rejects_slashless_repo():
+    with pytest.raises(apply_rederive.RederiveError, match="repo"):
+        apply_rederive.neutral_proposal_id(
+            {"repo": "agent-kernel", "transformation": "format-python"}
+        )
+
+
+def test_neutral_proposal_id_rejects_missing_transformation():
+    with pytest.raises(apply_rederive.RederiveError, match="transformation"):
+        apply_rederive.neutral_proposal_id({"repo": NEUTRAL_REPO})
+
+
+def test_neutral_summary_matches_binding_and_proposal_id():
+    summary = apply_rederive.neutral_summary(neutral_binding())
+    assert summary == {
+        "binding": NEUTRAL_REPO,
+        "transformation": "format-python",
+        "proposal_id": "apply-format-python-hiivmind-agent-kernel",
+    }

--- a/lib/pulse/scripts/tests/test_apply_rederive.py
+++ b/lib/pulse/scripts/tests/test_apply_rederive.py
@@ -834,3 +834,71 @@ def test_neutral_summary_matches_binding_and_proposal_id():
         "transformation": "format-python",
         "proposal_id": "apply-format-python-hiivmind-agent-kernel",
     }
+
+
+def _neutral_gh_api(head_sha=NEUTRAL_HEAD):
+    def gh_api(path):
+        if path == f"repos/{NEUTRAL_REPO}/branches/main":
+            return {"commit": {"sha": head_sha}}
+        return None
+    return gh_api
+
+
+def neutral_registry():
+    return mutation_plan.load_registry({
+        "transformations": {
+            "format-python": {
+                "id": "format-python",
+                "command_argv": ["ruff", "format", "."],
+                "applies_to": ["profile:python"],
+                "validation": {"kind": "none"},
+                "allow_scheduled": True,
+            },
+        },
+    })
+
+
+def test_collect_inputs_neutral_fetches_live_head():
+    io_seams = apply_rederive.IoSeams(gh_api=_neutral_gh_api(), registry=neutral_registry())
+    inputs = apply_rederive.collect_inputs(
+        "neutral", neutral_binding(),
+        {"binding": NEUTRAL_REPO, "transformation": "format-python",
+         "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+        actor=ACTOR, io_seams=io_seams,
+    )
+    assert isinstance(inputs, apply_rederive.NeutralProviderInputs)
+    assert inputs.head_sha == NEUTRAL_HEAD
+    assert inputs.registry is io_seams.registry
+
+
+def test_collect_inputs_neutral_rejects_missing_base_ref():
+    io_seams = apply_rederive.IoSeams(gh_api=_neutral_gh_api())
+    with pytest.raises(apply_rederive.RederiveError, match="base_ref"):
+        apply_rederive.collect_inputs(
+            "neutral", {"repo": NEUTRAL_REPO, "transformation": "format-python"},
+            {"binding": NEUTRAL_REPO, "transformation": "format-python",
+             "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+            actor=ACTOR, io_seams=io_seams,
+        )
+
+
+def test_collect_inputs_neutral_rejects_missing_head_evidence():
+    io_seams = apply_rederive.IoSeams(gh_api=lambda path: None)
+    with pytest.raises(apply_rederive.RederiveError, match="HEAD"):
+        apply_rederive.collect_inputs(
+            "neutral", neutral_binding(),
+            {"binding": NEUTRAL_REPO, "transformation": "format-python",
+             "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+            actor=ACTOR, io_seams=io_seams,
+        )
+
+
+def test_collect_inputs_neutral_rejects_binding_identity_mismatch():
+    io_seams = apply_rederive.IoSeams(gh_api=_neutral_gh_api())
+    with pytest.raises(apply_rederive.RederiveError, match="binding"):
+        apply_rederive.collect_inputs(
+            "neutral", neutral_binding(),
+            {"binding": "someone/else", "transformation": "format-python",
+             "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+            actor=ACTOR, io_seams=io_seams,
+        )

--- a/lib/pulse/scripts/tests/test_apply_rederive.py
+++ b/lib/pulse/scripts/tests/test_apply_rederive.py
@@ -902,3 +902,84 @@ def test_collect_inputs_neutral_rejects_binding_identity_mismatch():
              "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
             actor=ACTOR, io_seams=io_seams,
         )
+
+
+def test_rederive_neutral_builds_allow_listed_proposal():
+    registry = neutral_registry()
+    inputs = apply_rederive.collect_inputs(
+        "neutral", neutral_binding(),
+        {"binding": NEUTRAL_REPO, "transformation": "format-python",
+         "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+        actor=ACTOR, io_seams=apply_rederive.IoSeams(gh_api=_neutral_gh_api(), registry=registry),
+    )
+    rederived = apply_rederive.rederive(inputs)
+    assert rederived.binding_id == NEUTRAL_REPO
+    assert rederived.source_kind == "neutral"
+    assert rederived.finalizer_record is None
+    assert rederived.proposal.id == "apply-format-python-hiivmind-agent-kernel"
+    assert rederived.proposal.selection == (NEUTRAL_REPO,)
+    assert rederived.proposal.transformation == "format-python"
+    assert rederived.proposal.expected_shas == {NEUTRAL_REPO: NEUTRAL_HEAD}
+    assert rederived.proposal.bound_paths == {
+        NEUTRAL_REPO: ("src/**", "tests/**", "examples/**")
+    }
+
+
+def test_rederive_neutral_rejects_non_neutral_transformation():
+    inputs = apply_rederive.NeutralProviderInputs(
+        binding=neutral_binding(transformation="plan-sync-doc-patch"),
+        head_sha=NEUTRAL_HEAD, actor=ACTOR,
+    )
+    with pytest.raises(apply_rederive.RederiveError, match="neutral transformation"):
+        apply_rederive.rederive(inputs)
+
+
+def test_rederive_neutral_rejects_unresolved_head_sha():
+    inputs = apply_rederive.NeutralProviderInputs(
+        binding=neutral_binding(), head_sha=None, actor=ACTOR,
+    )
+    with pytest.raises(apply_rederive.RederiveError, match="head_sha"):
+        apply_rederive.rederive(inputs)
+
+
+def test_rederive_neutral_rejects_empty_bound_paths():
+    inputs = apply_rederive.NeutralProviderInputs(
+        binding=neutral_binding(bound_paths=[]), head_sha=NEUTRAL_HEAD, actor=ACTOR,
+    )
+    with pytest.raises(apply_rederive.RederiveError, match="build failed"):
+        apply_rederive.rederive(inputs)
+
+
+def test_neutral_result_round_trips_through_authorization():
+    registry = neutral_registry()
+    inputs = apply_rederive.collect_inputs(
+        "neutral", neutral_binding(),
+        {"binding": NEUTRAL_REPO, "transformation": "format-python",
+         "proposal_id": "apply-format-python-hiivmind-agent-kernel"},
+        actor=ACTOR, io_seams=apply_rederive.IoSeams(gh_api=_neutral_gh_api(), registry=registry),
+    )
+    rederived = apply_rederive.rederive(inputs)
+    auth = apply_authorization.ApplyAuthorization(
+        transformation="format-python", mutation_policy="allow-listed",
+        permitted_repos=(NEUTRAL_REPO,),
+        bound_paths={NEUTRAL_REPO: ("src/**", "tests/**", "examples/**")},
+    )
+    apply_authorization.authorize(rederived, auth, {
+        "binding": NEUTRAL_REPO, "transformation": "format-python",
+        "proposal_id": "apply-format-python-hiivmind-agent-kernel",
+    })
+
+
+def test_neutral_transformations_are_self_contained_in_template_registry():
+    """The allowlist is fail-safe only if its entries are truly standalone:
+    no `nave generate` argv and no `profile:claude-plugin` predicate."""
+    template = Path(__file__).resolve().parents[4] / "templates" / "transformations.yaml.template"
+    registry = mutation_plan.load_registry(template)
+    for entry_id in apply_rederive.NEUTRAL_TRANSFORMATIONS:
+        entry = registry.get(entry_id)
+        assert not entry.command_argv[0:1] == ("nave",), (
+            f"{entry_id} argv must be self-contained (no nave generate dispatch)"
+        )
+        assert all(not p.startswith("profile:claude-plugin") for p in entry.applies_to), (
+            f"{entry_id} must not carry a profile:claude-plugin predicate"
+        )


### PR DESCRIPTION
Adds the 4th `neutral` source kind to the apply re-derivation provider: interfaces, live-HEAD collection, build_proposal degenerate re-derivation, resolve_intended_base branch, and the driver contract (optional recorded_summary + gh_api seam).

Pairs with hiivmind/hiivmind-workspace#3 (apply-neutral.yaml + apply-authorization.yaml) for the format-python enrollment on hiivmind/agent-kernel.

Spec: docs/superpowers/specs/2026-08-14-apply-mode-workspace-enrollment-design.md (two adversarial reviews folded in).
Plan: docs/superpowers/plans/2026-08-14-apply-mode-workspace-enrollment.md.

Verified: 1519 tests pass (19 new: 15 neutral in apply_rederive, 2 reconcile, 2 driver).