### PR TITLE
feat(apply): multi-repo apply (v2) — one proposal, N repos

### DIFF
--- a/docs/superpowers/plans/2026-08-15-multi-repo-apply.md
+++ b/docs/superpowers/plans/2026-08-15-multi-repo-apply.md
@@ -1,0 +1,1294 @@
+# Multi-Repo Apply (v2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generalize the apply pipeline from one repository per run to one proposal spanning N repositories, with per-repo independent outcomes and a fleet-level rollup, plus a nave fleet-query command for selector-based bindings.
+
+**Architecture:** The mutation spine (Proposal, authorize, journal, all six apply phases, nave pen) is already multi-repo. This plan removes the four files' scalar assumptions: `apply_rederive.py` (fleet expansion + multi-repo proposal), `apply_reconcile.py` (multi-repo apply-status + per-repo reconcile), `apply_driver.py` (per-repo iteration), `resolve_run.py` (step `repos`), plus `validate_result.py` (schema) and one new nave subcommand.
+
+**Tech Stack:** Python 3.10+ (pulse-gh), pytest, PyYAML; Rust (nave), clap, serde.
+
+## Global Constraints
+
+- Deterministic transforms only — crash-resume relies on reset + re-exec producing identical output. No network-dependent or nondeterministic steps in the transform itself.
+- Nave owns fleet discovery — pulse-gh never enumerates repos itself; selector resolution shells out to `nave fleet list --json`.
+- Fleet proposal id: `apply-{transformation}-{owner}-{sha256(sorted_repos)[:12]}`. Single-repo bindings keep the existing `apply-{transformation}-{owner}-{name}` (backward compatible).
+- Per-repo independent failure: a repo failing at provision/transform/commit/push is recorded in its own outcome; the run continues.
+- Backward compatibility: a v1 single-repo apply-status file (no `repos` map) must still load and reconcile.
+- No new Python runtime dependencies (use existing `yaml`, `hashlib`, `json`).
+- pulse-gh tests: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -k <pattern> -v` (targeted) and `uv run pytest lib/pulse/scripts/tests/ -q` (suite). nave tests: `cargo test -p nave --test fleet`.
+- Commits use conventional prefixes (`feat:`, `fix:`, `test:`); never `--no-verify` on pulse-gh (no husky there); nave has a husky pre-commit hook that may need `--no-verify` if `echo-comment` is absent.
+
+---
+
+### Task 1: nave `fleet list --json` subcommand
+
+**Files:**
+- Create: `crates/nave/src/commands/fleet.rs`
+- Modify: `crates/nave/src/commands/mod.rs` (register `pub(crate) mod fleet;`)
+- Modify: `crates/nave/src/main.rs` (add `Fleet(commands::fleet::FleetArgs)` to the `Command` enum and the match arm)
+- Test: `crates/nave/tests/fleet.rs`
+
+**Interfaces:**
+- Consumes: `nave_config::{NaveConfig, cache_root, load_default}`, `nave_config::cache::read_repo_meta` (`read_repo_meta(cache_root: &Path, owner: &str, repo: &str) -> Result<Option<RepoMeta>>`), `RepoMeta` (`owner`, `name`, `default_branch`, `clone_url`, `tree_sha`, `pushed_at`).
+- Produces: `nave fleet list --json` → stdout is a JSON array `[{"owner": String, "name": String, "default_branch": String}]`, sorted by `(owner, name)`. Exit 0 on success; non-zero + a stderr message when the fleet cache is missing/empty.
+
+**Behavior:** Read `~/.cache/nave/fleet/<owner>/<repo>/meta.toml` for every repo (two-level directory walk like `prune_stale_repos` in `crates/nave_scan/src/lib.rs`), collect `{owner, name, default_branch}`, sort, print as JSON. No GitHub API access.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `crates/nave/tests/fleet.rs`:
+
+```rust
+//! End-to-end coverage for `nave fleet list --json` against a seeded fleet cache.
+
+use std::io::Read;
+
+fn temp_dir(tag: &str) -> std::path::PathBuf {
+    let dir = std::env::temp_dir().join(format!(
+        "nave-fleet-{tag}-{}-{:?}",
+        std::process::id(),
+        std::thread::current().id()
+    ));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write_config(home: &std::path::Path, cache_root: &std::path::Path) {
+    let cfg_dir = home.join(".config");
+    std::fs::create_dir_all(&cfg_dir).unwrap();
+    let toml = format!(
+        "[github]\nuse_gh_cli = false\nusername = \"acme\"\n[cache]\nroot = \"{}\"\n",
+        cache_root.display()
+    );
+    std::fs::write(cfg_dir.join("nave.toml"), toml).unwrap();
+}
+
+fn seed_repo(cache: &std::path::Path, owner: &str, name: &str, default_branch: &str) {
+    let dir = cache.join("fleet").join(owner).join(name);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("meta.toml"),
+        format!(
+            "owner = \"{owner}\"\nname = \"{name}\"\ndefault_branch = \"{default_branch}\"\n\
+             clone_url = \"https://example.invalid/{owner}/{name}.git\"\n"
+        ),
+    )
+    .unwrap();
+}
+
+#[test]
+fn fleet_list_emits_sorted_json() {
+    let home = temp_dir("list");
+    let cache = temp_dir("cache");
+    // Seed out of order to prove sorting.
+    seed_repo(&cache, "acme", "zeta", "main");
+    seed_repo(&cache, "acme", "alpha", "develop");
+    write_config(&home, &cache);
+
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_nave"))
+        .args(["fleet", "list", "--json"])
+        .env("HOME", &home)
+        .output()
+        .expect("failed to execute nave");
+
+    let _ = std::fs::remove_dir_all(&home);
+    let _ = std::fs::remove_dir_all(&cache);
+
+    assert!(
+        output.status.success(),
+        "fleet list failed; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value = serde_json::from_str(stdout.trim()).unwrap();
+    assert_eq!(
+        parsed,
+        serde_json::json!([
+            {"owner": "acme", "name": "alpha", "default_branch": "develop"},
+            {"owner": "acme", "name": "zeta", "default_branch": "main"},
+        ])
+    );
+}
+```
+
+Add `serde_json` as a dev-dependency of the `nave` crate if not already present (check `crates/nave/Cargo.toml`; the smoke test does not use it).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test -p nave --test fleet`
+Expected: FAIL — `error: unexpected argument 'fleet' found` (the subcommand does not exist yet).
+
+- [ ] **Step 3: Implement the command**
+
+Create `crates/nave/src/commands/fleet.rs`:
+
+```rust
+use anyhow::{Context, Result};
+use clap::Args;
+use serde::Serialize;
+
+use nave_config::{NaveConfig, cache_root, load_default};
+
+#[derive(Args, Debug)]
+pub(crate) struct FleetArgs {
+    /// Emit a JSON array of {owner, name, default_branch}, sorted.
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Serialize)]
+struct FleetRepo {
+    owner: String,
+    name: String,
+    default_branch: String,
+}
+
+pub(crate) fn run(args: FleetArgs) -> Result<()> {
+    let cfg: NaveConfig = load_default()?;
+    let root = match cfg.cache.root.clone() {
+        Some(r) => r,
+        None => cache_root()?,
+    };
+    let fleet_root = root.join("fleet");
+    if !fleet_root.exists() {
+        anyhow::bail!(
+            "no fleet cache at {} — run `nave scan` first",
+            fleet_root.display()
+        );
+    }
+
+    let mut repos: Vec<FleetRepo> = Vec::new();
+    for owner_entry in std::fs::read_dir(&fleet_root)
+        .with_context(|| format!("reading fleet cache {}", fleet_root.display()))?
+    {
+        let owner_entry = owner_entry?;
+        if !owner_entry.file_type()?.is_dir() {
+            continue;
+        }
+        let owner = owner_entry.file_name().to_string_lossy().into_owned();
+        for repo_entry in std::fs::read_dir(owner_entry.path())? {
+            let repo_entry = repo_entry?;
+            if !repo_entry.file_type()?.is_dir() {
+                continue;
+            }
+            let name = repo_entry.file_name().to_string_lossy().into_owned();
+            let meta = nave_config::cache::read_repo_meta(&root, &owner, &name)?;
+            if let Some(meta) = meta {
+                repos.push(FleetRepo {
+                    owner: meta.owner,
+                    name: meta.name,
+                    default_branch: meta.default_branch,
+                });
+            }
+        }
+    }
+    repos.sort_by(|a, b| (a.owner.as_str(), a.name.as_str()).cmp(&(b.owner.as_str(), b.name.as_str())));
+    if repos.is_empty() {
+        anyhow::bail!("fleet cache is empty — run `nave scan` first");
+    }
+
+    if args.json {
+        println!("{}", serde_json::to_string(&repos)?);
+    } else {
+        for r in &repos {
+            println!("{}/{} ({})", r.owner, r.name, r.default_branch);
+        }
+    }
+    Ok(())
+}
+```
+
+`serde_json` and `serde` are already dependencies of the `nave` crate (the search command emits JSON); confirm `serde::Serialize` is available (it is, via `serde`).
+
+- [ ] **Step 4: Register the subcommand**
+
+In `crates/nave/src/commands/mod.rs`, add `pub(crate) mod fleet;` alongside the other `pub(crate) mod` lines. In `crates/nave/src/main.rs`, add `Fleet(commands::fleet::FleetArgs)` to the `Command` enum and the arm `Command::Fleet(args) => commands::fleet::run(args).await,` in the match. `run` is synchronous (`Result<()>`); if the match arms are `.await`-ed uniformly, wrap with `async` or call without await — match the existing pattern (most commands are `async fn run(...) -> Result<()>`). If `run` must be async to fit the match, declare `pub(crate) async fn run(args: FleetArgs) -> Result<()>`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cargo test -p nave --test fleet`
+Expected: PASS (1 test).
+
+- [ ] **Step 6: Full nave suite**
+
+Run: `cargo test -p nave` (or `cargo test` for the workspace)
+Expected: all pass (158 existing + 1 new).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/nave/src/commands/fleet.rs crates/nave/src/commands/mod.rs crates/nave/src/main.rs crates/nave/tests/fleet.rs
+git commit -m "feat(fleet): add 'nave fleet list --json' fleet-cache query"
+```
+
+---
+
+### Task 2: pulse-gh binding validation + fleet expansion (`apply_rederive.py`)
+
+**Files:**
+- Modify: `lib/pulse/scripts/apply_rederive.py`
+- Test: `lib/pulse/scripts/tests/test_apply_rederive.py`
+
+**Interfaces:**
+- Consumes: `IoSeams.runner` (`(argv: list[str], cwd) -> CompletedProcess-like`, already injected), `IoSeams.gh_api` (`(endpoint) -> parsed JSON`), `mutation_plan.build_proposal`, `RederivedProposal`.
+- Produces (new/changed):
+  - `NeutralProviderInputs` gains `selection: tuple[str, ...]` and `head_shas: dict[str, str]` (replacing the single `head_sha: str | None`).
+  - `_validate_neutral_binding(binding) -> tuple[str, tuple[str, ...]]` — returns `(transformation, selection)` after validating exactly one of `repo` or (`repos`/`repo_selector`); for a single-repo binding, `selection` is the one-element tuple.
+  - `_resolve_neutral_repos(binding, runner) -> tuple[str, ...]` — returns the de-duplicated, sorted repo set (explicit `repos` ∪ selector results).
+  - `_collect_neutral(binding_ref, actor, io_seams) -> NeutralProviderInputs` — fetches per-repo HEAD into `head_shas`.
+
+**Behavior:** A binding is single-repo (`repo: "owner/name"`) or fleet (`repos: [...]` and/or `repo_selector: {term: ...}`). Explicit repos and selector results union, de-duplicate, sort. Each resolved repo's live HEAD is fetched via `gh_api(repos/{owner}/{name}/branches/{base})`. A repo whose HEAD fetch fails is dropped from `selection` and recorded as a per-repo blocked outcome (see Task 5 for where outcomes live; in collect, a dropped repo is surfaced by its absence from `head_shas`/`selection`).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `lib/pulse/scripts/tests/test_apply_rederive.py`:
+
+```python
+def test_neutral_fleet_expands_explicit_repos_with_live_heads(registry):
+    from lib.pulse.scripts import apply_rederive as r
+
+    binding = {
+        "repos": ["hiivmind/a", "hiivmind/b"],
+        "transformation": "format-python",
+        "base_ref": "main",
+        "bound_paths": ["src/**"],
+    }
+
+    def gh_api(endpoint):
+        # endpoint == "repos/{owner}/{name}/branches/{base}"
+        parts = endpoint.split("/")
+        name = parts[1]
+        return {"commit": {"sha": {"a": "sha-a", "b": "sha-b"}[name]}}
+
+    inputs = r._collect_neutral(
+        binding, {"gh_login": "x", "machine": "m", "mode": "interactive"},
+        r.IoSeams(runner=None, gh_api=gh_api),
+    )
+    assert inputs.selection == ("hiivmind/a", "hiivmind/b")
+    assert inputs.head_shas == {"hiivmind/a": "sha-a", "hiivmind/b": "sha-b"}
+
+
+def test_neutral_fleet_selector_unions_and_dedups(registry):
+    from lib.pulse.scripts import apply_rederive as r
+
+    binding = {
+        "repos": ["hiivmind/a", "hiivmind/b"],
+        "repo_selector": {"term": "pyproject:true"},
+        "transformation": "format-python",
+        "bound_paths": ["src/**"],
+    }
+
+    class Completed:
+        def __init__(self, stdout):
+            self.stdout = stdout
+            self.returncode = 0
+
+    def runner(argv, cwd):
+        assert argv[:3] == ["nave", "fleet", "list"]
+        return Completed(
+            '[{"owner":"hiivmind","name":"b","default_branch":"main"},'
+            '{"owner":"hiivmind","name":"c","default_branch":"main"}]'
+        )
+
+    def gh_api(endpoint):
+        return {"commit": {"sha": "sha"}}
+
+    inputs = r._collect_neutral(
+        binding, {"gh_login": "x", "machine": "m", "mode": "interactive"},
+        r.IoSeams(runner=runner, gh_api=gh_api),
+    )
+    # explicit [a, b] union selector [b, c] == [a, b, c], sorted
+    assert inputs.selection == ("hiivmind/a", "hiivmind/b", "hiivmind/c")
+
+
+def test_neutral_fleet_empty_selector_raises(registry):
+    from lib.pulse.scripts import apply_rederive as r
+    from lib.pulse.scripts import apply_reconcile  # noqa: F401  (imports settle)
+
+    binding = {
+        "repo_selector": {"term": "nope:true"},
+        "transformation": "format-python",
+        "bound_paths": ["src/**"],
+    }
+
+    class Completed:
+        stdout = "[]"
+        returncode = 0
+
+    def runner(argv, cwd):
+        return Completed()
+
+    with pytest.raises(r.RederiveError):
+        r._collect_neutral(
+            binding, {"gh_login": "x", "machine": "m", "mode": "interactive"},
+            r.IoSeams(runner=runner, gh_api=lambda e: {"commit": {"sha": "sha"}}),
+        )
+```
+
+Confirm the `registry` fixture name by checking the top of `test_apply_rederive.py`; if existing tests use a different fixture (e.g. `transformation_registry`), match it.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -k "fleet" -v`
+Expected: FAIL — `TypeError`/`AttributeError` (no `_resolve_neutral_repos`; `NeutralProviderInputs` has no `selection`/`head_shas`).
+
+- [ ] **Step 3: Implement fleet validation + resolution**
+
+In `apply_rederive.py`, replace `NeutralProviderInputs` (lines 129-137) and `_validate_neutral_binding` (lines 165-182), and add `_resolve_neutral_repos`:
+
+```python
+@dataclass(frozen=True)
+class NeutralProviderInputs:
+    """Fresh neutral evidence: `binding` is the caller-supplied `binding_ref`
+    (validated); `selection` is the resolved, sorted repo set; `head_shas` maps
+    each selected repo to the live HEAD of its `base_ref` branch."""
+
+    binding: Mapping[str, Any]
+    selection: tuple[str, ...]
+    head_shas: dict[str, str]
+    actor: Mapping[str, Any] | mutation_plan.Actor
+    registry: mutation_plan.TransformationRegistry | None = None
+
+
+def _repo_name(value: Any) -> str:
+    if not isinstance(value, str) or not value or value.count("/") != 1:
+        raise RederiveError(
+            f"apply_rederive: repo must be 'owner/name', got {value!r}"
+        )
+    return value
+
+
+def _validate_neutral_binding(
+    binding: Mapping[str, Any],
+) -> tuple[str, tuple[str, ...]]:
+    """Validate a neutral binding; return (transformation, resolved_selection).
+
+    A binding is exactly one of single-repo (`repo`) or fleet
+    (`repos` and/or `repo_selector`). Raises `RederiveError` (never
+    KeyError/ValueError) on any malformed shape.
+    """
+    transformation = binding.get("transformation")
+    if not isinstance(transformation, str) or not transformation:
+        raise RederiveError(
+            "apply_rederive: neutral binding requires a non-empty transformation, "
+            f"got {transformation!r}"
+        )
+    has_repo = binding.get("repo") is not None
+    has_repos = binding.get("repos") is not None
+    has_selector = binding.get("repo_selector") is not None
+    if has_repo and (has_repos or has_selector):
+        raise RederiveError(
+            "apply_rederive: neutral binding must be either single-repo (`repo`) "
+            "or fleet (`repos`/`repo_selector`), not both"
+        )
+    if not (has_repo or has_repos or has_selector):
+        raise RederiveError(
+            "apply_rederive: neutral binding requires `repo` or `repos`/`repo_selector`"
+        )
+    if has_repo:
+        return transformation, (_repo_name(binding.get("repo")),)
+    repos = binding.get("repos") or []
+    if not isinstance(repos, list) or any(
+        not isinstance(r, str) or not r for r in repos
+    ):
+        raise RederiveError(
+            f"apply_rederive: neutral binding `repos` must be a list of 'owner/name', got {repos!r}"
+        )
+    selection = tuple(_repo_name(r) for r in repos)
+    if len(set(selection)) != len(selection):
+        raise RederiveError("apply_rederive: neutral binding `repos` has duplicates")
+    return transformation, selection
+
+
+def _resolve_neutral_repos(
+    binding: Mapping[str, Any], runner: Callable[..., Any] | None
+) -> tuple[str, ...]:
+    """Union explicit `repos` with `repo_selector` results (via `nave fleet
+    list --json`), de-duplicated and sorted."""
+    _, selection = _validate_neutral_binding(binding)
+    selector = binding.get("repo_selector")
+    if selector is not None:
+        if runner is None:
+            raise RederiveError(
+                "apply_rederive: neutral repo_selector requires io_seams.runner"
+            )
+        if not isinstance(selector, Mapping) or not isinstance(
+            selector.get("term"), str
+        ):
+            raise RederiveError(
+                f"apply_rederive: repo_selector must be {{term: str}}, got {selector!r}"
+            )
+        proc = runner(["nave", "fleet", "list", "--json"], cwd=None)
+        if getattr(proc, "returncode", 0) != 0:
+            raise RederiveError(
+                "apply_rederive: selector resolution failed (nave fleet list): "
+                f"{getattr(proc, 'stderr', '') or getattr(proc, 'stdout', '')}"
+            )
+        raw = getattr(proc, "stdout", "")
+        try:
+            entries = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise RederiveError(
+                f"apply_rederive: selector resolution returned invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(entries, list) or any(
+            not isinstance(e, Mapping) or not isinstance(e.get("owner"), str)
+            or not isinstance(e.get("name"), str) for e in entries
+        ):
+            raise RederiveError(
+                "apply_rederive: selector resolution returned a malformed fleet list"
+            )
+        selection = selection + tuple(
+            f"{e['owner']}/{e['name']}" for e in entries
+        )
+    selection = tuple(sorted(set(selection)))
+    if not selection:
+        raise RederiveError(
+            "apply_rederive: neutral binding resolved to an empty selection"
+        )
+    return selection
+```
+
+Add `import json` to the top of `apply_rederive.py` if not already imported.
+
+- [ ] **Step 4: Rewrite `_collect_neutral`**
+
+Replace `_collect_neutral` (lines 340-373) with:
+
+```python
+def _collect_neutral(
+    binding_ref: Mapping[str, Any],
+    actor: Mapping[str, Any] | mutation_plan.Actor,
+    io_seams: IoSeams,
+) -> NeutralProviderInputs:
+    transformation, _ = _validate_neutral_binding(binding_ref)
+    selection = _resolve_neutral_repos(binding_ref, io_seams.runner)
+    base_ref = binding_ref.get("base_ref")
+    if not isinstance(base_ref, str) or not base_ref:
+        raise RederiveError(
+            f"apply_rederive: neutral binding requires a non-empty base_ref, got {base_ref!r}"
+        )
+    if io_seams.gh_api is None:
+        raise RederiveError("apply_rederive: neutral requires io_seams.gh_api")
+    head_shas: dict[str, str] = {}
+    for repo in selection:
+        owner, name = repo.split("/", 1)
+        try:
+            payload = io_seams.gh_api(f"repos/{owner}/{name}/branches/{base_ref}")
+        except Exception as exc:
+            # Per-repo collect failure: drop the repo; the driver records it as
+            # a blocked outcome. Never abort the whole fleet.
+            continue
+        head_sha = None
+        if isinstance(payload, Mapping):
+            commit = payload.get("commit")
+            if isinstance(commit, Mapping) and isinstance(commit.get("sha"), str):
+                head_sha = commit["sha"] or None
+        if head_sha is not None:
+            head_shas[repo] = head_sha
+    if not head_shas:
+        raise RederiveError(
+            "apply_rederive: neutral could not resolve HEAD for any selected repo"
+        )
+    return NeutralProviderInputs(
+        binding=binding_ref,
+        selection=tuple(repo for repo in selection if repo in head_shas),
+        head_shas=head_shas,
+        actor=actor,
+        registry=io_seams.registry,
+    )
+```
+
+Note: `transformation` is returned by `_validate_neutral_binding` but re-read from `binding_ref["transformation"]` in the re-derive; keep the local for the empty-selection guard's clarity or drop it — use `_ = _validate_neutral_binding(binding_ref)` if unused to satisfy lint.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -k "fleet or neutral" -v`
+Expected: PASS (new fleet tests + existing neutral tests still green — the existing single-repo neutral tests use `binding={"repo": ...}` and must still pass through the single-repo branch).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/pulse/scripts/apply_rederive.py lib/pulse/scripts/tests/test_apply_rederive.py
+git commit -m "feat(apply): neutral fleet expansion (explicit repos + nave selector)"
+```
+
+---
+
+### Task 3: pulse-gh multi-repo re-derive (`apply_rederive.py`)
+
+**Files:**
+- Modify: `lib/pulse/scripts/apply_rederive.py`
+- Test: `lib/pulse/scripts/tests/test_apply_rederive.py`
+
+**Interfaces:**
+- Consumes: Task 2's `NeutralProviderInputs` (`selection`, `head_shas`), `_validate_neutral_binding`, `_resolve_neutral_repos`.
+- Produces:
+  - `neutral_proposal_id(binding) -> str` — single-repo: `apply-{t}-{owner}-{name}`; fleet: `apply-{t}-{owner}-{sha256(sorted repos joined by ',')[:12]}`.
+  - `neutral_summary(binding) -> dict` — adds `"selection": list[str]` alongside `binding`, `transformation`, `proposal_id`.
+  - `_rederive_neutral(inputs) -> RederivedProposal` — builds the multi-repo proposal.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_neutral_fleet_proposal_id_is_deterministic_over_sorted_set(registry):
+    from lib.pulse.scripts import apply_rederive as r
+    import hashlib
+
+    binding = {
+        "repos": ["hiivmind/b", "hiivmind/a"],
+        "transformation": "format-python",
+        "bound_paths": ["src/**"],
+    }
+    id1 = r.neutral_proposal_id(binding)
+    binding2 = dict(binding, repos=["hiivmind/a", "hiivmind/b"])
+    id2 = r.neutral_proposal_id(binding2)
+    assert id1 == id2
+    assert id1.startswith("apply-format-python-hiivmind-")
+    assert len(id1.split("-")[-1]) == 12
+    # single-repo id is unchanged
+    single = {"repo": "hiivmind/agent-kernel", "transformation": "format-python"}
+    assert r.neutral_proposal_id(single) == "apply-format-python-hiivmind-agent-kernel"
+
+
+def test_neutral_fleet_rederive_builds_multi_repo_proposal(registry):
+    from lib.pulse.scripts import apply_rederive as r
+
+    binding = {
+        "repos": ["hiivmind/a", "hiivmind/b"],
+        "transformation": "format-python",
+        "bound_paths": ["src/**"],
+    }
+    inputs = r.NeutralProviderInputs(
+        binding=binding,
+        selection=("hiivmind/a", "hiivmind/b"),
+        head_shas={"hiivmind/a": "sha-a", "hiivmind/b": "sha-b"},
+        actor={"gh_login": "x", "machine": "m", "mode": "interactive"},
+        registry=registry,
+    )
+    rederived = r._rederive_neutral(inputs)
+    assert rederived.proposal.selection == ("hiivmind/a", "hiivmind/b")
+    assert rederived.proposal.expected_shas == {
+        "hiivmind/a": "sha-a",
+        "hiivmind/b": "sha-b",
+    }
+    assert rederived.proposal.bound_paths == {
+        "hiivmind/a": ("src/**",),
+        "hiivmind/b": ("src/**",),
+    }
+    assert rederived.source_kind == "neutral"
+    assert rederived.finalizer_record is None
+    assert rederived.binding_id == rederived.proposal.id
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -k "fleet" -v`
+Expected: FAIL — fleet id is `apply-format-python-hiivmind-a` (old formula uses `name`); `_rederive_neutral` returns a single-repo selection.
+
+- [ ] **Step 3: Implement `neutral_fleet_proposal_id` + `neutral_proposal_id` + `neutral_summary`**
+
+Replace `neutral_proposal_id` and `neutral_summary` (lines 185-203) and add `neutral_fleet_proposal_id`:
+
+```python
+def neutral_fleet_proposal_id(transformation: str, selection: tuple[str, ...]) -> str:
+    """Fleet-scoped deterministic id: `apply-{t}-{owner}-{sha256(sorted repos)[:12]}`."""
+    owner = selection[0].split("/", 1)[0]
+    digest = hashlib.sha256(",".join(sorted(selection)).encode()).hexdigest()[:12]
+    return f"apply-{transformation}-{owner}-{digest}"
+
+
+def neutral_proposal_id(binding: Mapping[str, Any]) -> str:
+    """Deterministic neutral proposal id. Single source of the id.
+
+    Single-repo (`repo`): `apply-{t}-{owner}-{name}` (stable, backward
+    compatible). Explicit-repos fleet: `neutral_fleet_proposal_id` over the
+    sorted set. A selector-only binding has no fixed id before resolution —
+    the driver resolves it and uses `neutral_fleet_proposal_id`.
+    """
+    transformation = binding.get("transformation")
+    if not isinstance(transformation, str) or not transformation:
+        raise RederiveError(
+            "apply_rederive: neutral binding requires a non-empty transformation"
+        )
+    if binding.get("repo") is not None:
+        owner, name = _repo_name(binding["repo"]).split("/", 1)
+        return f"apply-{transformation}-{owner}-{name}"
+    repos = binding.get("repos")
+    if isinstance(repos, list) and repos:
+        selection = tuple(sorted({_repo_name(r) for r in repos}))
+        return neutral_fleet_proposal_id(transformation, selection)
+    raise RederiveError(
+        "apply_rederive: selector-only binding has no fixed proposal id before resolution"
+    )
+
+
+def neutral_summary(binding: Mapping[str, Any]) -> dict[str, Any]:
+    """Synthesize the `recorded_summary` for a neutral apply (no propose phase)."""
+    proposal_id = neutral_proposal_id(binding)
+    if binding.get("repo") is not None:
+        selection = [binding["repo"]]
+    else:
+        selection = sorted({_repo_name(r) for r in (binding.get("repos") or [])})
+    return {
+        "binding": binding.get("repo") or proposal_id,
+        "transformation": binding["transformation"],
+        "proposal_id": proposal_id,
+        "selection": selection,
+    }
+```
+
+Add `import hashlib` to the top of `apply_rederive.py`.
+
+`_repo_name` is the Task 2 helper (validates `owner/name`). For a selector-only binding,
+`neutral_proposal_id`/`neutral_summary` raise — the driver (Task 5 Step 3) resolves the selector
+first and synthesizes the summary from the resolved selection via `neutral_fleet_proposal_id`.
+
+- [ ] **Step 4: Implement `_rederive_neutral`**
+
+Replace `_rederive_neutral` (lines 518-546) with:
+
+```python
+def _rederive_neutral(inputs: NeutralProviderInputs) -> RederivedProposal:
+    binding = inputs.binding
+    transformation = binding.get("transformation")
+    if transformation not in NEUTRAL_TRANSFORMATIONS:
+        raise RederiveError(
+            f"apply_rederive: transformation {transformation!r} is not a neutral transformation"
+        )
+    selection = inputs.selection
+    if not selection or any(sha is None for sha in inputs.head_shas.values()):
+        raise RederiveError("apply_rederive: neutral requires a resolved HEAD per repo")
+    if len(selection) == 1 and binding.get("repo") == selection[0]:
+        proposal_id = neutral_proposal_id(binding)
+    else:
+        proposal_id = neutral_fleet_proposal_id(transformation, selection)
+    bound_paths = binding.get("bound_paths")
+    try:
+        proposal = mutation_plan.build_proposal(
+            id=proposal_id,
+            selection=list(selection),
+            transformation=transformation,
+            expected_shas=dict(inputs.head_shas),
+            actor=inputs.actor,
+            mutation_policy="allow-listed",
+            bound_paths={repo: bound_paths for repo in selection},
+            registry=inputs.registry,
+        )
+    except mutation_plan.MutationPlanError as exc:
+        raise RederiveError(f"apply_rederive: neutral build failed: {exc}") from exc
+    return RederivedProposal(
+        binding_id=proposal_id,
+        proposal=proposal,
+        source_kind="neutral",
+        finalizer_record=None,
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_rederive.py -v`
+Expected: PASS (new fleet tests + all existing neutral tests — the existing single-repo id `apply-format-python-hiivmind-agent-kernel` is preserved).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/pulse/scripts/apply_rederive.py lib/pulse/scripts/tests/test_apply_rederive.py
+git commit -m "feat(apply): neutral multi-repo re-derive + deterministic fleet id"
+```
+
+---
+
+### Task 4: pulse-gh multi-repo apply-status + per-repo base resolution (`apply_reconcile.py`, `validate_result.py`)
+
+**Files:**
+- Modify: `lib/pulse/scripts/apply_reconcile.py`
+- Modify: `lib/pulse/scripts/validate_result.py`
+- Test: `lib/pulse/scripts/tests/test_apply_reconcile.py`
+
+**Interfaces:**
+- Consumes: `validate_result.validate(data, "apply-status")`.
+- Produces:
+  - `resolve_intended_base(source_kind, binding_ref, finalizer_record=None) -> str | dict[str, str]` — neutral returns `dict[repo, base_ref]` (single-repo binding → a one-key dict).
+  - `write_apply_status(path, *, proposal_id, selection, repos, state, ...) -> dict` — `repos: dict[repo, dict]` of per-repo `{branch, state, intended_base, expected_head_sha, pushed_sha, pr_url, merged_sha, observed_base, observed_head_sha, reason}`; `state` is the rollup.
+  - `rollup_state(repos: dict[str, dict]) -> str` — § 6.2 precedence function.
+  - `load_apply_status(path) -> dict | None` — normalizes a v1 scalar doc to a one-element `repos` map in memory.
+  - `upsert_repo_status(path, *, proposal_id, selection, repo, repo_doc) -> dict` — load-modify-write one repo's entry, recompute rollup.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_rollup_state_precedence():
+    from lib.pulse.scripts.apply_reconcile import rollup_state
+
+    def repo(state):
+        return {"state": state, "branch": "b", "intended_base": "main",
+                "expected_head_sha": "s", "pushed_sha": "s", "pr_url": None,
+                "merged_sha": None, "observed_base": None, "observed_head_sha": None,
+                "reason": None}
+
+    assert rollup_state({"a": repo("pr_opened"), "b": repo("applied")}) == "pr_opened"
+    assert rollup_state({"a": repo("applied"), "b": repo("applied")}) == "applied"
+    assert rollup_state({"a": repo("rejected"), "b": repo("rejected")}) == "rejected"
+    assert rollup_state({"a": repo("failed"), "b": repo("blocked")}) == "failed"
+    assert rollup_state({"a": repo("applied"), "b": repo("failed")}) == "partial"
+
+
+def test_write_and_load_multi_repo_status_round_trip(tmp_path):
+    from lib.pulse.scripts import apply_reconcile as rc
+
+    repos = {
+        "hiivmind/a": {"branch": "pulse/apply/x", "state": "pr_opened",
+                       "intended_base": "main", "expected_head_sha": "sha-a",
+                       "pushed_sha": "sha-a", "pr_url": "https://x/a/1",
+                       "merged_sha": None, "observed_base": None,
+                       "observed_head_sha": None, "reason": None},
+        "hiivmind/b": {"branch": "pulse/apply/x", "state": "applied",
+                       "intended_base": "main", "expected_head_sha": "sha-b",
+                       "pushed_sha": "sha-b", "pr_url": "https://x/b/1",
+                       "merged_sha": "merge-b", "observed_base": "main",
+                       "observed_head_sha": "sha-b", "reason": None},
+    }
+    path = tmp_path / "result.yaml"
+    rc.write_apply_status(
+        path, proposal_id="pid", selection=["hiivmind/a", "hiivmind/b"],
+        repos=repos, state=rc.rollup_state(repos),
+        recorded_proposal_id="pid", proposal_digest="d1",
+        authorization_digest="d2", workspace="w",
+        actor={"gh_login": "x", "machine": "m", "mode": "interactive"},
+    )
+    loaded = rc.load_apply_status(path)
+    assert loaded["repos"] == repos
+    assert loaded["selection"] == ["hiivmind/a", "hiivmind/b"]
+    assert loaded["state"] == "pr_opened"
+
+
+def test_load_normalizes_v1_single_repo(tmp_path):
+    from lib.pulse.scripts import apply_reconcile as rc
+    import yaml
+
+    v1 = {
+        "contract_version": 1, "kind": "apply-status", "state": "pr_opened",
+        "proposal_id": "pid", "recorded_proposal_id": "pid",
+        "proposal_digest": "d1", "authorization_digest": "d2",
+        "selection": ["hiivmind/a"], "branch": "pulse/apply/x",
+        "pushed_sha": "sha", "pr_url": "https://x/a/1", "merged_sha": None,
+        "reason": None, "intended_base": "main", "expected_head_sha": "sha",
+        "observed_base": None, "observed_head_sha": None,
+    }
+    path = tmp_path / "result.yaml"
+    path.write_text(yaml.safe_dump(v1))
+    loaded = rc.load_apply_status(path)
+    assert loaded["selection"] == ["hiivmind/a"]
+    assert loaded["repos"]["hiivmind/a"]["branch"] == "pulse/apply/x"
+```
+
+Check `test_apply_reconcile.py` for its existing fixtures (e.g. a `GhOps` fake) and match the import style.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_reconcile.py -k "rollup or multi_repo or normalizes" -v`
+Expected: FAIL — `ImportError: cannot import name 'rollup_state'`; `write_apply_status` lacks `repos`/`selection` params.
+
+- [ ] **Step 3: Implement `rollup_state` + `resolve_intended_base` neutral branch**
+
+In `apply_reconcile.py`, add after `load_apply_status`:
+
+```python
+def rollup_state(repos: Mapping[str, Mapping[str, Any]]) -> str:
+    """Fleet rollup (§ 6.2), total over every combination, first match wins."""
+    states = [r.get("state") for r in repos.values()]
+    if any(s in {"pr_opened", "pushed"} for s in states):
+        return "pr_opened"
+    if all(s == "applied" for s in states):
+        return "applied"
+    if all(s == "rejected" for s in states):
+        return "rejected"
+    if all(s in {"failed", "blocked"} for s in states):
+        return "failed"
+    return "partial"
+```
+
+Change `resolve_intended_base`'s neutral branch (lines 237-241) to return a per-repo dict:
+
+```python
+    if source_kind == "neutral":
+        if binding_ref.get("repo") is not None:
+            repo = binding_ref["repo"]
+            base = binding_ref.get("base_ref")
+            if not isinstance(base, str) or not base:
+                raise ValueError("cannot resolve intended base for neutral: no base_ref")
+            return {repo: base}
+        repos = binding_ref.get("repos") or []
+        base = binding_ref.get("base_ref")
+        if not isinstance(base, str) or not base:
+            raise ValueError("cannot resolve intended base for neutral: no base_ref")
+        if not isinstance(repos, list) or not repos:
+            raise ValueError("cannot resolve intended base for neutral: no repos")
+        return {repo: base for repo in repos}
+```
+
+Note: the return type widens from `str` to `str | dict[str, str]`. Existing single-repo callers (driver `base_refs = {repo: resolve_intended_base(...)}`) must be updated in Task 5 — but the current driver passes a single-repo neutral binding, so `resolve_intended_base` returns a one-key dict. Update the docstring's return annotation and the driver's use in Task 5; until then the driver may break. To keep the suite green within this task, update the driver's call site minimally (Task 5 does the full rewrite): change `base_refs = {repo: apply_reconcile.resolve_intended_base(...)}` to handle the dict return. Coordinate: this task's Step 6 commit must leave the suite green — if the driver change is substantial, do the minimal one-line fix here and the full rewrite in Task 5.
+
+- [ ] **Step 4: Implement multi-repo `write_apply_status` + `load_apply_status` normalization + `upsert_repo_status`**
+
+Rewrite `write_apply_status` (lines 308-364) to the multi-repo shape:
+
+```python
+def write_apply_status(
+    path: str | Path,
+    *,
+    proposal_id: str,
+    selection: list[str],
+    repos: Mapping[str, Mapping[str, Any]],
+    state: str,
+    recorded_proposal_id: str,
+    proposal_digest: str,
+    authorization_digest: str,
+    reason: str | None = None,
+    workspace: str = "unknown",
+    actor: dict | None = None,
+    errors: list[str] | None = None,
+) -> dict:
+    if actor is None:
+        actor = {"gh_login": "unknown", "machine": "unknown", "mode": "interactive"}
+    doc = {
+        "contract_version": 1,
+        "kind": "apply-status",
+        "workspace": workspace,
+        "run_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "actor": actor,
+        "errors": errors or [],
+        "proposal_id": proposal_id,
+        "recorded_proposal_id": recorded_proposal_id,
+        "proposal_digest": proposal_digest,
+        "authorization_digest": authorization_digest,
+        "selection": list(selection),
+        "repos": {repo: dict(entry) for repo, entry in repos.items()},
+        "state": state,
+        "reason": reason,
+    }
+    validation_errors = validate_result.validate(doc, "apply-status")
+    if validation_errors:
+        raise ValueError(
+            f"Invalid apply-status document: {'; '.join(validation_errors)}"
+        )
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    _atomic_write_yaml(p, doc)
+    return doc
+```
+
+Add `upsert_repo_status` (used by `open_apply_pr` in Task 5 and `reconcile_apply` in Task 6):
+
+```python
+def upsert_repo_status(
+    path: str | Path,
+    *,
+    proposal_id: str,
+    selection: list[str],
+    repo: str,
+    repo_doc: Mapping[str, Any],
+    recorded_proposal_id: str,
+    proposal_digest: str,
+    authorization_digest: str,
+    workspace: str = "unknown",
+    actor: dict | None = None,
+) -> dict:
+    """Load-modify-write one repo's entry; recompute the rollup."""
+    existing = load_apply_status(path) or {}
+    repos = dict(existing.get("repos") or {})
+    repos[repo] = dict(repo_doc)
+    return write_apply_status(
+        path,
+        proposal_id=proposal_id,
+        selection=selection,
+        repos=repos,
+        state=rollup_state(repos),
+        recorded_proposal_id=recorded_proposal_id,
+        proposal_digest=proposal_digest,
+        authorization_digest=authorization_digest,
+        workspace=workspace,
+        actor=actor,
+        errors=list(existing.get("errors") or []),
+    )
+```
+
+Update `load_apply_status` (lines 250-273) to normalize v1 → multi-repo after validation:
+
+```python
+    data = data  # already validated as a mapping
+    if "repos" not in data and data.get("selection"):
+        repo = data["selection"][0]
+        data = dict(data)
+        data["repos"] = {
+            repo: {
+                "branch": data.get("branch"),
+                "state": data.get("state"),
+                "intended_base": data.get("intended_base"),
+                "expected_head_sha": data.get("expected_head_sha"),
+                "pushed_sha": data.get("pushed_sha"),
+                "pr_url": data.get("pr_url"),
+                "merged_sha": data.get("merged_sha"),
+                "observed_base": data.get("observed_base"),
+                "observed_head_sha": data.get("observed_head_sha"),
+                "reason": data.get("reason"),
+            }
+        }
+    return data
+```
+
+(Insert this normalization between the schema validation and `return data`.)
+
+`open_apply_pr` (lines 367-444) currently calls `write_apply_status` with the scalar signature, which
+now raises `TypeError`. Replace that call with `upsert_repo_status(...)` so it load-modify-writes the
+single repo's `pr_opened` entry and recomputes the rollup; its return doc becomes the multi-repo shape.
+Update `test_open_apply_pr_creates_and_reuses_pr` (in `test_apply_reconcile.py`) accordingly:
+`doc["pushed_sha"]` → `doc["repos"]["testorg/repo1"]["pushed_sha"]`, `doc["pr_url"]` →
+`doc["repos"]["testorg/repo1"]["pr_url"]`; `doc["state"]` stays `"pr_opened"`.
+
+- [ ] **Step 5: Extend the `apply-status` validator**
+
+In `validate_result.py` `elif kind == "apply-status":` (lines 707-751), keep the scalar fields optional (for v1 back-compat via `_require_nullable`) and add multi-repo validation:
+
+```python
+    elif kind == "apply-status":
+        state = _require_enum(data, "state", APPLY_STATUS_STATES, errors)
+        _require(data, "proposal_id", str, errors)
+        _require(data, "recorded_proposal_id", str, errors)
+        _require(data, "proposal_digest", str, errors)
+        _require(data, "authorization_digest", str, errors)
+        _validate_string_list(data, "selection", errors)
+        if "repos" in data:
+            repos = data.get("repos")
+            if not isinstance(repos, dict) or not repos:
+                _err(errors, "repos must be a non-empty mapping")
+            else:
+                seen = set()
+                for repo, entry in repos.items():
+                    if not isinstance(repo, str) or "/" not in repo:
+                        _err(errors, f"repos key {repo!r} must be owner/name")
+                    if repo in seen:
+                        _err(errors, f"duplicate repo key {repo}")
+                    seen.add(repo)
+                    if not isinstance(entry, dict):
+                        _err(errors, f"repos[{repo}] must be a mapping")
+                        continue
+                    _require(entry, "branch", str, errors, ctx=f"repos[{repo}].")
+                    _require_enum(entry, "state", APPLY_STATUS_STATES, errors, ctx=f"repos[{repo}].")
+                    _require_nullable(entry, "pushed_sha", str, errors, ctx=f"repos[{repo}].")
+                    _require_nullable(entry, "pr_url", str, errors, ctx=f"repos[{repo}].")
+                    _require_nullable(entry, "merged_sha", str, errors, ctx=f"repos[{repo}].")
+                    _require_nullable(entry, "reason", str, errors, ctx=f"repos[{repo}].")
+                    _require_nullable(entry, "intended_base", str, errors, ctx=f"repos[{repo}].")
+                    _require_nullable(entry, "expected_head_sha", str, errors, ctx=f"repos[{repo}].")
+                    _require_nullable(entry, "observed_base", str, errors, ctx=f"repos[{repo}].")
+                    _require_nullable(entry, "observed_head_sha", str, errors, ctx=f"repos[{repo}].")
+                    if entry.get("state") == "applied" and entry.get("merged_sha") is None:
+                        _err(errors, f"repos[{repo}].merged_sha must not be null when state is applied")
+            # fleet invariants
+            selection = data.get("selection") or []
+            if set(repos) != set(selection):
+                _err(errors, "repos keys must match selection")
+        else:
+            # v1 scalar shape (legacy): keep the existing scalar checks unchanged.
+            _require(data, "branch", str, errors)
+            _require_nullable(data, "pushed_sha", str, errors)
+            # ... (retain the existing scalar block verbatim)
+```
+
+Check `_require`/`_require_enum`/`_require_nullable`/`_validate_string_list` signatures in `validate_result.py` for the `ctx=` parameter (they accept a positional `ctx` string prefix); if `ctx` is not supported, inline the prefix into the field name string instead.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_reconcile.py -v`
+Expected: PASS (new multi-repo tests + existing reconcile tests still green — existing tests that call `write_apply_status` with the old scalar signature must be updated to the new signature in this task; list them with `grep -rn "write_apply_status" lib/pulse/scripts/tests/` and update each call site to pass `selection`/`repos`/`state`).
+
+- [ ] **Step 7: Full pulse-gh suite green**
+
+Run: `uv run pytest lib/pulse/scripts/tests/ -q`
+Expected: PASS (1522 + new tests; fix any call-site fallout from the `write_apply_status` signature change and the `resolve_intended_base` dict return).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/pulse/scripts/apply_reconcile.py lib/pulse/scripts/validate_result.py lib/pulse/scripts/tests/test_apply_reconcile.py lib/pulse/scripts/apply_driver.py
+git commit -m "feat(apply): multi-repo apply-status + rollup + per-repo base resolution"
+```
+
+---
+
+### Task 5: pulse-gh driver per-repo iteration (`apply_driver.py`, `resolve_run.py`)
+
+**Files:**
+- Modify: `lib/pulse/scripts/apply_driver.py`
+- Modify: `lib/pulse/scripts/resolve_run.py` (step `repos`)
+- Test: `lib/pulse/scripts/tests/test_apply_driver.py`
+
+**Interfaces:**
+- Consumes: Task 3's `_rederive_neutral` (multi-repo proposal), Task 4's `resolve_intended_base` (dict return), `write_apply_status`/`open_apply_pr`/`upsert_repo_status`.
+- Produces: `run_apply(...)` returns an apply-status document with a multi-repo `repos` map and rollup `state`.
+
+**Behavior:** Delete the `len(selection) > 1` guard. `base_refs` is now the dict from `resolve_intended_base`. Iterate repos through the phases (already per-repo); on a repo's phase failure, record that repo's outcome as `failed`/`blocked` and continue. `_finish_push`/`open_apply_pr` are per repo. The ledger step records `repos: [...]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Delete the existing `test_multi_repo_blocks_before_pen_create` (it asserts the old blocking behavior — now wrong) and add:
+
+```python
+def test_run_apply_multi_repo_one_repo_fails_others_continue(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    other = "acme/other"
+    kwargs, runner, _, result_path = setup_run(tmp_path, monkeypatch, (REPO, other))
+
+    monkeypatch.setattr(
+        apply_driver.nave_adapter, "pen_capabilities",
+        lambda r: runner.calls.append(["pen", "capabilities"]) or {
+            "adapter_state": "ok", "protocol_version": 1},
+    )
+    monkeypatch.setattr(
+        apply_driver.nave_adapter, "pen_create",
+        lambda r, q, n: runner.calls.append(["pen", "create"]) or SimpleNamespace(
+            state="ok", pen={"name": n, "repos": [{"repo": REPO}, {"repo": other}]}, stderr=""),
+    )
+    monkeypatch.setattr(
+        apply_driver.nave_adapter, "pen_status", lambda r, n: {
+            "repos": [
+                {"owner": "acme", "repo": "widget", "clone_path": "/clone/widget"},
+                {"owner": "acme", "repo": "other", "clone_path": "/clone/other"},
+            ]},
+    )
+    reader = SimpleNamespace(
+        read_repo_head=lambda repo: "commit",
+        read_repo_file=lambda *a: b"",
+        read_repo_changed_paths=lambda *a: (),
+    )
+    monkeypatch.setattr(apply_driver.pen_clone_reader, "make_pen_clone_reader", lambda *a, **k: reader)
+    monkeypatch.setattr(
+        apply_driver.apply_phases, "preflight_phase",
+        lambda *a: {REPO: {"state": "ok"}, other: {"state": "ok"}},
+    )
+    monkeypatch.setattr(
+        apply_driver.apply_phases, "provision_phase",
+        lambda *a: {REPO: {"state": "ok", "observed_base_sha": "base"},
+                    other: {"state": "failed", "reason": "boom"}},
+    )
+    monkeypatch.setattr(apply_driver.apply_phases, "exec_phase", lambda *a: {REPO: {"state": "ok"}})
+    monkeypatch.setattr(apply_driver.apply_phases, "validate_phase", lambda *a: {REPO: {"state": "ok"}})
+
+    class MultiOps:
+        def __init__(self):
+            self.calls = []
+        def commit_repos(self, message, bounds):
+            self.calls.append("commit")
+            return {REPO: {"state": "ok", "local_commit_sha": "commit"}}
+        def push_repos(self, branch):
+            self.calls.append("push")
+            return {REPO: {"state": "ok", "remote_ref": branch, "remote_sha": "commit",
+                           "upstream": f"origin/{branch}"}}
+
+    monkeypatch.setattr(apply_driver.apply_ops, "make_apply_ops", lambda *a: MultiOps())
+
+    result = apply_driver.run_apply(**kwargs)
+    assert result["state"] == "pr_opened"
+    assert result["repos"][other]["state"] == "blocked"
+    assert "boom" in result["repos"][other]["reason"]
+    assert result["repos"][REPO]["state"] == "pr_opened"
+```
+
+Note: `setup_run` monkeypatches `resolve_intended_base` to return the string `"main"`; the rewritten driver broadcasts a string base across all repos (`isinstance(resolved_base, str)` guard), so this harness remains valid. The new test asserts the observable contract (per-repo states + rollup), leaving the driver's internal `pending`-list mechanics to Step 4.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_driver.py -k multi_repo -v`
+Expected: FAIL — the driver raises `RederiveError("multi-repo apply is v2")`.
+
+- [ ] **Step 3: Remove the guard + thread per-repo base refs**
+
+In `run_apply` (lines 150-207):
+- Delete lines 175-176 (`if len(proposal.selection) > 1: raise ...`).
+- Replace `repo = proposal.selection[0]` (line 179) with `selection = proposal.selection`.
+- Replace the `base_refs = {repo: apply_reconcile.resolve_intended_base(...)}` (lines 181-183) with:
+
+```python
+        resolved_base = apply_reconcile.resolve_intended_base(
+            rederived.source_kind, binding_ref, rederived.finalizer_record
+        )
+        if isinstance(resolved_base, str):
+            base_refs = {repo: resolved_base for repo in proposal.selection}
+        else:
+            base_refs = resolved_base
+```
+
+- Every subsequent `repo` scalar reference in the fenced body (lines 209-397) becomes a loop over `proposal.selection`. The phases already return per-repo dicts; the driver interprets them. For each repo that fails a phase, call `journal` per repo (already keyed) and accumulate a `repo_outcomes` dict. `_finish_push` becomes a per-repo function taking `(repo, remote_sha)`.
+
+- [ ] **Step 4: Rewrite the fenced body as a per-repo loop**
+
+The fenced block (lines 262-397) is restructured so each phase is driven once, its per-repo outcome dict is interpreted, and failed repos are recorded and excluded from subsequent phases. Concretely, keep the pen creation + preflight as-is (they return per-repo dicts already), then for the provision/exec/validate/commit/push sequence, track `pending = list(selection)` and `outcomes: dict[repo, dict]`; after each phase, remove repos whose outcome is not `ok` and record them. `_finish_push(repo, remote_sha)` calls `open_apply_pr` for that repo. After the loop, write the multi-repo status via `write_apply_status(..., selection=list(selection), repos=outcomes, state=rollup_state(outcomes), ...)`.
+
+Because this is the largest change, structure it as: (a) a helper `_repo_outcome(state, **fields)`; (b) `failure()` now takes `repo_outcomes` and writes the multi-repo doc; (c) the happy path accumulates per-repo outcomes and calls `_finish_push` per repo.
+
+- [ ] **Step 5: Ledger step `repos` (`resolve_run.py`)**
+
+In `cmd_create` (lines 129-146), change the step dict to write `"repos": [r for r in (s.get("repos") or s.get("repo") or "").split(",") if r]` instead of the scalar `"repo"` field, keeping a `"repo": s.get("repo", "")` legacy field for backward compat if any consumer reads it. Keep the run-level `repos` (lines 163) unchanged. Add a test in `test_apply_driver.py` (or a `resolve_run` test) asserting a created step has `repos == ["hiivmind/a", "hiivmind/b"]`.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_driver.py -v`
+Expected: PASS (multi-repo driver test + existing driver tests green).
+
+- [ ] **Step 7: Full pulse-gh suite green**
+
+Run: `uv run pytest lib/pulse/scripts/tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/pulse/scripts/apply_driver.py lib/pulse/scripts/resolve_run.py lib/pulse/scripts/tests/test_apply_driver.py
+git commit -m "feat(apply): per-repo driver iteration + ledger step repos"
+```
+
+---
+
+### Task 6: pulse-gh per-repo reconcile loop (`apply_reconcile.py`)
+
+**Files:**
+- Modify: `lib/pulse/scripts/apply_reconcile.py`
+- Test: `lib/pulse/scripts/tests/test_apply_reconcile.py`
+
+**Interfaces:**
+- Consumes: Task 4's `load_apply_status` (multi-repo doc), `upsert_repo_status`, `rollup_state`.
+- Produces: `reconcile_apply(...)` reconciles every repo in the result's `repos` map in one pass and recomputes the rollup. It keeps its existing scalar parameters for one repo (backward compat) but the CLI (`main`) iterates the `repos` map.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_reconcile_repos_iterates_and_rolls_up(tmp_path):
+    ledger_path = create_test_ledger(tmp_path, step_id="reconcile-repo1")
+    result_path = tmp_path / "apply-status.yaml"
+    gh_ops = FakeGhOps()
+
+    repos = {
+        "testorg/repo1": {"branch": "pulse/apply/p", "state": "pr_opened",
+                          "intended_base": "main", "expected_head_sha": "sha1",
+                          "pushed_sha": "sha1", "pr_url": "https://x/1",
+                          "merged_sha": None, "observed_base": None,
+                          "observed_head_sha": None, "reason": None},
+        "testorg/repo2": {"branch": "pulse/apply/p", "state": "pr_opened",
+                          "intended_base": "main", "expected_head_sha": "sha2",
+                          "pushed_sha": "sha2", "pr_url": "https://x/2",
+                          "merged_sha": None, "observed_base": None,
+                          "observed_head_sha": None, "reason": None},
+    }
+    apply_reconcile.write_apply_status(
+        result_path, proposal_id="prop-101",
+        selection=["testorg/repo1", "testorg/repo2"], repos=repos,
+        state="pr_opened", recorded_proposal_id="prop-101",
+        proposal_digest=PROPOSAL_DIGEST, authorization_digest=AUTHORIZATION_DIGEST,
+        workspace="testorg",
+        actor={"gh_login": "octocat", "machine": "mba-m4", "mode": "interactive"},
+    )
+    # repo1 merged; repo2 still open.
+    gh_ops.prs[("testorg/repo1", "pulse/apply/p")] = {
+        "url": "https://x/1", "state": "MERGED", "merged": True,
+        "merge_commit_sha": "merge1", "base": "main", "head_ref": "sha1",
+    }
+    gh_ops.prs[("testorg/repo2", "pulse/apply/p")] = {
+        "url": "https://x/2", "state": "OPEN", "merged": False,
+        "merge_commit_sha": None, "base": "main", "head_ref": "sha2",
+    }
+
+    doc = apply_reconcile.reconcile_repos(
+        ledger_path=ledger_path, step_id="reconcile-repo1", result_path=result_path,
+        gh_ops=gh_ops, recorded_proposal_id="prop-101",
+        proposal_digest=PROPOSAL_DIGEST, authorization_digest=AUTHORIZATION_DIGEST,
+        actor_id="octocat@mba-m4", workspace="testorg",
+    )
+    assert doc["repos"]["testorg/repo1"]["state"] == "applied"
+    assert doc["repos"]["testorg/repo1"]["merged_sha"] == "merge1"
+    assert doc["repos"]["testorg/repo2"]["state"] == "pr_opened"
+    assert doc["state"] == "pr_opened"
+```
+
+`FakeGhOps.view_pr` already returns `observed_base`/`observed_head_sha` from the seeded PR's
+`base`/`head_ref`, so repo1 (base `main` == intended, head `sha1` == expected) passes the merge gate
+and reaches `applied`, while repo2 stays `pr_opened`; the rollup is `pr_opened`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_reconcile.py -k iterates -v`
+Expected: FAIL — `reconcile_apply` reads scalar `existing["pushed_sha"]` (now absent in the multi-repo doc) and does not iterate.
+
+- [ ] **Step 3: Add a `reconcile_repos` loop**
+
+Add a new function next to `reconcile_apply` that drives the existing single-repo merge check per repo:
+
+```python
+def reconcile_repos(
+    *,
+    ledger_path: str | Path,
+    step_id: str,
+    result_path: str | Path,
+    gh_ops: GhOps,
+    recorded_proposal_id: str,
+    proposal_digest: str,
+    authorization_digest: str,
+    actor_id: str = "octocat@mba-m4",
+    workspace: str = "unknown",
+) -> dict:
+    """Reconcile every repo in the result's `repos` map in one pass."""
+    existing = load_apply_status(result_path)
+    if existing is None or "repos" not in existing:
+        raise ApplyStatusError(
+            "reconcile_repos requires a multi-repo apply-status document"
+        )
+    proposal_id = existing["proposal_id"]
+    selection = existing["selection"]
+    for repo, entry in list(existing["repos"].items()):
+        if entry.get("state") in {"applied", "rejected"}:
+            continue
+        updated = _reconcile_one_repo(
+            ledger_path=ledger_path, step_id=step_id, result_path=result_path,
+            proposal_id=proposal_id, selection=selection, repo=repo, entry=entry,
+            gh_ops=gh_ops, recorded_proposal_id=recorded_proposal_id,
+            proposal_digest=proposal_digest, authorization_digest=authorization_digest,
+            actor_id=actor_id, workspace=workspace,
+        )
+        if updated:
+            existing = updated
+    return existing
+```
+
+Factor the merge-check body of `reconcile_apply` (lines 502-737: `view_pr` → merged/not-merged → `write_apply_status` per repo) into `_reconcile_one_repo(...)`, which uses `upsert_repo_status` to write the single repo's updated entry. `_reconcile_one_repo` returns the full updated doc (or `None` if the repo was already terminal). The existing `reconcile_apply` keeps its scalar signature for backward compatibility and delegates to `_reconcile_one_repo` for a one-element selection.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest lib/pulse/scripts/tests/test_apply_reconcile.py -v`
+Expected: PASS (new test + existing reconcile tests green).
+
+- [ ] **Step 5: Full pulse-gh suite green**
+
+Run: `uv run pytest lib/pulse/scripts/tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/pulse/scripts/apply_reconcile.py lib/pulse/scripts/tests/test_apply_reconcile.py
+git commit -m "feat(apply): per-repo reconcile loop with fleet rollup"
+```
+
+---
+
+## Final verification (after Task 6)
+
+- [ ] `uv run pytest lib/pulse/scripts/tests/ -q` — full pulse-gh suite green.
+- [ ] `cargo test` in `~/git/discreteds/nave` — nave suite green (158 + 1 fleet test).
+- [ ] Live proof (manual, after merge): seed `apply-neutral.yaml` with a 2-repo `format-python` fleet binding, run the driver against two real hiivmind repos, confirm two PRs → merge one → `partial` → merge both → `applied`. Then re-run with a `repo_selector` binding after `nave scan`.
+
+## Execution Handoff
+
+The plan is saved. Execute with superpowers:subagent-driven-development (fresh subagent per task + review between tasks) or superpowers:executing-plans (batch with checkpoints).

--- a/docs/superpowers/specs/2026-08-15-multi-repo-apply-design.md
+++ b/docs/superpowers/specs/2026-08-15-multi-repo-apply-design.md
@@ -1,0 +1,278 @@
+# Multi-Repo Apply (v2) — Design Spec
+
+**Date:** 2026-08-15
+**Status:** Approved (brainstorm)
+**Origin:** `lib/pulse/scripts/apply_driver.py` — the `raise RederiveError("multi-repo apply is v2")`
+guard; the apply-mode production-wiring spec's single-mutator / single-repo v1 scope
+(`docs/superpowers/specs/2026-07-30-apply-mode-production-wiring-design.md`).
+
+**Read alongside:** the production-wiring spec (§ 4 authorization model, § 5A–E components), the
+workspace-enrollment design (`docs/superpowers/specs/2026-08-14-apply-mode-workspace-enrollment-design.md`),
+`lib/pulse/scripts/apply_rederive.py` (re-derivation providers), `lib/pulse/scripts/apply_driver.py`
+(the fenced sequencer), `lib/pulse/scripts/apply_reconcile.py` (status + reconcile), and
+`docs/backlogs/README.md` (cross-repo dependency map).
+
+---
+
+## 1. Problem — one repo at a time
+
+Apply-mode today lands one allow-listed mutation on **one** repository per run. The driver's
+`run_apply` hard-blocks at `len(proposal.selection) > 1` with `RederiveError("multi-repo apply is
+v2")`. For fleet-of-repos management — the flagship use case the harness exists for — that means a
+fleet-wide sweep (e.g. `format-python` across every hiivmind Python repo) is N manual single-repo
+invocations with no shared proposal, fence, journal, or rollup. One repo's outcome is invisible to
+the others, and there is no fleet-level terminal state.
+
+This closes the gap: **one proposal → N repositories**, driven through the existing already-multi-
+repo spine, with per-repo independent outcomes and a fleet-level rollup.
+
+## 2. Decisions (settled in brainstorm)
+
+1. **One proposal, N repos** — a single proposal id + one fence/lease/journal spans all repos; one
+   pen holds N clones; N branches/PRs (one per repo); per-repo reconcile with a fleet rollup. This
+   is the literal `multi-repo is v2` stub, not an orchestration fan-out of the single-repo driver.
+2. **Fleet naming = explicit list + optional selector.** A binding names `repos: [...]`
+   explicitly, and may add a `repo_selector` resolved at collect-time against nave's fleet cache.
+   The two union (de-duplicated, sorted) and the resolved list is recorded in the proposal for
+   audit.
+3. **Per-repo independent failure.** A repo failing at provision/transform/commit/push is recorded
+   `failed`/`blocked` in its own outcome; the rest continue. Terminal is per-repo.
+4. **Nave owns fleet discovery.** Selector resolution shells out to nave (per F11: "nave owns the
+   clone lifecycle end-to-end — fleet discovery, refresh, pen creation"). pulse-gh never
+   re-implements repo enumeration; it consumes a nave fleet-query result.
+5. **Fleet id is deterministic over the resolved repo set.** Single-repo bindings keep the existing
+   `apply-{transformation}-{owner}-{name}` id (stable — referenced in existing ledgers/audit
+   trails); fleet bindings use `apply-{transformation}-{owner}-{sha256(sorted repos)[:12]}` so a
+   membership change yields a new proposal id.
+
+## 3. Architecture — what already works vs. what changes
+
+The mutation spine is **already multi-repo**. Verified against current code:
+
+| Layer | Shape today | Change needed |
+|-------|-------------|---------------|
+| `mutation_plan.Proposal` | `selection: tuple`, `expected_shas: dict[repo,sha]`, `bound_paths: dict[repo,paths]` | none |
+| `mutation_plan.build_proposal` | cross-repo validation (no dupes, shas/bounds cover selection exactly) | none |
+| `apply_authorization.authorize` | iterates every selected repo against `permitted_repos` + per-repo `bound_paths` | none |
+| `apply_journal.Journal` | records keyed `repos[repo]` with per-repo phase/evidence | none |
+| `apply_phases.{preflight,provision,exec,validate,commit,push}` | all loop `for repo in proposal.selection`, return `dict[repo, outcome]` | none |
+| `nave_pen` / `nave_apply` | one pen ↔ N clones; verbs take per-repo request maps | none |
+| `apply_rederive._collect_neutral` / `_rederive_neutral` | single `repo`, single `head_sha` | **fleet expansion + per-repo HEAD** |
+| `apply_reconcile.resolve_intended_base` | returns one `base_ref` string | **per-repo base refs** |
+| `apply_driver.run_apply` | `>1` guard + scalar `repo`/`base_refs`/`_finish_push` | **per-repo iteration + outcomes** |
+| `apply_reconcile.write_apply_status` / `open_apply_pr` / `reconcile_apply` | scalar `branch`/`pushed_sha`/`pr_url`/`merged_sha` | **per-repo `repos` map + rollup** |
+| `resolve_run` ledger step | scalar `repo` (run-level `repos` already a list) | **step `repos: [...]`** |
+
+Four files carry the scalar assumptions; the rest is untouched.
+
+## 4. pulse-gh changes
+
+### 4.1 Binding schema + fleet expansion (`apply_rederive.py`)
+
+A neutral binding is exactly one of single-repo or fleet:
+
+```yaml
+# single (unchanged)                 # fleet (new)
+- repo: hiivmind/agent-kernel        - repos: [hiivmind/a, hiivmind/b]
+  transformation: format-python        repo_selector:            # optional; unions in
+  base_ref: main                         term: "pyproject:true"  # resolved via nave fleet
+  bound_paths: [src/**]                transformation: format-python
+                                       bound_paths: [src/**]
+```
+
+- `_validate_neutral_binding` accepts exactly one of `repo` (single) or `repos`/`repo_selector`
+  (fleet) — both present, or neither, is a `RederiveError` (fail-closed).
+- `_collect_neutral` resolves the fleet: explicit `repos` ∪ selector results, de-duplicated and
+  sorted, then fetches live HEAD **per repo** via `io_seams.gh_api(repos/{o}/{n}/branches/{base})`,
+  returning `head_shas: dict[repo, sha]` (replacing the single `head_sha`). A per-repo HEAD fetch
+  failure is a per-repo blocked outcome, not a whole-run abort — see § 5.1 for the collect/fence
+  split.
+- **Selector resolution** uses nave as the fleet source of truth: pulse-gh shells out to
+  `nave fleet list --json` (new, § 8) and parses `[{owner, name, default_branch}]`. A selector is
+  a nave search term (the same term syntax `nave search` uses). The resolved list is captured in the
+  proposal for audit (§ 4.3).
+- **Per-repo base ref**: each repo's base is its resolved default branch (from fleet meta), with the
+  binding's explicit `base_ref` as a global override (or a per-repo `base_refs` map for
+  heterogeneous fleets). `resolve_intended_base("neutral", …)` returns `dict[repo, base_ref]`.
+
+### 4.2 Re-derivation (`_rederive_neutral`)
+
+Builds one multi-repo proposal from the binding + per-repo HEADs:
+
+```python
+selection = tuple(sorted(resolved_repos))
+id = neutral_proposal_id(binding)          # single-repo: apply-{t}-{owner}-{name};
+                                            # fleet:      apply-{t}-{owner}-{sha256(selection)[:12]}
+mutation_plan.build_proposal(
+    id=id,
+    selection=selection,
+    transformation=binding["transformation"],
+    expected_shas=head_shas,               # dict[repo, sha] — every repo covered
+    bound_paths={repo: binding["bound_paths"] for repo in selection},
+    mutation_policy="allow-listed",
+    actor=actor,
+    registry=inputs.registry,
+)
+```
+
+The neutral transformation allowlist (`NEUTRAL_TRANSFORMATIONS`) and `build_proposal`'s exact
+per-repo `bound_paths` coverage checks are unchanged — they now fire per repo. `NeutralProviderInputs`
+gains `head_shas: dict[str, str]` and a resolved `selection: tuple[str, ...]` (replacing the single
+`head_sha`; the single-repo path is a degenerate one-element fleet). `binding_id` for `authorize()`
+identity becomes the fleet id (single-repo keeps `binding["repo"]`).
+
+### 4.3 Audit of the resolved fleet
+
+Selector expansion is **dynamic**, so the proposal must record what it actually resolved. The
+resolved, sorted `selection` is:
+- the `Proposal.selection` (already part of the proposal → already in the proposal digest), and
+- captured in `recorded_summary["selection"]` so the synthesized-summary identity check (§ 4.5 of
+  the enrollment spec) pins the exact membership the run is authorized for.
+
+A selector that resolves to an empty set is a `RederiveError` (fail-closed: "nothing to do" is
+never silently a no-op apply).
+
+## 5. Driver (`apply_driver.py`)
+
+### 5.1 Fence + collection split
+
+The current driver collects/re-derives/authorizes **before** acquiring the lease, and a collect
+failure returns a whole-run `blocked` status. For multi-repo this is wrong: one repo's missing HEAD
+must not block the other N. Split:
+
+- **Collect + re-derive + authorize** (pre-fence): fleet resolution must succeed as a whole —
+  selector expansion, proposal construction, and `authorize()` are whole-run gates (a bad binding,
+  an unauthorized repo, or an empty selector is a whole-run `blocked`, because the proposal itself
+  is the unit of authorization). A per-repo HEAD fetch that fails here is recorded as a **per-repo
+  blocked outcome** and the repo is dropped from `selection` — not a whole-run abort — because the
+  remaining repos still form a valid, authorized proposal.
+- **Fenced mutation** (post-lease): per-repo independent. The existing phases already return
+  per-repo outcomes; the driver loops, records each repo's outcome in the journal, and continues on
+  failure.
+
+### 5.2 Iteration
+
+- Delete the `len(selection) > 1` guard. `apply_branch = pulse/apply/{id}` and
+  `pen_name = pulse-apply-{id}` stay scalar — one proposal, one pen, one branch name per repo
+  (branches live in different repos, so the shared name does not collide).
+- `base_refs` becomes `dict[repo, base_ref]` (from § 4.1); `bound_paths` stays `dict[repo, paths]`
+  (already per-repo; the existing `_expand_bound_globs` already iterates repos).
+- Drive the phases once per proposal (they already loop repos internally); the driver's job is to
+  interpret the per-repo outcome dict and record each repo's journal state.
+- **`_finish_push` → per repo**: `open_apply_pr` is called once per repo that reached `pushed`;
+  each PR is recorded in that repo's outcome. Repos that failed earlier are already recorded and
+  skipped.
+
+### 5.3 Crash-resume
+
+The existing resume contract holds per repo: the journal is keyed per repo, and a crash between a
+phase and its completion receipt resumes that repo (reset + re-exec for `transformed`, remote
+reconciliation for `pushed`) without touching repos that already completed. The driver's resume
+logic iterates the same per-repo records it already reads; the only change is looping over the
+selection instead of a single `repo`.
+
+## 6. Status + reconcile (`apply_reconcile.py`)
+
+### 6.1 Multi-repo apply-status
+
+`write_apply_status` gains a per-repo map while keeping the top-level summary fields:
+
+```yaml
+kind: apply-status
+contract_version: 1
+state: pr_opened                    # fleet rollup (§ 6.2)
+proposal_id: apply-format-python-hiivmind-<hash12>
+selection: [hiivmind/a, hiivmind/b]   # was [repo]; now the full fleet
+repos:
+  hiivmind/a:
+    state: pr_opened
+    branch: pulse/apply/apply-format-python-hiivmind-<hash12>
+    intended_base: main
+    expected_head_sha: 5be8f8f…
+    pushed_sha: 5be8f8f…
+    pr_url: https://github.com/hiivmind/a/pull/1
+    merged_sha: null
+    observed_base: main
+    observed_head_sha: 5be8f8f…
+    reason: null
+  hiivmind/b:
+    state: applied
+    # … same shape, merged_sha set
+```
+
+Backward compatibility: `load_apply_status` accepts the v1 single-repo shape (no `repos` map) and
+normalizes it to a one-element fleet in memory, so an in-flight v1 result file is still reconcilable.
+New writes always emit the multi-repo shape.
+
+### 6.2 Fleet rollup state
+
+The top-level `state` is a pure function of the per-repo states, in precedence order (first match
+wins — this is total over every combination):
+
+```
+any repo state in {pr_opened, pushed}            -> pr_opened
+all repos applied                                -> applied
+all repos rejected                               -> rejected
+all repos in {failed, blocked}                   -> failed
+otherwise (mixed applied/rejected/failed/blocked) -> partial
+```
+
+Whole-run `blocked`/`failed` statuses from the pre-fence gates (§ 5.1) are not a rollup — they are
+written directly, before any per-repo outcome exists.
+
+### 6.3 Reconcile loop
+
+`reconcile_apply` re-runs per repo: for each repo in the `repos` map, it checks that repo's PR merge
+state (base + head verified, same CAS as today), updates that repo's `state`/`merged_sha`, then
+recomputes the rollup. Pure-neutral means no base advance per repo (§ 4.4 of the enrollment spec);
+the `applied` terminal needs **all** repos merged. `open_apply_pr` and the CLI surface are per-repo:
+the driver calls them per repo; the reconcile CLI takes the same fleet-scoped proposal id and
+reconciles every repo in the result's `repos` map in one pass.
+
+## 7. Ledger (`resolve_run.py`)
+
+The ledger step's scalar `repo` becomes `repos: [...]` (the run-level `repos` is already a list; the
+step now mirrors it so one step = one fleet proposal). Single-repo steps keep `repos: [one]`.
+`find_step`/`check_dag`/`recompute_status` are unchanged (they already treat `repos` as opaque at the
+run level; the step field is additive). The `--repos` create flag already accepts a comma-separated
+list, so `cmd_create` needs only to write the step's `repos` from the same source.
+
+## 8. nave — fleet query (`nave fleet list --json`)
+
+- A dedicated `nave fleet list --json` subcommand (chosen over a `--json` flag on `nave search`:
+  a stable, search-syntax-independent contract the driver depends on; `nave search`'s term syntax
+  remains free to evolve). It resolves a term against the fleet cache and emits:
+
+```json
+[{"owner": "hiivmind", "name": "agent-kernel", "default_branch": "main"}]
+```
+
+- Reuses the existing `nave_search` matcher against the scanned fleet cache; no new discovery logic.
+- Deterministic output (sorted) so the resolved selection is stable and the fleet id is reproducible.
+- Missing/empty fleet cache → non-zero exit; the driver surfaces that as a `blocked` outcome
+  ("selector resolution requires a prior `nave scan`"), matching the F11 "scan before pen" lifecycle.
+
+## 9. Testing
+
+1. **Re-derive** (`test_apply_rederive_neutral`): fleet expansion from explicit `repos`; selector
+   union + dedup + sort; per-repo HEAD fetch into `head_shas`; fleet id determinism (same sorted
+   set → same id; different set → different id); empty selector → `RederiveError`; single-repo id
+   unchanged for backward compatibility.
+2. **Driver**: N repos through the full phase sequence; one repo failing at provision/transform/
+   commit leaves the others proceeding; per-repo journal states; `_finish_push` opens N PRs.
+3. **Reconcile**: multi-repo status schema round-trip; v1 single-repo normalization; rollup
+   transitions (`pr_opened` → `partial` → `applied`); per-repo merge detection.
+4. **Live proof**: a 2-repo `format-python` run (bindings for two real hiivmind repos) driving the
+   real `apply_driver` → one pen/two clones → two branches → two PRs → merge one → `partial` →
+   merge both → `applied`. Then the selector path against the real fleet (post `nave scan`).
+
+## 10. Non-goals (v2 scope guard)
+
+- **Scheduled multi-repo applies** (sweeps on a cron) — the ledger already carries scheduled mode,
+  but the fleet run is still triggered interactively here; a scheduled sweep workflow is a follow-up.
+- **Merge-on-green auto-merge policy** — reconcile still waits for manual merge per repo (as v1).
+- **Cross-repo atomicity** — PRs are independent by nature; there is no all-or-nothing rollback.
+- **Non-neutral sources' multi-repo** — plan-sync / generated-artifact / marketplace-sync remain
+  single-repo (their bindings are single-repo by shape); this spec generalizes the neutral provider
+  only. The driver/reconcile/status changes are source-agnostic, so the other providers gain the
+  capability for free when their bindings grow a fleet shape — but that is out of scope here.

--- a/lib/pulse/scripts/apply_driver.py
+++ b/lib/pulse/scripts/apply_driver.py
@@ -172,15 +172,17 @@ def run_apply(*, source_kind, binding_ref, recorded_summary=None, authorization_
         auth = apply_authorization.load_authorization(authorization_path, proposal.transformation)
         authorization_digest = apply_authorization.authorization_digest(auth)
         apply_authorization.authorize(rederived, auth, recorded_summary)
-        if len(proposal.selection) > 1:
-            raise apply_rederive.RederiveError("multi-repo apply is v2")
         if not proposal.selection:
             raise apply_rederive.RederiveError("apply proposal selection is empty")
-        repo = proposal.selection[0]
+        selection = proposal.selection
         entry = _entry(inputs, workspace, proposal.transformation)
-        base_refs = {repo: apply_reconcile.resolve_intended_base(
+        resolved_base = apply_reconcile.resolve_intended_base(
             rederived.source_kind, binding_ref, rederived.finalizer_record
-        )}
+        )
+        if isinstance(resolved_base, str):
+            base_refs = {repo: resolved_base for repo in selection}
+        else:
+            base_refs = resolved_base
         if rederived.finalizer_record:
             _persist_finalizer(result_path, rederived.finalizer_record)
     except (apply_rederive.RederiveError, apply_authorization.AuthorizationError,
@@ -228,16 +230,34 @@ def run_apply(*, source_kind, binding_ref, recorded_summary=None, authorization_
             nave_version=nave_version, repo_outcomes=outcomes,
         )
 
-    def _finish_push(remote_sha):
-        """Durable pushed receipt + PR open — shared by the normal path and the
-        pushed-boundary crash-resume path."""
+    def _finish_push(repo, remote_sha):
+        """Durable pushed receipt + PR open for one repo — shared by the normal
+        path and the pushed-boundary crash-resume path."""
+        actor_doc = {"gh_login": actor.gh_login, "machine": actor.machine, "mode": actor.mode}
         pushed_result = apply_reconcile.write_apply_status(
-            result_path, proposal_id=proposal.id, repo=repo, branch=apply_branch,
-            state="pushed", recorded_proposal_id=recorded_summary["proposal_id"],
-            proposal_digest=proposal_digest, authorization_digest=authorization_digest,
-            intended_base=base_refs[repo], expected_head_sha=remote_sha,
-            pushed_sha=remote_sha, workspace=workspace,
-            actor={"gh_login": actor.gh_login, "machine": actor.machine, "mode": actor.mode},
+            result_path,
+            proposal_id=proposal.id,
+            selection=list(selection),
+            repos={
+                repo: {
+                    "branch": apply_branch,
+                    "state": "pushed",
+                    "intended_base": base_refs[repo],
+                    "expected_head_sha": remote_sha,
+                    "pushed_sha": remote_sha,
+                    "pr_url": None,
+                    "merged_sha": None,
+                    "observed_base": None,
+                    "observed_head_sha": None,
+                    "reason": None,
+                },
+            },
+            state="pushed",
+            recorded_proposal_id=recorded_summary["proposal_id"],
+            proposal_digest=proposal_digest,
+            authorization_digest=authorization_digest,
+            workspace=workspace,
+            actor=actor_doc,
         )
         try:
             resolve_run.renew_lease(ledger_path, step_id, actor_id, token)
@@ -250,14 +270,24 @@ def run_apply(*, source_kind, binding_ref, recorded_summary=None, authorization_
                 recorded_proposal_id=recorded_summary["proposal_id"],
                 proposal_digest=proposal_digest, authorization_digest=authorization_digest,
                 intended_base=base_refs[repo], expected_head_sha=remote_sha,
-                token=token, actor_id=actor_id, workspace=workspace,
+                selection=list(selection), token=token, actor_id=actor_id, workspace=workspace,
             )
-            journal.complete(repo, "pr_opened", pr_url=result.get("pr_url"))
+            journal.complete(repo, "pr_opened", pr_url=result.get("repos", {}).get(repo, {}).get("pr_url"))
             return result
         except Exception:
             # The pushed receipt is the crash-recovery input. Never replace it
             # with a pre-push repo-mutation document when PR creation fails.
             return pushed_result
+    repo = selection[0]
+
+    if len(selection) > 1:
+        return _run_multi_repo(
+            ledger_path=ledger_path, step_id=step_id, actor_id=actor_id, token=token,
+            runner=runner, gh_ops=gh_ops, result_path=result_path, workspace=workspace,
+            proposal=proposal, selection=list(selection), base_refs=base_refs, entry=entry,
+            recorded_summary=recorded_summary, proposal_digest=proposal_digest,
+            authorization_digest=authorization_digest, actor=actor, nave_version=nave_version,
+        )
 
     try:
         with ApplyLock(f"{ledger_path}.apply.lock"):
@@ -290,7 +320,7 @@ def run_apply(*, source_kind, binding_ref, recorded_summary=None, authorization_
                 remote_sha = previous["evidence"].get("remote_sha")
                 if not remote_sha:
                     return failure("failed", "resume from pushed: missing remote_sha journal evidence")
-                return _finish_push(remote_sha)
+                return _finish_push(repo, remote_sha)
             if resume_transform:
                 pen = {"name": pen_name, "repos": [{"repo": repo}]}
             else:
@@ -394,11 +424,256 @@ def run_apply(*, source_kind, binding_ref, recorded_summary=None, authorization_
                 return failure("failed", _phase_reason("push", outcomes), _failed_outcomes(outcomes, "failed"))
             remote_sha = outcomes[repo]["remote_sha"]
             journal.complete(repo, "pushed", remote_ref=outcomes[repo]["remote_ref"], remote_sha=remote_sha)
-            return _finish_push(remote_sha)
+            return _finish_push(repo, remote_sha)
     except (resolve_run.LeaseError, ApplyLockError) as exc:
         return failure("blocked", f"fencing stopped apply: {exc}")
     except Exception as exc:
         return failure("failed", exc)
+
+def _run_multi_repo(
+    *,
+    ledger_path,
+    step_id,
+    actor_id,
+    token,
+    runner,
+    gh_ops,
+    result_path,
+    workspace,
+    proposal,
+    selection,
+    base_refs,
+    entry,
+    recorded_summary,
+    proposal_digest,
+    authorization_digest,
+    actor,
+    nave_version,
+) -> dict:
+    """Drive one proposal across N repos with per-repo independent outcomes."""
+    apply_branch = f"pulse/apply/{proposal.id}"
+    pen_name = f"pulse-apply-{proposal.id}"
+    journal = Journal(Path(f"{result_path}.journal"))
+    actor_doc = {"gh_login": actor.gh_login, "machine": actor.machine, "mode": actor.mode}
+
+    def _repo_doc(repo, state, reason=None, **fields):
+        doc = {
+            "branch": apply_branch,
+            "state": state,
+            "intended_base": base_refs.get(repo),
+            "expected_head_sha": proposal.expected_shas.get(repo),
+            "pushed_sha": None,
+            "pr_url": None,
+            "merged_sha": None,
+            "observed_base": None,
+            "observed_head_sha": None,
+            "reason": reason,
+        }
+        doc.update(fields)
+        return doc
+
+    def _subset_proposal(repos):
+        return mutation_plan.Proposal(
+            id=proposal.id,
+            selection=tuple(repos),
+            transformation=proposal.transformation,
+            expected_shas={r: proposal.expected_shas[r] for r in repos},
+            mutation_policy=proposal.mutation_policy,
+            actor=proposal.actor,
+            bound_paths={r: proposal.bound_paths[r] for r in repos},
+        )
+
+    def _subset_pen(pen, repos):
+        keep = {f"{item.get('owner')}/{item.get('repo')}" if item.get("owner") else item.get("repo")
+                for item in pen.get("repos", [])}
+        return {"name": pen.get("name"), "repos": [i for i in pen.get("repos", [])
+                                                  if (i.get("repo") or f"{i.get('owner')}/{i.get('repo')}") in set(repos)]}
+
+    def _write_fleet(repos_doc):
+        return apply_reconcile.write_apply_status(
+            result_path,
+            proposal_id=proposal.id,
+            selection=list(selection),
+            repos=repos_doc,
+            state=apply_reconcile.rollup_state(repos_doc),
+            recorded_proposal_id=recorded_summary["proposal_id"],
+            proposal_digest=proposal_digest,
+            authorization_digest=authorization_digest,
+            workspace=workspace,
+            actor=actor_doc,
+        )
+
+    def _finish(repo, remote_sha):
+        pushed = apply_reconcile.upsert_repo_status(
+            result_path,
+            proposal_id=proposal.id,
+            selection=list(selection),
+            repo=repo,
+            repo_doc=_repo_doc(repo, "pushed", pushed_sha=remote_sha),
+            recorded_proposal_id=recorded_summary["proposal_id"],
+            proposal_digest=proposal_digest,
+            authorization_digest=authorization_digest,
+            workspace=workspace,
+            actor=actor_doc,
+        )
+        try:
+            resolve_run.renew_lease(ledger_path, step_id, actor_id, token)
+            journal.begin(repo, "pr_opened", token)
+            result = apply_reconcile.open_apply_pr(
+                ledger_path=ledger_path, step_id=step_id, proposal_id=proposal.id,
+                repo=repo, branch=apply_branch, base=base_refs[repo], pushed_sha=remote_sha,
+                title=f"pulse-apply {proposal.id}", body=f"Automated apply for proposal {proposal.id}.",
+                result_path=result_path, gh_ops=gh_ops,
+                recorded_proposal_id=recorded_summary["proposal_id"],
+                proposal_digest=proposal_digest, authorization_digest=authorization_digest,
+                intended_base=base_refs[repo], expected_head_sha=remote_sha,
+                selection=list(selection), token=token, actor_id=actor_id, workspace=workspace,
+            )
+            journal.complete(repo, "pr_opened", pr_url=result.get("repos", {}).get(repo, {}).get("pr_url"))
+            return result
+        except Exception:
+            return pushed
+
+    try:
+        with ApplyLock(f"{ledger_path}.apply.lock"):
+            resolve_run.renew_lease(ledger_path, step_id, actor_id, token)
+            handle = nave_adapter.pen_create(
+                runner, nave_adapter.PenQuery(terms=list(proposal.selection)), pen_name
+            )
+            if handle.state != "ok":
+                return _write_failure(
+                    result_path, state="failed", reason=handle.stderr or "pen create failed",
+                    actor=actor, workspace=workspace, proposal=proposal,
+                    recorded_summary=recorded_summary, proposal_digest=proposal_digest,
+                    authorization_digest=authorization_digest, nave_version=nave_version,
+                )
+            pen = handle.pen
+            status = nave_adapter.pen_status(runner, pen_name)
+            clone_paths = {
+                f"{item['owner']}/{item['repo']}": item["clone_path"]
+                for item in status.get("repos", [])
+                if isinstance(item, dict) and item.get("owner") and item.get("repo") and item.get("clone_path")
+            }
+            try:
+                pen_clone_reader.make_pen_clone_reader(clone_paths, proposal.selection)
+            except Exception as exc:
+                return _write_failure(
+                    result_path, state="blocked", reason=f"clone identity preflight failed: {exc}",
+                    actor=actor, workspace=workspace, proposal=proposal,
+                    recorded_summary=recorded_summary, proposal_digest=proposal_digest,
+                    authorization_digest=authorization_digest, nave_version=nave_version,
+                )
+
+            outcomes = {}
+            preflight = apply_phases.preflight_phase(runner, pen, proposal, clone_paths)
+            for repo in proposal.selection:
+                o = preflight.get(repo, {})
+                if o.get("state") != "ok":
+                    outcomes[repo] = _repo_doc(repo, "blocked", o.get("reason") or "preflight failed")
+            pending = [r for r in proposal.selection if r not in outcomes]
+            if not pending:
+                return _write_fleet(outcomes)
+
+            ops = apply_ops.make_apply_ops(runner, pen_name, dict(proposal.bound_paths), base_refs)
+            for repo in pending:
+                journal.begin(repo, "branch_provisioned", token, apply_branch=apply_branch,
+                              expected_base_sha=proposal.expected_shas[repo], base_ref=base_refs[repo])
+            prov = apply_phases.provision_phase(runner, pen, ops, proposal, apply_branch, base_refs)
+            base_shas = {}
+            for repo in list(pending):
+                o = prov.get(repo, {})
+                if o.get("state") != "ok":
+                    outcomes[repo] = _repo_doc(repo, "blocked", o.get("reason") or "provision failed")
+                    pending.remove(repo)
+                else:
+                    base_shas[repo] = o["observed_base_sha"]
+                    journal.complete(repo, "branch_provisioned", observed_base_sha=o["observed_base_sha"])
+            if not pending:
+                return _write_fleet(outcomes)
+
+            reader = pen_clone_reader.make_pen_clone_reader(
+                clone_paths, tuple(pending), expected_branch=apply_branch,
+                expected_heads=base_shas, expected_remotes={r: r for r in pending},
+            )
+            for repo in pending:
+                journal.begin(repo, "transformed", token)
+            sub_pen = _subset_pen(pen, pending)
+            executed = apply_phases.exec_phase(runner, sub_pen, entry)
+            for repo in list(pending):
+                o = executed.get(repo, {})
+                if o.get("state") != "ok":
+                    outcomes[repo] = _repo_doc(repo, o.get("state", "failed") if o.get("state") in ("blocked", "failed") else "failed", o.get("reason") or "transform failed")
+                    pending.remove(repo)
+                else:
+                    journal.complete(repo, "transformed")
+            if not pending:
+                return _write_fleet(outcomes)
+
+            for repo in pending:
+                journal.begin(repo, "validated", token)
+            validated = apply_phases.validate_phase(entry, reader, _subset_proposal(pending))
+            for repo in list(pending):
+                o = validated.get(repo, {})
+                if o.get("state") != "ok":
+                    outcomes[repo] = _repo_doc(repo, o.get("state", "failed") if o.get("state") in ("blocked", "failed") else "failed", o.get("reason") or "validate failed")
+                    pending.remove(repo)
+                else:
+                    journal.complete(repo, "validated")
+            if not pending:
+                return _write_fleet(outcomes)
+
+            for repo in pending:
+                journal.begin(repo, "committed", token)
+            bound_paths = {
+                r: _expand_bound_globs(clone_paths[r], proposal.bound_paths.get(r, ()))
+                for r in pending
+            }
+            committed = apply_phases.commit_phase(
+                ops, _subset_proposal(pending),
+                f"pulse-apply {proposal.id} by {actor.gh_login}@{actor.machine}",
+                bound_paths=bound_paths,
+            )
+            local_shas = {}
+            for repo in list(pending):
+                o = committed.get(repo, {})
+                if o.get("state") != "ok":
+                    outcomes[repo] = _repo_doc(repo, "failed", o.get("reason") or "commit failed")
+                    pending.remove(repo)
+                else:
+                    local_shas[repo] = o["local_commit_sha"]
+                    journal.complete(repo, "committed", local_commit_sha=o["local_commit_sha"])
+            if not pending:
+                return _write_fleet(outcomes)
+
+            for repo in pending:
+                journal.begin(repo, "pushed", token, local_commit_sha=local_shas[repo])
+            pushed = apply_phases.push_phase(ops, reader, apply_branch, local_shas)
+            for repo in list(pending):
+                o = pushed.get(repo, {})
+                if o.get("state") != "ok":
+                    outcomes[repo] = _repo_doc(repo, "failed", o.get("reason") or "push failed")
+                    pending.remove(repo)
+                else:
+                    journal.complete(repo, "pushed", remote_ref=o["remote_ref"], remote_sha=o["remote_sha"])
+
+            for repo in pending:
+                final = _finish(repo, pushed[repo]["remote_sha"])
+                outcomes[repo] = final.get("repos", {}).get(repo, _repo_doc(repo, "pr_opened", pushed_sha=pushed[repo]["remote_sha"]))
+            return _write_fleet(outcomes)
+    except (resolve_run.LeaseError, ApplyLockError) as exc:
+        return _write_failure(
+            result_path, state="blocked", reason=f"fencing stopped apply: {exc}",
+            actor=actor, workspace=workspace, proposal=proposal,
+            recorded_summary=recorded_summary, proposal_digest=proposal_digest,
+            authorization_digest=authorization_digest, nave_version=nave_version,
+        )
+    except Exception as exc:
+        return _write_failure(
+            result_path, state="failed", reason=exc,
+            actor=actor, workspace=workspace, proposal=proposal,
+            recorded_summary=recorded_summary, proposal_digest=proposal_digest,
+            authorization_digest=authorization_digest, nave_version=nave_version,
+        )
 
 
 def main(argv=None):

--- a/lib/pulse/scripts/apply_driver.py
+++ b/lib/pulse/scripts/apply_driver.py
@@ -326,7 +326,7 @@ def run_apply(*, source_kind, binding_ref, recorded_summary=None, authorization_
             else:
                 journal.begin(repo, "pen_ready", token)
                 handle = nave_adapter.pen_create(
-                    runner, nave_adapter.PenQuery(terms=list(proposal.selection)), pen_name
+                    runner, nave_adapter.PenQuery(terms=["repo:" + "|".join(proposal.selection)]), pen_name
                 )
                 if handle.state != "ok":
                     return failure("failed", handle.stderr or "pen create failed")
@@ -484,10 +484,14 @@ def _run_multi_repo(
         )
 
     def _subset_pen(pen, repos):
-        keep = {f"{item.get('owner')}/{item.get('repo')}" if item.get("owner") else item.get("repo")
-                for item in pen.get("repos", [])}
-        return {"name": pen.get("name"), "repos": [i for i in pen.get("repos", [])
-                                                  if (i.get("repo") or f"{i.get('owner')}/{i.get('repo')}") in set(repos)]}
+        wanted = set(repos)
+        return {
+            "name": pen.get("name"),
+            "repos": [
+                i for i in pen.get("repos", [])
+                if (i.get("repo") or f"{i.get('owner')}/{i.get('name')}") in wanted
+            ],
+        }
 
     def _write_fleet(repos_doc):
         return apply_reconcile.write_apply_status(
@@ -538,7 +542,7 @@ def _run_multi_repo(
         with ApplyLock(f"{ledger_path}.apply.lock"):
             resolve_run.renew_lease(ledger_path, step_id, actor_id, token)
             handle = nave_adapter.pen_create(
-                runner, nave_adapter.PenQuery(terms=list(proposal.selection)), pen_name
+                runner, nave_adapter.PenQuery(terms=["repo:" + "|".join(proposal.selection)]), pen_name
             )
             if handle.state != "ok":
                 return _write_failure(

--- a/lib/pulse/scripts/apply_reconcile.py
+++ b/lib/pulse/scripts/apply_reconcile.py
@@ -212,7 +212,7 @@ def resolve_intended_base(
     source_kind: str,
     binding_ref: Mapping[str, Any],
     finalizer_record: Mapping[str, Any] | None = None,
-) -> str:
+) -> str | dict[str, str]:
     if source_kind == "plan-sync":
         if finalizer_record and finalizer_record.get("base_ref"):
             return finalizer_record["base_ref"]
@@ -235,10 +235,19 @@ def resolve_intended_base(
         )
 
     if source_kind == "neutral":
+        if binding_ref.get("repo") is not None:
+            repo = binding_ref["repo"]
+            base = binding_ref.get("base_ref")
+            if not isinstance(base, str) or not base:
+                raise ValueError("cannot resolve intended base for neutral: no base_ref")
+            return {repo: base}
+        repos = binding_ref.get("repos") or []
         base = binding_ref.get("base_ref")
         if not isinstance(base, str) or not base:
             raise ValueError("cannot resolve intended base for neutral: no base_ref")
-        return base
+        if not isinstance(repos, list) or not repos:
+            raise ValueError("cannot resolve intended base for neutral: no repos")
+        return {repo: base for repo in repos}
 
     raise ValueError(f"unknown source_kind: {source_kind}")
 
@@ -270,6 +279,24 @@ def load_apply_status(path: str | Path) -> dict | None:
             f"could not load apply status {p}: schema-invalid document: "
             f"{'; '.join(schema_errors)}"
         )
+    # Normalize a v1 single-repo doc (no `repos` map) to a one-element fleet in memory.
+    if "repos" not in data and data.get("selection"):
+        repo = data["selection"][0]
+        data = dict(data)
+        data["repos"] = {
+            repo: {
+                "branch": data.get("branch"),
+                "state": data.get("state"),
+                "intended_base": data.get("intended_base"),
+                "expected_head_sha": data.get("expected_head_sha"),
+                "pushed_sha": data.get("pushed_sha"),
+                "pr_url": data.get("pr_url"),
+                "merged_sha": data.get("merged_sha"),
+                "observed_base": data.get("observed_base"),
+                "observed_head_sha": data.get("observed_head_sha"),
+                "reason": data.get("reason"),
+            }
+        }
     return data
 
 
@@ -305,23 +332,30 @@ def _atomic_write_yaml(path: str | Path, doc: Mapping[str, Any]) -> None:
         raise ApplyStatusError(f"could not write apply status {p}: {exc}") from exc
 
 
+def rollup_state(repos: Mapping[str, Mapping[str, Any]]) -> str:
+    """Fleet rollup (spec § 6.2), total over every combination, first match wins."""
+    states = [r.get("state") for r in repos.values()]
+    if any(s in {"pr_opened", "pushed"} for s in states):
+        return "pr_opened"
+    if all(s == "applied" for s in states):
+        return "applied"
+    if all(s == "rejected" for s in states):
+        return "rejected"
+    if all(s in {"failed", "blocked"} for s in states):
+        return "failed"
+    return "partial"
+
+
 def write_apply_status(
     path: str | Path,
     *,
     proposal_id: str,
-    repo: str,
-    branch: str,
+    selection: list[str],
+    repos: Mapping[str, Mapping[str, Any]],
     state: str,
     recorded_proposal_id: str,
     proposal_digest: str,
     authorization_digest: str,
-    intended_base: str,
-    expected_head_sha: str,
-    observed_base: str | None = None,
-    observed_head_sha: str | None = None,
-    pushed_sha: str | None = None,
-    pr_url: str | None = None,
-    merged_sha: str | None = None,
     reason: str | None = None,
     workspace: str = "unknown",
     actor: dict | None = None,
@@ -340,17 +374,10 @@ def write_apply_status(
         "recorded_proposal_id": recorded_proposal_id,
         "proposal_digest": proposal_digest,
         "authorization_digest": authorization_digest,
-        "selection": [repo],
-        "branch": branch,
+        "selection": list(selection),
+        "repos": {repo: dict(entry) for repo, entry in repos.items()},
         "state": state,
-        "pushed_sha": pushed_sha,
-        "pr_url": pr_url,
-        "merged_sha": merged_sha,
         "reason": reason,
-        "intended_base": intended_base,
-        "expected_head_sha": expected_head_sha,
-        "observed_base": observed_base,
-        "observed_head_sha": observed_head_sha,
     }
     validation_errors = validate_result.validate(doc, "apply-status")
     if validation_errors:
@@ -362,6 +389,38 @@ def write_apply_status(
     p.parent.mkdir(parents=True, exist_ok=True)
     _atomic_write_yaml(p, doc)
     return doc
+
+
+def upsert_repo_status(
+    path: str | Path,
+    *,
+    proposal_id: str,
+    selection: list[str],
+    repo: str,
+    repo_doc: Mapping[str, Any],
+    recorded_proposal_id: str,
+    proposal_digest: str,
+    authorization_digest: str,
+    workspace: str = "unknown",
+    actor: dict | None = None,
+) -> dict:
+    """Load-modify-write one repo's entry; recompute the rollup."""
+    existing = load_apply_status(path) or {}
+    repos = dict(existing.get("repos") or {})
+    repos[repo] = dict(repo_doc)
+    return write_apply_status(
+        path,
+        proposal_id=proposal_id,
+        selection=selection,
+        repos=repos,
+        state=rollup_state(repos),
+        recorded_proposal_id=recorded_proposal_id,
+        proposal_digest=proposal_digest,
+        authorization_digest=authorization_digest,
+        workspace=workspace,
+        actor=actor,
+        errors=list(existing.get("errors") or []),
+    )
 
 
 def open_apply_pr(
@@ -382,10 +441,13 @@ def open_apply_pr(
     authorization_digest: str,
     intended_base: str,
     expected_head_sha: str,
+    selection: list[str] | None = None,
     token: str | None = None,
     actor_id: str = "octocat@mba-m4",
     workspace: str = "unknown",
 ) -> dict:
+    if selection is None:
+        selection = [repo]
     if base != intended_base:
         raise ValueError(
             f"open_apply_pr: base {base!r} != intended_base {intended_base!r} "
@@ -404,8 +466,10 @@ def open_apply_pr(
     )
 
     existing = load_apply_status(result_path)
-    if existing and existing.get("state") in {"pr_opened", "applied", "rejected"}:
-        return existing
+    if existing:
+        entry = (existing.get("repos") or {}).get(repo)
+        if entry and entry.get("state") in {"pr_opened", "applied", "rejected"}:
+            return existing
 
     pr_info = gh_ops.create_or_get_pr(
         repo=repo, branch=branch, base=base, title=title, body=body
@@ -417,19 +481,26 @@ def open_apply_pr(
     machine = actor_parts[1] if len(actor_parts) > 1 else ""
     actor_doc = {"gh_login": login, "machine": machine, "mode": "interactive"}
 
-    doc = write_apply_status(
+    doc = upsert_repo_status(
         result_path,
         proposal_id=proposal_id,
+        selection=selection,
         repo=repo,
-        branch=branch,
-        state="pr_opened",
+        repo_doc={
+            "branch": branch,
+            "state": "pr_opened",
+            "intended_base": intended_base,
+            "expected_head_sha": expected_head_sha,
+            "pushed_sha": pushed_sha,
+            "pr_url": pr_url,
+            "merged_sha": None,
+            "observed_base": None,
+            "observed_head_sha": None,
+            "reason": None,
+        },
         recorded_proposal_id=recorded_proposal_id,
         proposal_digest=proposal_digest,
         authorization_digest=authorization_digest,
-        intended_base=intended_base,
-        expected_head_sha=expected_head_sha,
-        pushed_sha=pushed_sha,
-        pr_url=pr_url,
         workspace=workspace,
         actor=actor_doc,
     )
@@ -453,11 +524,12 @@ def _branch_cleanup_note(branch: str, result: dict) -> str:
     return f"branch cleanup failed for {branch}: {reason}"
 
 
-def reconcile_apply(
+def _reconcile_one_repo(
     *,
     ledger_path: str | Path,
     step_id: str,
     proposal_id: str,
+    selection: list[str],
     repo: str,
     branch: str,
     result_path: str | Path,
@@ -468,32 +540,19 @@ def reconcile_apply(
     intended_base: str,
     expected_head_sha: str,
     advance_base: Callable[[str, str], dict] | None = None,
-    token: str | None = None,
     actor_id: str = "octocat@mba-m4",
     workspace: str = "unknown",
 ) -> dict:
-    """Reconcile a pushed apply branch against remote PR state and advance base off merged SHA.
+    """Reconcile one repo's pushed branch against remote PR state.
 
-    Note on bare CLI vs Python API: When advance_base is None (e.g. bare CLI execution
-    via main()), base advancement is deferred to the caller driver, and reconcile_apply
-    marks the step done once merge is detected. When advance_base is provided, base
-    advancement must be idempotent, and the step is marked done ONLY after advance_base
-    returns {"state": "ok"}.
+    Reads the repo's entry from the (normalized) multi-repo apply-status, views
+    the remote PR, and load-modify-writes that repo's updated entry via
+    `upsert_repo_status`. Returns the full updated document.
     """
-    if token is not None:
-        resolve_run.renew_lease(ledger_path, step_id, actor_id, token)
-    else:
-        resolve_run.acquire_lease(ledger_path, step_id, actor_id)
-    resolve_run.snapshot_audit(
-        ledger_path,
-        step_id,
-        recorded_proposal_id=recorded_proposal_id,
-        proposal_digest=proposal_digest,
-        authorization_digest=authorization_digest,
-    )
-
     existing = load_apply_status(result_path)
-    if existing and existing.get("state") == "rejected":
+    entry = (existing.get("repos") or {}).get(repo) if existing else None
+    repo_state = entry.get("state") if entry else None
+    if repo_state == "rejected":
         ledger_doc = resolve_run.load(ledger_path)
         step = resolve_run.find_step(ledger_doc, step_id)
         if step["status"] == "failed":
@@ -506,12 +565,35 @@ def reconcile_apply(
     machine = actor_parts[1] if len(actor_parts) > 1 else ""
     actor_doc = {"gh_login": login, "machine": machine, "mode": "interactive"}
 
-    pushed_sha = (
-        existing.get("pushed_sha")
-        if existing and existing.get("pushed_sha")
-        else expected_head_sha
-    )
-    pr_url = pr_info.get("url") or (existing.get("pr_url") if existing else None)
+    pushed_sha = (entry.get("pushed_sha") if entry and entry.get("pushed_sha") else expected_head_sha)
+    pr_url = pr_info.get("url") or (entry.get("pr_url") if entry else None)
+
+    def _upsert(state: str, **fields: Any) -> dict:
+        repo_doc = {
+            "branch": branch,
+            "state": state,
+            "intended_base": intended_base,
+            "expected_head_sha": expected_head_sha,
+            "pushed_sha": pushed_sha,
+            "pr_url": pr_url,
+            "merged_sha": None,
+            "observed_base": None,
+            "observed_head_sha": None,
+            "reason": None,
+        }
+        repo_doc.update(fields)
+        return upsert_repo_status(
+            result_path,
+            proposal_id=proposal_id,
+            selection=selection,
+            repo=repo,
+            repo_doc=repo_doc,
+            recorded_proposal_id=recorded_proposal_id,
+            proposal_digest=proposal_digest,
+            authorization_digest=authorization_digest,
+            workspace=workspace,
+            actor=actor_doc,
+        )
 
     if pr_info.get("merged") and pr_info.get("merge_commit_sha"):
         merged_sha = pr_info["merge_commit_sha"]
@@ -523,30 +605,14 @@ def reconcile_apply(
                 f"observed_base={observed_base} (want {intended_base}), "
                 f"observed_head_sha={observed_head_sha} (want {expected_head_sha})"
             )
-            doc = write_apply_status(
-                result_path,
-                proposal_id=proposal_id,
-                repo=repo,
-                branch=branch,
-                state="rejected",
-                recorded_proposal_id=recorded_proposal_id,
-                proposal_digest=proposal_digest,
-                authorization_digest=authorization_digest,
-                intended_base=intended_base,
-                expected_head_sha=expected_head_sha,
+            doc = _upsert(
+                "rejected",
                 observed_base=observed_base,
                 observed_head_sha=observed_head_sha,
-                pushed_sha=pushed_sha,
-                pr_url=pr_url or "",
                 merged_sha=merged_sha,
                 reason=reason,
-                workspace=workspace,
-                actor=actor_doc,
             )
-            cleanup_result = gh_ops.delete_remote_branch(
-                repo, branch, observed_head_sha
-            )
-
+            cleanup_result = gh_ops.delete_remote_branch(repo, branch, observed_head_sha)
             ledger_doc = resolve_run.load(ledger_path)
             step = resolve_run.find_step(ledger_doc, step_id)
             step["status"] = "failed"
@@ -558,47 +624,23 @@ def reconcile_apply(
             resolve_run.save(ledger_path, ledger_doc)
             return doc
 
-        doc = write_apply_status(
-            result_path,
-            proposal_id=proposal_id,
-            repo=repo,
-            branch=branch,
-            state="applied",
-            recorded_proposal_id=recorded_proposal_id,
-            proposal_digest=proposal_digest,
-            authorization_digest=authorization_digest,
-            intended_base=intended_base,
-            expected_head_sha=expected_head_sha,
+        doc = _upsert(
+            "applied",
             observed_base=observed_base,
             observed_head_sha=observed_head_sha,
-            pushed_sha=pushed_sha,
-            pr_url=pr_url or "",
             merged_sha=merged_sha,
-            workspace=workspace,
-            actor=actor_doc,
         )
 
-        satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
+        satisfied, detail = resolve_run.evaluate_merge_detected_gate(
+            str(result_path), repo=repo
+        )
         if not satisfied:
-            doc = write_apply_status(
-                result_path,
-                proposal_id=proposal_id,
-                repo=repo,
-                branch=branch,
-                state="rejected",
-                recorded_proposal_id=recorded_proposal_id,
-                proposal_digest=proposal_digest,
-                authorization_digest=authorization_digest,
-                intended_base=intended_base,
-                expected_head_sha=expected_head_sha,
+            doc = _upsert(
+                "rejected",
                 observed_base=observed_base,
                 observed_head_sha=observed_head_sha,
-                pushed_sha=pushed_sha,
-                pr_url=pr_url or "",
                 merged_sha=merged_sha,
                 reason=detail,
-                workspace=workspace,
-                actor=actor_doc,
             )
             ledger_doc = resolve_run.load(ledger_path)
             step = resolve_run.find_step(ledger_doc, step_id)
@@ -643,33 +685,16 @@ def reconcile_apply(
 
         return doc
 
-    elif pr_info.get("state") == "CLOSED" and not pr_info.get("merged"):
+    if pr_info.get("state") == "CLOSED" and not pr_info.get("merged"):
         reason = "PR closed without merging"
-        doc = write_apply_status(
-            result_path,
-            proposal_id=proposal_id,
-            repo=repo,
-            branch=branch,
-            state="rejected",
-            recorded_proposal_id=recorded_proposal_id,
-            proposal_digest=proposal_digest,
-            authorization_digest=authorization_digest,
-            intended_base=intended_base,
-            expected_head_sha=expected_head_sha,
+        doc = _upsert(
+            "rejected",
             observed_base=pr_info.get("observed_base"),
             observed_head_sha=pr_info.get("observed_head_sha"),
-            pushed_sha=pushed_sha,
-            pr_url=pr_url,
             reason=reason,
-            workspace=workspace,
-            actor=actor_doc,
         )
-
         cleanup_expected_sha = pr_info.get("observed_head_sha") or pushed_sha
-        cleanup_result = gh_ops.delete_remote_branch(
-            repo, branch, cleanup_expected_sha
-        )
-
+        cleanup_result = gh_ops.delete_remote_branch(repo, branch, cleanup_expected_sha)
         ledger_doc = resolve_run.load(ledger_path)
         step = resolve_run.find_step(ledger_doc, step_id)
         step["status"] = "failed"
@@ -679,7 +704,6 @@ def reconcile_apply(
         )
         resolve_run.recompute_status(ledger_doc)
         resolve_run.save(ledger_path, ledger_doc)
-
         return doc
 
     if pr_info.get("state") == "ERROR" and existing:
@@ -695,7 +719,7 @@ def reconcile_apply(
         resolve_run.save(ledger_path, ledger_doc)
         return existing
 
-    if existing and existing.get("state") in {"pr_opened", "applied"}:
+    if repo_state in {"pr_opened", "applied"}:
         return existing
 
     ledger_doc = resolve_run.load(ledger_path)
@@ -719,22 +743,117 @@ def reconcile_apply(
             f"cannot determine PR state for {repo} {branch}: no PR URL"
         )
 
-    return write_apply_status(
-        result_path,
+    return _upsert("pr_opened")
+
+
+def reconcile_apply(
+    *,
+    ledger_path: str | Path,
+    step_id: str,
+    proposal_id: str,
+    repo: str,
+    branch: str,
+    result_path: str | Path,
+    gh_ops: GhOps,
+    recorded_proposal_id: str,
+    proposal_digest: str,
+    authorization_digest: str,
+    intended_base: str,
+    expected_head_sha: str,
+    advance_base: Callable[[str, str], dict] | None = None,
+    token: str | None = None,
+    actor_id: str = "octocat@mba-m4",
+    workspace: str = "unknown",
+) -> dict:
+    """Reconcile one pushed apply branch (single-repo entry point; see docstring note below)."""
+    if token is not None:
+        resolve_run.renew_lease(ledger_path, step_id, actor_id, token)
+    else:
+        resolve_run.acquire_lease(ledger_path, step_id, actor_id)
+    resolve_run.snapshot_audit(
+        ledger_path,
+        step_id,
+        recorded_proposal_id=recorded_proposal_id,
+        proposal_digest=proposal_digest,
+        authorization_digest=authorization_digest,
+    )
+    return _reconcile_one_repo(
+        ledger_path=ledger_path,
+        step_id=step_id,
         proposal_id=proposal_id,
+        selection=[repo],
         repo=repo,
         branch=branch,
-        state="pr_opened",
+        result_path=result_path,
+        gh_ops=gh_ops,
         recorded_proposal_id=recorded_proposal_id,
         proposal_digest=proposal_digest,
         authorization_digest=authorization_digest,
         intended_base=intended_base,
         expected_head_sha=expected_head_sha,
-        pushed_sha=pushed_sha,
-        pr_url=pr_url,
+        advance_base=advance_base,
+        actor_id=actor_id,
         workspace=workspace,
-        actor=actor_doc,
     )
+
+
+def reconcile_repos(
+    *,
+    ledger_path: str | Path,
+    step_id: str,
+    result_path: str | Path,
+    gh_ops: GhOps,
+    recorded_proposal_id: str,
+    proposal_digest: str,
+    authorization_digest: str,
+    token: str | None = None,
+    actor_id: str = "octocat@mba-m4",
+    workspace: str = "unknown",
+) -> dict:
+    """Reconcile every repo in the result's `repos` map in one pass."""
+    if token is not None:
+        resolve_run.renew_lease(ledger_path, step_id, actor_id, token)
+    else:
+        resolve_run.acquire_lease(ledger_path, step_id, actor_id)
+    resolve_run.snapshot_audit(
+        ledger_path,
+        step_id,
+        recorded_proposal_id=recorded_proposal_id,
+        proposal_digest=proposal_digest,
+        authorization_digest=authorization_digest,
+    )
+
+    existing = load_apply_status(result_path)
+    if existing is None or "repos" not in existing:
+        raise ApplyStatusError(
+            "reconcile_repos requires a multi-repo apply-status document"
+        )
+    proposal_id = existing["proposal_id"]
+    selection = existing["selection"]
+    for repo, entry in list(existing["repos"].items()):
+        if entry.get("state") in {"applied", "rejected"}:
+            continue
+        updated = _reconcile_one_repo(
+            ledger_path=ledger_path,
+            step_id=step_id,
+            proposal_id=proposal_id,
+            selection=selection,
+            repo=repo,
+            branch=entry.get("branch"),
+            result_path=result_path,
+            gh_ops=gh_ops,
+            recorded_proposal_id=recorded_proposal_id,
+            proposal_digest=proposal_digest,
+            authorization_digest=authorization_digest,
+            intended_base=entry.get("intended_base"),
+            expected_head_sha=entry.get("expected_head_sha"),
+            advance_base=None,
+            actor_id=actor_id,
+            workspace=workspace,
+        )
+        if updated:
+            existing = updated
+    return existing
 
 
 def main():

--- a/lib/pulse/scripts/apply_reconcile.py
+++ b/lib/pulse/scripts/apply_reconcile.py
@@ -853,7 +853,19 @@ def reconcile_repos(
         )
         if updated:
             existing = updated
-    return existing
+    # Fleet terminal: the step is "done" only when every repo is applied.
+    final = load_apply_status(result_path) or existing
+    ledger_doc = resolve_run.load(ledger_path)
+    step = resolve_run.find_step(ledger_doc, step_id)
+    if final.get("state") == "applied":
+        satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
+        resolve_run._apply_gate_result(step, satisfied, detail)
+        step["status"] = "done" if satisfied else "blocked-on-gate"
+    else:
+        step["status"] = "blocked-on-gate"
+    resolve_run.recompute_status(ledger_doc)
+    resolve_run.save(ledger_path, ledger_doc)
+    return final
 
 
 def main():

--- a/lib/pulse/scripts/apply_rederive.py
+++ b/lib/pulse/scripts/apply_rederive.py
@@ -217,8 +217,8 @@ def _validate_neutral_binding(
 def _resolve_neutral_repos(
     binding: Mapping[str, Any], runner: Callable[..., Any] | None
 ) -> tuple[str, ...]:
-    """Union explicit `repos` with `repo_selector` results (via `nave fleet
-    list --json`), de-duplicated and sorted."""
+    """Union explicit `repos` with `repo_selector` results (resolved via
+    `nave fleet list --json --term <term>`), de-duplicated and sorted."""
     _, selection = _validate_neutral_binding(binding)
     selector = binding.get("repo_selector")
     if selector is not None:
@@ -232,10 +232,13 @@ def _resolve_neutral_repos(
             raise RederiveError(
                 f"apply_rederive: repo_selector must be {{term: str}}, got {selector!r}"
             )
-        proc = runner(["nave", "fleet", "list", "--json"], cwd=None)
+        proc = runner(
+            ["nave", "fleet", "list", "--json", "--term", selector["term"]],
+            cwd=None,
+        )
         if getattr(proc, "returncode", 0) != 0:
             raise RederiveError(
-                "apply_rederive: selector resolution failed (nave fleet list): "
+                "apply_rederive: selector resolution failed (nave fleet list --term): "
                 f"{getattr(proc, 'stderr', '') or getattr(proc, 'stdout', '')}"
             )
         raw = getattr(proc, "stdout", "")

--- a/lib/pulse/scripts/apply_rederive.py
+++ b/lib/pulse/scripts/apply_rederive.py
@@ -28,6 +28,8 @@ mirroring the seam-injection style already used across this codebase
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
+import json
 from pathlib import Path
 from typing import Any, Callable, Mapping
 
@@ -125,14 +127,15 @@ class MarketplaceProviderInputs:
     actor: Mapping[str, Any] | mutation_plan.Actor
     registry: mutation_plan.TransformationRegistry | None = None
 
-
 @dataclass(frozen=True)
 class NeutralProviderInputs:
     """Fresh neutral evidence: `binding` is the caller-supplied `binding_ref`
-    (validated); `head_sha` is the live HEAD of the binding's `base_ref` branch."""
+    (validated); `selection` is the resolved, sorted repo set; `head_shas` maps
+    each selected repo to the live HEAD of its `base_ref` branch."""
 
     binding: Mapping[str, Any]
-    head_sha: str | None
+    selection: tuple[str, ...]
+    head_shas: dict[str, str]
     actor: Mapping[str, Any] | mutation_plan.Actor
     registry: mutation_plan.TransformationRegistry | None = None
 
@@ -160,46 +163,154 @@ class RederivedProposal:
     proposal: mutation_plan.Proposal
     source_kind: str
     finalizer_record: dict[str, Any] | None
-
-
-def _validate_neutral_binding(binding: Mapping[str, Any]) -> tuple[str, str]:
-    """Validate a neutral binding's `repo` + `transformation`; return (owner, name).
-
-    Raises `RederiveError` (never KeyError/ValueError) so a malformed binding
-    blocks (the driver turns it into a `blocked` result), never crashes.
-    """
-    repo = binding.get("repo")
-    if not isinstance(repo, str) or not repo or repo.count("/") != 1:
+def _repo_name(value: Any) -> str:
+    if not isinstance(value, str) or not value or value.count("/") != 1:
         raise RederiveError(
-            f"apply_rederive: neutral binding requires repo 'owner/name', got {repo!r}"
+            f"apply_rederive: repo must be 'owner/name', got {value!r}"
         )
+    return value
+
+
+def _validate_neutral_binding(
+    binding: Mapping[str, Any],
+) -> tuple[str, tuple[str, ...]]:
+    """Validate a neutral binding; return (transformation, resolved_selection).
+
+    A binding is exactly one of single-repo (`repo`) or fleet
+    (`repos` and/or `repo_selector`). Raises `RederiveError` (never
+    KeyError/ValueError) on any malformed shape.
+    """
     transformation = binding.get("transformation")
     if not isinstance(transformation, str) or not transformation:
         raise RederiveError(
             "apply_rederive: neutral binding requires a non-empty transformation, "
             f"got {transformation!r}"
         )
-    return repo.split("/", 1)
+    has_repo = binding.get("repo") is not None
+    has_repos = binding.get("repos") is not None
+    has_selector = binding.get("repo_selector") is not None
+    if has_repo and (has_repos or has_selector):
+        raise RederiveError(
+            "apply_rederive: neutral binding must be either single-repo (`repo`) "
+            "or fleet (`repos`/`repo_selector`), not both"
+        )
+    if not (has_repo or has_repos or has_selector):
+        raise RederiveError(
+            "apply_rederive: neutral binding requires `repo` or `repos`/`repo_selector`"
+        )
+    if has_repo:
+        return transformation, (_repo_name(binding.get("repo")),)
+    repos = binding.get("repos") or []
+    if not isinstance(repos, list) or any(
+        not isinstance(r, str) or not r for r in repos
+    ):
+        raise RederiveError(
+            "apply_rederive: neutral binding `repos` must be a list of 'owner/name', "
+            f"got {repos!r}"
+        )
+    selection = tuple(_repo_name(r) for r in repos)
+    if len(set(selection)) != len(selection):
+        raise RederiveError("apply_rederive: neutral binding `repos` has duplicates")
+    return transformation, selection
+
+
+def _resolve_neutral_repos(
+    binding: Mapping[str, Any], runner: Callable[..., Any] | None
+) -> tuple[str, ...]:
+    """Union explicit `repos` with `repo_selector` results (via `nave fleet
+    list --json`), de-duplicated and sorted."""
+    _, selection = _validate_neutral_binding(binding)
+    selector = binding.get("repo_selector")
+    if selector is not None:
+        if runner is None:
+            raise RederiveError(
+                "apply_rederive: neutral repo_selector requires io_seams.runner"
+            )
+        if not isinstance(selector, Mapping) or not isinstance(
+            selector.get("term"), str
+        ):
+            raise RederiveError(
+                f"apply_rederive: repo_selector must be {{term: str}}, got {selector!r}"
+            )
+        proc = runner(["nave", "fleet", "list", "--json"], cwd=None)
+        if getattr(proc, "returncode", 0) != 0:
+            raise RederiveError(
+                "apply_rederive: selector resolution failed (nave fleet list): "
+                f"{getattr(proc, 'stderr', '') or getattr(proc, 'stdout', '')}"
+            )
+        raw = getattr(proc, "stdout", "")
+        try:
+            entries = json.loads(raw)
+        except (TypeError, ValueError) as exc:
+            raise RederiveError(
+                f"apply_rederive: selector resolution returned invalid JSON: {exc}"
+            ) from exc
+        if not isinstance(entries, list) or any(
+            not isinstance(e, Mapping)
+            or not isinstance(e.get("owner"), str)
+            or not isinstance(e.get("name"), str)
+            for e in entries
+        ):
+            raise RederiveError(
+                "apply_rederive: selector resolution returned a malformed fleet list"
+            )
+        selection = selection + tuple(f"{e['owner']}/{e['name']}" for e in entries)
+    selection = tuple(sorted(set(selection)))
+    if not selection:
+        raise RederiveError(
+            "apply_rederive: neutral binding resolved to an empty selection"
+        )
+    return selection
+
+
+def neutral_fleet_proposal_id(
+    transformation: str, selection: tuple[str, ...]
+) -> str:
+    """Fleet-scoped deterministic id: `apply-{t}-{owner}-{sha256(sorted repos)[:12]}`."""
+    owner = selection[0].split("/", 1)[0]
+    digest = hashlib.sha256(",".join(sorted(selection)).encode()).hexdigest()[:12]
+    return f"apply-{transformation}-{owner}-{digest}"
 
 
 def neutral_proposal_id(binding: Mapping[str, Any]) -> str:
-    """Deterministic neutral proposal id: `apply-{transformation}-{owner}-{name}`.
+    """Deterministic neutral proposal id. Single source of the id.
 
-    Single source of the id, shared by `neutral_summary` and `_rederive_neutral`
-    so the synthesized `recorded_summary.proposal_id` can never drift from the
-    re-derived proposal's id.
+    Single-repo (`repo`): `apply-{t}-{owner}-{name}` (stable, backward
+    compatible). Explicit-repos fleet: `neutral_fleet_proposal_id` over the
+    sorted set. A selector-only binding has no fixed id before resolution —
+    the driver resolves it and uses `neutral_fleet_proposal_id`.
     """
-    owner, name = _validate_neutral_binding(binding)
-    return f"apply-{binding['transformation']}-{owner}-{name}"
+    transformation = binding.get("transformation")
+    if not isinstance(transformation, str) or not transformation:
+        raise RederiveError(
+            "apply_rederive: neutral binding requires a non-empty transformation"
+        )
+    if binding.get("repo") is not None:
+        owner, name = _repo_name(binding["repo"]).split("/", 1)
+        return f"apply-{transformation}-{owner}-{name}"
+    repos = binding.get("repos")
+    if isinstance(repos, list) and repos:
+        selection = tuple(sorted({_repo_name(r) for r in repos}))
+        return neutral_fleet_proposal_id(transformation, selection)
+    if binding.get("repo_selector") is not None:
+        raise RederiveError(
+            "apply_rederive: selector-only binding has no fixed proposal id before resolution"
+        )
+    raise RederiveError("apply_rederive: neutral binding requires `repo` or `repos`")
 
 
-def neutral_summary(binding: Mapping[str, Any]) -> dict[str, str]:
+def neutral_summary(binding: Mapping[str, Any]) -> dict[str, Any]:
     """Synthesize the `recorded_summary` for a neutral apply (no propose phase)."""
-    proposal_id = neutral_proposal_id(binding)  # validates repo + transformation first
+    proposal_id = neutral_proposal_id(binding)
+    if binding.get("repo") is not None:
+        selection = [binding["repo"]]
+    else:
+        selection = sorted({_repo_name(r) for r in (binding.get("repos") or [])})
     return {
-        "binding": binding["repo"],
+        "binding": binding.get("repo") or proposal_id,
         "transformation": binding["transformation"],
         "proposal_id": proposal_id,
+        "selection": selection,
     }
 
 
@@ -226,11 +337,17 @@ def collect_inputs(
     if source_kind not in SOURCE_KINDS:
         raise RederiveError(f"apply_rederive: unknown source_kind: {source_kind!r}")
 
-    binding_id = binding_ref.get(
-        "repo"
-        if source_kind == "neutral"
-        else ("plugin_id" if source_kind == "marketplace-sync" else "id")
-    )
+    if source_kind == "neutral":
+        # Neutral identity is `repo` for single-repo bindings and the
+        # deterministic proposal id for explicit-repos fleet bindings
+        # (matches `neutral_summary`'s synthesized `binding`).
+        binding_id = binding_ref.get("repo")
+        if binding_id is None and binding_ref.get("repos"):
+            binding_id = neutral_proposal_id(binding_ref)
+    else:
+        binding_id = binding_ref.get(
+            "plugin_id" if source_kind == "marketplace-sync" else "id"
+        )
     recorded_binding = recorded_summary.get("binding")
     if recorded_binding is not None and binding_id != recorded_binding:
         raise RederiveError(
@@ -342,7 +459,8 @@ def _collect_neutral(
     actor: Mapping[str, Any] | mutation_plan.Actor,
     io_seams: IoSeams,
 ) -> NeutralProviderInputs:
-    owner, name = _validate_neutral_binding(binding_ref)  # repo + transformation
+    _validate_neutral_binding(binding_ref)  # fail closed on a malformed shape
+    selection = _resolve_neutral_repos(binding_ref, io_seams.runner)
     base_ref = binding_ref.get("base_ref")
     if not isinstance(base_ref, str) or not base_ref:
         raise RederiveError(
@@ -350,24 +468,30 @@ def _collect_neutral(
         )
     if io_seams.gh_api is None:
         raise RederiveError("apply_rederive: neutral requires io_seams.gh_api")
-    try:
-        payload = io_seams.gh_api(f"repos/{owner}/{name}/branches/{base_ref}")
-    except Exception as exc:
+    head_shas: dict[str, str] = {}
+    for repo in selection:
+        owner, name = repo.split("/", 1)
+        try:
+            payload = io_seams.gh_api(f"repos/{owner}/{name}/branches/{base_ref}")
+        except Exception:
+            # Per-repo collect failure: drop the repo; the driver records it as
+            # a blocked outcome. Never abort the whole fleet.
+            continue
+        head_sha = None
+        if isinstance(payload, Mapping):
+            commit = payload.get("commit")
+            if isinstance(commit, Mapping) and isinstance(commit.get("sha"), str):
+                head_sha = commit["sha"] or None
+        if head_sha is not None:
+            head_shas[repo] = head_sha
+    if not head_shas:
         raise RederiveError(
-            f"apply_rederive: neutral HEAD fetch failed for {owner}/{name}: {exc}"
-        ) from exc
-    head_sha = None
-    if isinstance(payload, Mapping):
-        commit = payload.get("commit")
-        if isinstance(commit, Mapping) and isinstance(commit.get("sha"), str):
-            head_sha = commit["sha"] or None
-    if head_sha is None:
-        raise RederiveError(
-            f"apply_rederive: neutral could not resolve HEAD for {owner}/{name}@{base_ref}"
+            "apply_rederive: neutral could not resolve HEAD for any selected repo"
         )
     return NeutralProviderInputs(
         binding=binding_ref,
-        head_sha=head_sha,
+        selection=tuple(repo for repo in selection if repo in head_shas),
+        head_shas=head_shas,
         actor=actor,
         registry=io_seams.registry,
     )
@@ -522,24 +646,32 @@ def _rederive_neutral(inputs: NeutralProviderInputs) -> RederivedProposal:
         raise RederiveError(
             f"apply_rederive: transformation {transformation!r} is not a neutral transformation"
         )
-    head_sha = inputs.head_sha
-    if not isinstance(head_sha, str) or not head_sha:
-        raise RederiveError("apply_rederive: neutral requires a resolved head_sha")
+    selection = inputs.selection
+    if not selection or set(selection) != set(inputs.head_shas):
+        raise RederiveError("apply_rederive: neutral requires a resolved HEAD per repo")
+    single_repo = len(selection) == 1 and binding.get("repo") == selection[0]
+    if single_repo:
+        proposal_id = neutral_proposal_id(binding)
+        binding_id = binding["repo"]  # single-repo keeps its repo identity
+    else:
+        proposal_id = neutral_fleet_proposal_id(transformation, selection)
+        binding_id = proposal_id  # fleet identity is the deterministic fleet id
+    bound_paths = binding.get("bound_paths")
     try:
         proposal = mutation_plan.build_proposal(
-            id=neutral_proposal_id(binding),
-            selection=[binding["repo"]],
+            id=proposal_id,
+            selection=list(selection),
             transformation=transformation,
-            expected_shas={binding["repo"]: head_sha},
+            expected_shas=dict(inputs.head_shas),
             actor=inputs.actor,
             mutation_policy="allow-listed",
-            bound_paths={binding["repo"]: binding["bound_paths"]},
+            bound_paths={repo: bound_paths for repo in selection},
             registry=inputs.registry,
         )
     except mutation_plan.MutationPlanError as exc:
         raise RederiveError(f"apply_rederive: neutral build failed: {exc}") from exc
     return RederivedProposal(
-        binding_id=str(binding["repo"]),
+        binding_id=binding_id,
         proposal=proposal,
         source_kind="neutral",
         finalizer_record=None,

--- a/lib/pulse/scripts/resolve_run.py
+++ b/lib/pulse/scripts/resolve_run.py
@@ -126,12 +126,22 @@ def recompute_status(doc):
         doc["status"] = "running"
 
 
+def _step_repos(s: dict) -> list[str]:
+    raw = s.get("repos")
+    if raw is None:
+        raw = s.get("repo") or ""
+    if isinstance(raw, list):
+        return [r for r in raw if isinstance(r, str) and r]
+    return [r for r in str(raw).split(",") if r]
+
+
 def cmd_create(args):
     steps_in = json.loads(args.steps) if args.steps else [{"id": "run", "repo": ""}]
     check_dag(steps_in)
     steps = [{
         "id": s["id"],
         "repo": s.get("repo", ""),
+        "repos": _step_repos(s),
         "depends_on": s.get("depends_on", []),
         "gate": s.get("gate"),
         "has_workflow": bool(s.get("workflow")),
@@ -294,14 +304,47 @@ def evaluate_binding_edges_gate(result_path):
     return True, f"{len(edges)} edge(s) current"
 
 
-def evaluate_merge_detected_gate(result_path):
+def evaluate_merge_detected_gate(result_path, repo=None):
     """`merge_detected` — fail-closed gate over an apply-status result (F11).
-    Satisfied ONLY when the result file is present, validates cleanly as
-    kind `apply-status`, state is `applied`, `merged_sha` is a non-empty
-    string, and the remotely observed base/head match their intended values."""
+
+    With `repo` it checks that one repo's entry is applied + merged with
+    matching observed base/head; without `repo` it checks the whole result
+    (a fleet requires every repo applied; a v1 scalar doc is checked as before).
+    """
     data, errors = _load_result_kind(result_path, "apply-status")
     if data is None:
         return False, "; ".join(errors) or "invalid apply-status result"
+    if repo is not None:
+        entry = (data.get("repos") or {}).get(repo)
+        if entry is None:
+            return False, f"repo {repo} missing from apply-status"
+        merged_sha = entry.get("merged_sha")
+        if not merged_sha or not isinstance(merged_sha, str):
+            return False, f"{repo} merged_sha missing or empty"
+        if entry.get("observed_base") != entry.get("intended_base"):
+            return False, (
+                f"{repo} observed_base mismatch: {entry.get('observed_base')!r} != "
+                f"intended_base {entry.get('intended_base')!r}"
+            )
+        if entry.get("observed_head_sha") != entry.get("expected_head_sha"):
+            return False, (
+                f"{repo} observed_head_sha mismatch: {entry.get('observed_head_sha')!r} != "
+                f"expected_head_sha {entry.get('expected_head_sha')!r}"
+            )
+        return True, f"merge detected: {merged_sha}"
+    if "repos" in data:
+        repos = data.get("repos") or {}
+        if data.get("state") != "applied":
+            return False, f"apply-status state is {data.get('state')!r}, expected 'applied'"
+        for r, entry in repos.items():
+            merged_sha = entry.get("merged_sha")
+            if not merged_sha or not isinstance(merged_sha, str):
+                return False, f"{r} merged_sha missing or empty"
+            if entry.get("observed_base") != entry.get("intended_base"):
+                return False, f"{r} observed_base mismatch"
+            if entry.get("observed_head_sha") != entry.get("expected_head_sha"):
+                return False, f"{r} observed_head_sha mismatch"
+        return True, f"merge detected: {', '.join(str(e.get('merged_sha')) for e in repos.values())}"
     if data.get("state") != "applied":
         return False, f"apply-status state is {data.get('state')!r}, expected 'applied'"
     merged_sha = data.get("merged_sha")

--- a/lib/pulse/scripts/tests/test_apply_acceptance.py
+++ b/lib/pulse/scripts/tests/test_apply_acceptance.py
@@ -434,7 +434,7 @@ class TestNeutralApplyAcceptanceSuite:
         )
 
         assert doc_pr["state"] == "pr_opened"
-        assert doc_pr["pushed_sha"] == "pushed_sha_base_100"
+        assert doc_pr["repos"]["acme/docs-repo"]["pushed_sha"] == "pushed_sha_base_100"
         assert validate_result.validate(doc_pr, "apply-status") == []
 
         # Gate check before merge: merge-detected gate is NOT satisfied
@@ -495,7 +495,7 @@ class TestNeutralApplyAcceptanceSuite:
 
         # Assert: state is "applied", validates schema, merged SHA is set
         assert doc_reconcile_merged["state"] == "applied"
-        assert doc_reconcile_merged["merged_sha"] == "merged_sha_docs_999"
+        assert doc_reconcile_merged["repos"]["acme/docs-repo"]["merged_sha"] == "merged_sha_docs_999"
         assert validate_result.validate(doc_reconcile_merged, "apply-status") == []
 
         # Gate check after merge: gate IS satisfied
@@ -667,7 +667,7 @@ class TestNeutralApplyAcceptanceSuite:
         )
 
         assert doc_final["state"] == "applied"
-        assert doc_final["merged_sha"] == "merged_sha_node_888"
+        assert doc_final["repos"]["acme/node-repo"]["merged_sha"] == "merged_sha_node_888"
         assert validate_result.validate(doc_final, "apply-status") == []
         assert advance_calls == [("acme/node-repo", "merged_sha_node_888")]
 
@@ -707,9 +707,9 @@ class TestRealApplyDriverAcceptance:
         result = apply_driver.run_apply(**kwargs)
 
         assert result["state"] == "pr_opened"
-        assert result["branch"] == "pulse/apply/p1"
-        assert result["expected_head_sha"] == result["pushed_sha"] == "remote-verb-sha"
-        assert result["expected_head_sha"] != "base"
+        assert result["repos"][_driver_support.REPO]["branch"] == "pulse/apply/p1"
+        assert result["repos"][_driver_support.REPO]["expected_head_sha"] == result["repos"][_driver_support.REPO]["pushed_sha"] == "remote-verb-sha"
+        assert result["repos"][_driver_support.REPO]["expected_head_sha"] != "base"
         assert gh_ops.calls[0] == ("status", "pushed")
 
     @pytest.mark.parametrize(
@@ -1016,7 +1016,7 @@ class TestOverlayApplySuite:
         )
 
         assert doc_final["state"] == "applied"
-        assert doc_final["merged_sha"] == "merged_sha_mkt_777"
+        assert doc_final["repos"]["acme/plugin-repo"]["merged_sha"] == "merged_sha_mkt_777"
         assert validate_result.validate(doc_final, "apply-status") == []
         assert advance_calls == [("acme/plugin-repo", "merged_sha_mkt_777")]
 

--- a/lib/pulse/scripts/tests/test_apply_driver.py
+++ b/lib/pulse/scripts/tests/test_apply_driver.py
@@ -118,11 +118,65 @@ def test_unauthorized_blocks_before_pen_create(tmp_path, monkeypatch):
     assert not any(call[:2] == ["pen", "create"] for call in runner.calls)
 
 
-def test_multi_repo_blocks_before_pen_create(tmp_path, monkeypatch):
-    kwargs, runner, _, _ = setup_run(tmp_path, monkeypatch, (REPO, "acme/other"))
+def test_run_apply_multi_repo_one_repo_fails_others_continue(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    other = "acme/other"
+    kwargs, runner, _, _ = setup_run(tmp_path, monkeypatch, (REPO, other))
+
+    monkeypatch.setattr(
+        apply_driver.nave_adapter, "pen_capabilities",
+        lambda r: runner.calls.append(["pen", "capabilities"]) or {
+            "adapter_state": "ok", "protocol_version": 1},
+    )
+    monkeypatch.setattr(
+        apply_driver.nave_adapter, "pen_create",
+        lambda r, q, n: runner.calls.append(["pen", "create"]) or SimpleNamespace(
+            state="ok", pen={"name": n, "repos": [{"repo": REPO}, {"repo": other}]}, stderr=""),
+    )
+    monkeypatch.setattr(
+        apply_driver.nave_adapter, "pen_status", lambda r, n: {
+            "repos": [
+                {"owner": "acme", "repo": "widget", "clone_path": "/clone/widget"},
+                {"owner": "acme", "repo": "other", "clone_path": "/clone/other"},
+            ]},
+    )
+    reader = SimpleNamespace(
+        read_repo_head=lambda repo: "commit",
+        read_repo_file=lambda *a: b"",
+        read_repo_changed_paths=lambda *a: (),
+    )
+    monkeypatch.setattr(apply_driver.pen_clone_reader, "make_pen_clone_reader", lambda *a, **k: reader)
+    monkeypatch.setattr(
+        apply_driver.apply_phases, "preflight_phase",
+        lambda *a: {REPO: {"state": "ok"}, other: {"state": "ok"}},
+    )
+    monkeypatch.setattr(
+        apply_driver.apply_phases, "provision_phase",
+        lambda *a: {REPO: {"state": "ok", "observed_base_sha": "base"},
+                    other: {"state": "failed", "reason": "boom"}},
+    )
+    monkeypatch.setattr(apply_driver.apply_phases, "exec_phase", lambda *a: {REPO: {"state": "ok"}})
+    monkeypatch.setattr(apply_driver.apply_phases, "validate_phase", lambda *a: {REPO: {"state": "ok"}})
+
+    class MultiOps:
+        def __init__(self):
+            self.calls = []
+        def commit_repos(self, message, bounds):
+            self.calls.append("commit")
+            return {REPO: {"state": "ok", "local_commit_sha": "commit"}}
+        def push_repos(self, branch):
+            self.calls.append("push")
+            return {REPO: {"state": "ok", "remote_ref": branch, "remote_sha": "commit",
+                           "upstream": f"origin/{branch}"}}
+
+    monkeypatch.setattr(apply_driver.apply_ops, "make_apply_ops", lambda *a: MultiOps())
+
     result = apply_driver.run_apply(**kwargs)
-    assert result["state"] == "blocked" and "multi-repo apply is v2" in result["reason"]
-    assert not runner.calls
+    assert result["state"] == "pr_opened"
+    assert result["repos"][other]["state"] == "blocked"
+    assert "boom" in result["repos"][other]["reason"]
+    assert result["repos"][REPO]["state"] == "pr_opened"
 
 
 def test_summary_identity_mismatch_blocks_before_pen_create(tmp_path, monkeypatch):
@@ -181,7 +235,7 @@ def test_happy_path_persists_pushed_sha_before_opening_pr(tmp_path, monkeypatch)
     kwargs["gh_ops"] = gh
     result = apply_driver.run_apply(**kwargs)
     assert result["state"] == "pr_opened"
-    assert result["expected_head_sha"] == "commit" == result["pushed_sha"]
+    assert result["repos"][REPO]["expected_head_sha"] == "commit" == result["repos"][REPO]["pushed_sha"]
     assert gh.calls[0] == ("status", "pushed")
 
 
@@ -212,7 +266,7 @@ def test_resume_from_completed_push_reopens_pr_from_durable_evidence(tmp_path, m
     result = apply_driver.run_apply(**kwargs)
 
     assert result["state"] == "pr_opened"
-    assert result["pushed_sha"] == "commit"
+    assert result["repos"][REPO]["pushed_sha"] == "commit"
     assert "commit" not in ops.calls and "push" not in ops.calls
 
 
@@ -271,6 +325,7 @@ def test_run_apply_neutral_synthesizes_summary_and_threads_gh_api(tmp_path, monk
         "binding": "hiivmind/agent-kernel",
         "transformation": "format-python",
         "proposal_id": "apply-format-python-hiivmind-agent-kernel",
+        "selection": ["hiivmind/agent-kernel"],
     }
     assert captured["gh_api"] is fake_gh_api
 

--- a/lib/pulse/scripts/tests/test_apply_reconcile.py
+++ b/lib/pulse/scripts/tests/test_apply_reconcile.py
@@ -277,8 +277,8 @@ def test_open_apply_pr_creates_and_reuses_pr(tmp_path):
     )
 
     assert doc["state"] == "pr_opened"
-    assert doc["pushed_sha"] == "pushed_sha_111"
-    assert doc["pr_url"] == "https://github.com/testorg/repo1/pull/1"
+    assert doc["repos"]["testorg/repo1"]["pushed_sha"] == "pushed_sha_111"
+    assert doc["repos"]["testorg/repo1"]["pr_url"] == "https://github.com/testorg/repo1/pull/1"
     assert validate_result.validate(doc, "apply-status") == []
     assert gh_ops.create_calls == 1
 
@@ -303,7 +303,7 @@ def test_open_apply_pr_creates_and_reuses_pr(tmp_path):
         workspace="testorg",
     )
 
-    assert doc2["pr_url"] == doc["pr_url"]
+    assert doc2["repos"]["testorg/repo1"]["pr_url"] == doc["repos"]["testorg/repo1"]["pr_url"]
     assert gh_ops.create_calls == 1
 
     ledger_doc = resolve_run.load(ledger_path)
@@ -621,9 +621,9 @@ def test_reconcile_merged_pr_advances_base_off_merged_sha(tmp_path):
     )
 
     assert doc["state"] == "applied"
-    assert doc["merged_sha"] == "merged_commit_sha_999"
-    assert doc["observed_base"] == "main"
-    assert doc["observed_head_sha"] == "pushed_sha_111"
+    assert doc["repos"]["testorg/repo1"]["merged_sha"] == "merged_commit_sha_999"
+    assert doc["repos"]["testorg/repo1"]["observed_base"] == "main"
+    assert doc["repos"]["testorg/repo1"]["observed_head_sha"] == "pushed_sha_111"
     assert validate_result.validate(doc, "apply-status") == []
 
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
@@ -692,7 +692,7 @@ def test_reconcile_merged_pr_wrong_base_rejects(tmp_path):
     ledger_doc = resolve_run.load(ledger_path)
     step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
     assert doc["state"] == "rejected"
-    assert "observed_base=develop" in doc["reason"]
+    assert "observed_base=develop" in doc["repos"]["testorg/repo1"]["reason"]
     assert gh_ops.deleted_branches == [("testorg/repo1", "pulse/apply/prop-101")]
     assert gh_ops.delete_calls == [
         ("testorg/repo1", "pulse/apply/prop-101", "pushed_sha_111")
@@ -756,7 +756,7 @@ def test_reconcile_merged_pr_wrong_head_rejects(tmp_path):
     ledger_doc = resolve_run.load(ledger_path)
     step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
     assert doc["state"] == "rejected"
-    assert "observed_head_sha=other_sha" in doc["reason"]
+    assert "observed_head_sha=other_sha" in doc["repos"]["testorg/repo1"]["reason"]
     assert gh_ops.delete_calls == [
         ("testorg/repo1", "pulse/apply/prop-101", "other_sha")
     ]
@@ -800,7 +800,7 @@ def test_reconcile_merge_gate_failure_rejects(tmp_path, monkeypatch):
     monkeypatch.setattr(
         resolve_run,
         "evaluate_merge_detected_gate",
-        lambda path: (False, "simulated merge gate failure"),
+        lambda path, repo=None: (False, "simulated merge gate failure"),
     )
     advance_calls = []
 
@@ -825,7 +825,7 @@ def test_reconcile_merge_gate_failure_rejects(tmp_path, monkeypatch):
     ledger_doc = resolve_run.load(ledger_path)
     step = resolve_run.find_step(ledger_doc, "reconcile-repo1")
     assert doc["state"] == "rejected"
-    assert doc["reason"] == "simulated merge gate failure"
+    assert doc["repos"]["testorg/repo1"]["reason"] == "simulated merge gate failure"
     assert step["status"] == "failed"
     assert advance_calls == []
 
@@ -840,19 +840,25 @@ def test_reconcile_applied_crash_recovery(tmp_path):
     apply_reconcile.write_apply_status(
         result_path,
         proposal_id="prop-101",
-        repo="testorg/repo1",
-        branch="pulse/apply/prop-101",
+        selection=["testorg/repo1"],
+        repos={
+            "testorg/repo1": {
+                "branch": "pulse/apply/prop-101",
+                "state": "applied",
+                "intended_base": "main",
+                "expected_head_sha": "pushed_sha_111",
+                "observed_base": "main",
+                "observed_head_sha": "pushed_sha_111",
+                "pushed_sha": "pushed_sha_111",
+                "pr_url": "https://github.com/testorg/repo1/pull/1",
+                "merged_sha": "merged_commit_sha_777",
+                "reason": None,
+            },
+        },
         state="applied",
         recorded_proposal_id="prop-101",
         proposal_digest=PROPOSAL_DIGEST,
         authorization_digest=AUTHORIZATION_DIGEST,
-        intended_base="main",
-        expected_head_sha="pushed_sha_111",
-        observed_base="main",
-        observed_head_sha="pushed_sha_111",
-        pushed_sha="pushed_sha_111",
-        pr_url="https://github.com/testorg/repo1/pull/1",
-        merged_sha="merged_commit_sha_777",
         workspace="testorg",
     )
 
@@ -1016,7 +1022,7 @@ def test_reconcile_closed_unmerged_pr_rejects_and_deletes_branch(tmp_path):
     )
 
     assert doc["state"] == "rejected"
-    assert doc["reason"] is not None
+    assert doc["repos"]["testorg/repo1"]["reason"] is not None
     assert validate_result.validate(doc, "apply-status") == []
     assert advance_calls == []
     assert gh_ops.deleted_branches == [("testorg/repo1", "pulse/apply/prop-101")]
@@ -1323,101 +1329,56 @@ def test_atomic_apply_status_write_preserves_existing_file_on_replace_error(
 def test_merge_detected_gate_evaluator_fail_closed(tmp_path):
     result_path = tmp_path / "apply-status.yaml"
 
+    def write(state, **entry_fields):
+        entry = {
+            "branch": "b1",
+            "state": state,
+            "intended_base": "main",
+            "expected_head_sha": "sha1",
+            "pushed_sha": "sha1",
+            "pr_url": "https://pr1",
+            "merged_sha": None,
+            "observed_base": None,
+            "observed_head_sha": None,
+            "reason": None,
+        }
+        entry.update(entry_fields)
+        apply_reconcile.write_apply_status(
+            result_path,
+            proposal_id="p1",
+            selection=["acme/r1"],
+            repos={"acme/r1": entry},
+            state=state,
+            recorded_proposal_id="p1",
+            proposal_digest=PROPOSAL_DIGEST,
+            authorization_digest=AUTHORIZATION_DIGEST,
+        )
+
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
     assert satisfied is False
 
-    apply_reconcile.write_apply_status(
-        result_path,
-        proposal_id="p1",
-        repo="r1",
-        branch="b1",
-        state="pr_opened",
-        recorded_proposal_id="p1",
-        proposal_digest=PROPOSAL_DIGEST,
-        authorization_digest=AUTHORIZATION_DIGEST,
-        intended_base="main",
-        expected_head_sha="sha1",
-        pushed_sha="sha1",
-        pr_url="https://pr1",
-    )
+    write("pr_opened")
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
     assert satisfied is False
 
-    apply_reconcile.write_apply_status(
-        result_path,
-        proposal_id="p1",
-        repo="r1",
-        branch="b1",
-        state="rejected",
-        recorded_proposal_id="p1",
-        proposal_digest=PROPOSAL_DIGEST,
-        authorization_digest=AUTHORIZATION_DIGEST,
-        intended_base="main",
-        expected_head_sha="sha1",
-        reason="closed",
-    )
+    write("rejected", reason="closed")
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
     assert satisfied is False
 
-    apply_reconcile.write_apply_status(
-        result_path,
-        proposal_id="p1",
-        repo="r1",
-        branch="b1",
-        state="applied",
-        recorded_proposal_id="p1",
-        proposal_digest=PROPOSAL_DIGEST,
-        authorization_digest=AUTHORIZATION_DIGEST,
-        intended_base="main",
-        expected_head_sha="sha1",
-        observed_base="main",
-        observed_head_sha="sha1",
-        pushed_sha="sha1",
-        pr_url="https://pr1",
-        merged_sha="sha_merged_456",
-    )
+    write("applied", observed_base="main", observed_head_sha="sha1",
+          merged_sha="sha_merged_456")
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
     assert satisfied is True
     assert "sha_merged_456" in detail
 
-    apply_reconcile.write_apply_status(
-        result_path,
-        proposal_id="p1",
-        repo="r1",
-        branch="b1",
-        state="applied",
-        recorded_proposal_id="p1",
-        proposal_digest=PROPOSAL_DIGEST,
-        authorization_digest=AUTHORIZATION_DIGEST,
-        intended_base="main",
-        expected_head_sha="sha1",
-        observed_base="develop",
-        observed_head_sha="sha1",
-        pushed_sha="sha1",
-        pr_url="https://pr1",
-        merged_sha="sha_merged_456",
-    )
+    write("applied", observed_base="develop", observed_head_sha="sha1",
+          merged_sha="sha_merged_456")
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
     assert satisfied is False
     assert "observed_base" in detail
 
-    apply_reconcile.write_apply_status(
-        result_path,
-        proposal_id="p1",
-        repo="r1",
-        branch="b1",
-        state="applied",
-        recorded_proposal_id="p1",
-        proposal_digest=PROPOSAL_DIGEST,
-        authorization_digest=AUTHORIZATION_DIGEST,
-        intended_base="main",
-        expected_head_sha="sha1",
-        observed_base="main",
-        observed_head_sha="other_sha",
-        pushed_sha="sha1",
-        pr_url="https://pr1",
-        merged_sha="sha_merged_456",
-    )
+    write("applied", observed_base="main", observed_head_sha="other_sha",
+          merged_sha="sha_merged_456")
     satisfied, detail = resolve_run.evaluate_merge_detected_gate(str(result_path))
     assert satisfied is False
     assert "observed_head_sha" in detail
@@ -1425,10 +1386,125 @@ def test_merge_detected_gate_evaluator_fail_closed(tmp_path):
 
 def test_resolve_intended_base_neutral_uses_binding_base_ref():
     assert apply_reconcile.resolve_intended_base(
-        "neutral", {"base_ref": "main"}, None
-    ) == "main"
+        "neutral", {"repo": "hiivmind/a", "base_ref": "main"}, None
+    ) == {"hiivmind/a": "main"}
+    assert apply_reconcile.resolve_intended_base(
+        "neutral",
+        {"repos": ["hiivmind/a", "hiivmind/b"], "base_ref": "main"},
+        None,
+    ) == {"hiivmind/a": "main", "hiivmind/b": "main"}
 
 
 def test_resolve_intended_base_neutral_rejects_missing_base_ref():
     with pytest.raises(ValueError, match="cannot resolve intended base for neutral"):
-        apply_reconcile.resolve_intended_base("neutral", {}, None)
+        apply_reconcile.resolve_intended_base("neutral", {"repo": "hiivmind/a"}, None)
+    with pytest.raises(ValueError, match="cannot resolve intended base for neutral"):
+        apply_reconcile.resolve_intended_base("neutral", {"repos": ["hiivmind/a"]}, None)
+
+
+def test_rollup_state_precedence():
+    def repo(state):
+        return {"state": state, "branch": "b", "intended_base": "main",
+                "expected_head_sha": "s", "pushed_sha": "s", "pr_url": None,
+                "merged_sha": None, "observed_base": None, "observed_head_sha": None,
+                "reason": None}
+
+    assert apply_reconcile.rollup_state({"a": repo("pr_opened"), "b": repo("applied")}) == "pr_opened"
+    assert apply_reconcile.rollup_state({"a": repo("applied"), "b": repo("applied")}) == "applied"
+    assert apply_reconcile.rollup_state({"a": repo("rejected"), "b": repo("rejected")}) == "rejected"
+    assert apply_reconcile.rollup_state({"a": repo("failed"), "b": repo("blocked")}) == "failed"
+    assert apply_reconcile.rollup_state({"a": repo("applied"), "b": repo("failed")}) == "partial"
+
+
+def test_write_and_load_multi_repo_status_round_trip(tmp_path):
+    repos = {
+        "hiivmind/a": {"branch": "pulse/apply/x", "state": "pr_opened",
+                       "intended_base": "main", "expected_head_sha": "sha-a",
+                       "pushed_sha": "sha-a", "pr_url": "https://x/a/1",
+                       "merged_sha": None, "observed_base": None,
+                       "observed_head_sha": None, "reason": None},
+        "hiivmind/b": {"branch": "pulse/apply/x", "state": "applied",
+                       "intended_base": "main", "expected_head_sha": "sha-b",
+                       "pushed_sha": "sha-b", "pr_url": "https://x/b/1",
+                       "merged_sha": "merge-b", "observed_base": "main",
+                       "observed_head_sha": "sha-b", "reason": None},
+    }
+    path = tmp_path / "result.yaml"
+    apply_reconcile.write_apply_status(
+        path, proposal_id="pid", selection=["hiivmind/a", "hiivmind/b"],
+        repos=repos, state=apply_reconcile.rollup_state(repos),
+        recorded_proposal_id="pid", proposal_digest="d1",
+        authorization_digest="d2", workspace="w",
+        actor={"gh_login": "x", "machine": "m", "mode": "interactive"},
+    )
+    loaded = apply_reconcile.load_apply_status(path)
+    assert loaded["repos"] == repos
+    assert loaded["selection"] == ["hiivmind/a", "hiivmind/b"]
+    assert loaded["state"] == "pr_opened"
+
+
+def test_load_normalizes_v1_single_repo(tmp_path):
+    v1 = {
+        "contract_version": 1, "kind": "apply-status", "state": "pr_opened",
+        "workspace": "w", "run_at": "2026-01-01T00:00:00Z",
+        "actor": {"gh_login": "x", "machine": "m", "mode": "interactive"},
+        "errors": [],
+        "proposal_id": "pid", "recorded_proposal_id": "pid",
+        "proposal_digest": "d1", "authorization_digest": "d2",
+        "selection": ["hiivmind/a"], "branch": "pulse/apply/x",
+        "pushed_sha": "sha", "pr_url": "https://x/a/1", "merged_sha": None,
+        "reason": None, "intended_base": "main", "expected_head_sha": "sha",
+        "observed_base": None, "observed_head_sha": None,
+    }
+    path = tmp_path / "result.yaml"
+    path.write_text(yaml.safe_dump(v1))
+    loaded = apply_reconcile.load_apply_status(path)
+    assert loaded["selection"] == ["hiivmind/a"]
+    assert loaded["repos"]["hiivmind/a"]["branch"] == "pulse/apply/x"
+
+
+def test_reconcile_repos_iterates_and_rolls_up(tmp_path):
+    ledger_path = create_test_ledger(tmp_path, step_id="reconcile-repo1")
+    result_path = tmp_path / "apply-status.yaml"
+    gh_ops = FakeGhOps()
+
+    repos = {
+        "testorg/repo1": {"branch": "pulse/apply/p", "state": "pr_opened",
+                          "intended_base": "main", "expected_head_sha": "sha1",
+                          "pushed_sha": "sha1", "pr_url": "https://x/1",
+                          "merged_sha": None, "observed_base": None,
+                          "observed_head_sha": None, "reason": None},
+        "testorg/repo2": {"branch": "pulse/apply/p", "state": "pr_opened",
+                          "intended_base": "main", "expected_head_sha": "sha2",
+                          "pushed_sha": "sha2", "pr_url": "https://x/2",
+                          "merged_sha": None, "observed_base": None,
+                          "observed_head_sha": None, "reason": None},
+    }
+    apply_reconcile.write_apply_status(
+        result_path, proposal_id="prop-101",
+        selection=["testorg/repo1", "testorg/repo2"], repos=repos,
+        state="pr_opened", recorded_proposal_id="prop-101",
+        proposal_digest=PROPOSAL_DIGEST, authorization_digest=AUTHORIZATION_DIGEST,
+        workspace="testorg",
+        actor={"gh_login": "octocat", "machine": "mba-m4", "mode": "interactive"},
+    )
+    # repo1 merged; repo2 still open.
+    gh_ops.prs[("testorg/repo1", "pulse/apply/p")] = {
+        "url": "https://x/1", "state": "MERGED", "merged": True,
+        "merge_commit_sha": "merge1", "base": "main", "head_ref": "sha1",
+    }
+    gh_ops.prs[("testorg/repo2", "pulse/apply/p")] = {
+        "url": "https://x/2", "state": "OPEN", "merged": False,
+        "merge_commit_sha": None, "base": "main", "head_ref": "sha2",
+    }
+
+    doc = apply_reconcile.reconcile_repos(
+        ledger_path=ledger_path, step_id="reconcile-repo1", result_path=result_path,
+        gh_ops=gh_ops, recorded_proposal_id="prop-101",
+        proposal_digest=PROPOSAL_DIGEST, authorization_digest=AUTHORIZATION_DIGEST,
+        actor_id="octocat@mba-m4", workspace="testorg",
+    )
+    assert doc["repos"]["testorg/repo1"]["state"] == "applied"
+    assert doc["repos"]["testorg/repo1"]["merged_sha"] == "merge1"
+    assert doc["repos"]["testorg/repo2"]["state"] == "pr_opened"
+    assert doc["state"] == "pr_opened"

--- a/lib/pulse/scripts/tests/test_apply_reconcile.py
+++ b/lib/pulse/scripts/tests/test_apply_reconcile.py
@@ -1508,3 +1508,6 @@ def test_reconcile_repos_iterates_and_rolls_up(tmp_path):
     assert doc["repos"]["testorg/repo1"]["merged_sha"] == "merge1"
     assert doc["repos"]["testorg/repo2"]["state"] == "pr_opened"
     assert doc["state"] == "pr_opened"
+    # Fleet terminal: the step is done only when every repo is applied.
+    step = resolve_run.find_step(resolve_run.load(ledger_path), "reconcile-repo1")
+    assert step["status"] == "blocked-on-gate"

--- a/lib/pulse/scripts/tests/test_apply_rederive.py
+++ b/lib/pulse/scripts/tests/test_apply_rederive.py
@@ -1022,7 +1022,7 @@ def test_neutral_fleet_selector_unions_and_dedups():
     }
 
     def runner(argv, cwd):
-        assert argv[:3] == ["nave", "fleet", "list"]
+        assert argv == ["nave", "fleet", "list", "--json", "--term", "pyproject:true"]
         return Completed(
             stdout='[{"owner":"hiivmind","name":"b","default_branch":"main"},'
                    '{"owner":"hiivmind","name":"c","default_branch":"main"}]'

--- a/lib/pulse/scripts/tests/test_apply_rederive.py
+++ b/lib/pulse/scripts/tests/test_apply_rederive.py
@@ -833,6 +833,7 @@ def test_neutral_summary_matches_binding_and_proposal_id():
         "binding": NEUTRAL_REPO,
         "transformation": "format-python",
         "proposal_id": "apply-format-python-hiivmind-agent-kernel",
+        "selection": [NEUTRAL_REPO],
     }
 
 
@@ -867,7 +868,8 @@ def test_collect_inputs_neutral_fetches_live_head():
         actor=ACTOR, io_seams=io_seams,
     )
     assert isinstance(inputs, apply_rederive.NeutralProviderInputs)
-    assert inputs.head_sha == NEUTRAL_HEAD
+    assert inputs.selection == (NEUTRAL_REPO,)
+    assert inputs.head_shas == {NEUTRAL_REPO: NEUTRAL_HEAD}
     assert inputs.registry is io_seams.registry
 
 
@@ -928,7 +930,7 @@ def test_rederive_neutral_builds_allow_listed_proposal():
 def test_rederive_neutral_rejects_non_neutral_transformation():
     inputs = apply_rederive.NeutralProviderInputs(
         binding=neutral_binding(transformation="plan-sync-doc-patch"),
-        head_sha=NEUTRAL_HEAD, actor=ACTOR,
+        selection=(NEUTRAL_REPO,), head_shas={NEUTRAL_REPO: NEUTRAL_HEAD}, actor=ACTOR,
     )
     with pytest.raises(apply_rederive.RederiveError, match="neutral transformation"):
         apply_rederive.rederive(inputs)
@@ -936,15 +938,16 @@ def test_rederive_neutral_rejects_non_neutral_transformation():
 
 def test_rederive_neutral_rejects_unresolved_head_sha():
     inputs = apply_rederive.NeutralProviderInputs(
-        binding=neutral_binding(), head_sha=None, actor=ACTOR,
+        binding=neutral_binding(), selection=(NEUTRAL_REPO,), head_shas={}, actor=ACTOR,
     )
-    with pytest.raises(apply_rederive.RederiveError, match="head_sha"):
+    with pytest.raises(apply_rederive.RederiveError, match="HEAD"):
         apply_rederive.rederive(inputs)
 
 
 def test_rederive_neutral_rejects_empty_bound_paths():
     inputs = apply_rederive.NeutralProviderInputs(
-        binding=neutral_binding(bound_paths=[]), head_sha=NEUTRAL_HEAD, actor=ACTOR,
+        binding=neutral_binding(bound_paths=[]),
+        selection=(NEUTRAL_REPO,), head_shas={NEUTRAL_REPO: NEUTRAL_HEAD}, actor=ACTOR,
     )
     with pytest.raises(apply_rederive.RederiveError, match="build failed"):
         apply_rederive.rederive(inputs)
@@ -983,3 +986,116 @@ def test_neutral_transformations_are_self_contained_in_template_registry():
         assert all(not p.startswith("profile:claude-plugin") for p in entry.applies_to), (
             f"{entry_id} must not carry a profile:claude-plugin predicate"
         )
+
+
+# --- neutral fleet (multi-repo) -------------------------------------------------
+
+
+def test_neutral_fleet_expands_explicit_repos_with_live_heads():
+    binding = {
+        "repos": ["hiivmind/a", "hiivmind/b"],
+        "transformation": "format-python",
+        "base_ref": "main",
+        "bound_paths": ["src/**"],
+    }
+
+    def gh_api(endpoint):
+        # endpoint == "repos/{owner}/{name}/branches/{base}"
+        parts = endpoint.split("/")
+        name = parts[2]
+        return {"commit": {"sha": {"a": "sha-a", "b": "sha-b"}[name]}}
+
+    inputs = apply_rederive._collect_neutral(
+        binding, ACTOR,
+        apply_rederive.IoSeams(runner=None, gh_api=gh_api),
+    )
+    assert inputs.selection == ("hiivmind/a", "hiivmind/b")
+
+
+def test_neutral_fleet_selector_unions_and_dedups():
+    binding = {
+        "repos": ["hiivmind/a", "hiivmind/b"],
+        "repo_selector": {"term": "pyproject:true"},
+        "base_ref": "main",
+        "transformation": "format-python",
+        "bound_paths": ["src/**"],
+    }
+
+    def runner(argv, cwd):
+        assert argv[:3] == ["nave", "fleet", "list"]
+        return Completed(
+            stdout='[{"owner":"hiivmind","name":"b","default_branch":"main"},'
+                   '{"owner":"hiivmind","name":"c","default_branch":"main"}]'
+        )
+
+    def gh_api(endpoint):
+        return {"commit": {"sha": "sha"}}
+
+    inputs = apply_rederive._collect_neutral(
+        binding, ACTOR,
+        apply_rederive.IoSeams(runner=runner, gh_api=gh_api),
+    )
+    # explicit [a, b] union selector [b, c] == [a, b, c], sorted
+    assert inputs.selection == ("hiivmind/a", "hiivmind/b", "hiivmind/c")
+
+
+def test_neutral_fleet_empty_selector_raises():
+    binding = {
+        "repo_selector": {"term": "nope:true"},
+        "transformation": "format-python",
+        "bound_paths": ["src/**"],
+    }
+
+    def runner(argv, cwd):
+        return Completed(stdout="[]")
+
+    with pytest.raises(apply_rederive.RederiveError, match="empty selection"):
+        apply_rederive._collect_neutral(
+            binding, ACTOR,
+            apply_rederive.IoSeams(runner=runner, gh_api=lambda e: {"commit": {"sha": "sha"}}),
+        )
+
+
+def test_neutral_fleet_proposal_id_is_deterministic_over_sorted_set():
+    binding = {
+        "repos": ["hiivmind/b", "hiivmind/a"],
+        "transformation": "format-python",
+        "bound_paths": ["src/**"],
+    }
+    id1 = apply_rederive.neutral_proposal_id(binding)
+    binding2 = dict(binding, repos=["hiivmind/a", "hiivmind/b"])
+    id2 = apply_rederive.neutral_proposal_id(binding2)
+    assert id1 == id2
+    assert id1.startswith("apply-format-python-hiivmind-")
+    assert len(id1.split("-")[-1]) == 12
+    # single-repo id is unchanged
+    single = {"repo": "hiivmind/agent-kernel", "transformation": "format-python"}
+    assert apply_rederive.neutral_proposal_id(single) == "apply-format-python-hiivmind-agent-kernel"
+
+
+def test_neutral_fleet_rederive_builds_multi_repo_proposal():
+    binding = {
+        "repos": ["hiivmind/a", "hiivmind/b"],
+        "transformation": "format-python",
+        "bound_paths": ["src/**"],
+    }
+    inputs = apply_rederive.NeutralProviderInputs(
+        binding=binding,
+        selection=("hiivmind/a", "hiivmind/b"),
+        head_shas={"hiivmind/a": "sha-a", "hiivmind/b": "sha-b"},
+        actor=ACTOR,
+        registry=neutral_registry(),
+    )
+    rederived = apply_rederive._rederive_neutral(inputs)
+    assert rederived.proposal.selection == ("hiivmind/a", "hiivmind/b")
+    assert rederived.proposal.expected_shas == {
+        "hiivmind/a": "sha-a",
+        "hiivmind/b": "sha-b",
+    }
+    assert rederived.proposal.bound_paths == {
+        "hiivmind/a": ("src/**",),
+        "hiivmind/b": ("src/**",),
+    }
+    assert rederived.source_kind == "neutral"
+    assert rederived.finalizer_record is None
+    assert rederived.binding_id == rederived.proposal.id

--- a/lib/pulse/scripts/validate_result.py
+++ b/lib/pulse/scripts/validate_result.py
@@ -39,7 +39,9 @@ OUTCOMES = {"success", "failure", "skipped-cooldown", "aborted"}
 SEVERITIES = {"low", "medium", "high"}
 EDGE_STATES = {"current", "stale", "unknown"}
 REPO_MUTATION_STATES = {"proposed", "blocked", "failed"}
-APPLY_STATUS_STATES = {"pushed", "pr_opened", "applied", "rejected"}
+APPLY_STATUS_STATES = {
+    "pushed", "pr_opened", "applied", "rejected", "failed", "blocked", "partial",
+}
 
 REPO_OUTCOME_STATES = {"ok", "failed", "blocked"}
 
@@ -703,52 +705,90 @@ def validate(data, kind: str) -> list[str]:
             _require(proposal, "transformation", str, errors, ctx=ctx)
             _require(proposal, "proposal_id", str, errors, ctx=ctx)
         _validate_string_list(data, "proposed_actions", errors)
-
     elif kind == "apply-status":
-        state = _require_enum(data, "state", APPLY_STATUS_STATES, errors)
+        _require_enum(data, "state", APPLY_STATUS_STATES, errors)
         _require(data, "proposal_id", str, errors)
         _require(data, "recorded_proposal_id", str, errors)
         _require(data, "proposal_digest", str, errors)
         _require(data, "authorization_digest", str, errors)
         _validate_string_list(data, "selection", errors)
-        _require(data, "branch", str, errors)
-        _require_nullable(data, "pushed_sha", str, errors)
-        _require_nullable(data, "pr_url", str, errors)
-        _require_nullable(data, "merged_sha", str, errors)
-        _require_nullable(data, "reason", str, errors)
-        _require_nullable(data, "intended_base", str, errors)
-        _require_nullable(data, "expected_head_sha", str, errors)
-        _require_nullable(data, "observed_base", str, errors)
-        _require_nullable(data, "observed_head_sha", str, errors)
-        if state in {"pushed", "pr_opened", "applied"} and data.get("pushed_sha") is None:
-            _err(errors, f"pushed_sha must not be null when state is {state}")
-        if state in {"pr_opened", "applied"}:
-            if data.get("pr_url") is None:
-                _err(errors, f"pr_url must not be null when state is {state}")
-            elif data.get("pr_url") == "":
-                _err(errors, f"pr_url must not be empty when state is {state}")
-        if state == "applied" and data.get("merged_sha") is None:
-            _err(errors, "merged_sha must not be null when state is applied")
-        if state == "rejected" and data.get("reason") is None:
-            _err(errors, "reason must not be null when state is rejected")
-        if state in APPLY_STATUS_STATES and data.get("intended_base") is None:
-            _err(errors, f"intended_base must not be null when state is {state}")
-        if state in APPLY_STATUS_STATES and data.get("expected_head_sha") is None:
-            _err(errors, f"expected_head_sha must not be null when state is {state}")
-        if state == "applied" and data.get("observed_base") is None:
-            _err(errors, "observed_base must not be null when state is applied")
-        if state == "applied" and data.get("observed_head_sha") is None:
-            _err(errors, "observed_head_sha must not be null when state is applied")
-        pushed_sha_val = data.get("pushed_sha")
-        expected_head_sha_val = data.get("expected_head_sha")
-        if (
-            pushed_sha_val is not None
-            and expected_head_sha_val is not None
-            and pushed_sha_val != expected_head_sha_val
-        ):
-            _err(errors, "pushed_sha != expected_head_sha")
+        if "repos" in data:
+            # multi-repo shape
+            repos = data.get("repos")
+            if not isinstance(repos, dict) or not repos:
+                _err(errors, "repos must be a non-empty mapping")
+            else:
+                seen = set()
+                for repo, entry in repos.items():
+                    if not isinstance(repo, str) or "/" not in repo:
+                        _err(errors, f"repos key {repo!r} must be owner/name")
+                    if repo in seen:
+                        _err(errors, f"duplicate repo key {repo}")
+                    seen.add(repo)
+                    if not isinstance(entry, dict):
+                        _err(errors, f"repos[{repo}] must be a mapping")
+                        continue
+                    ctx = f"repos[{repo}]."
+                    _require(entry, "branch", str, errors, ctx=ctx)
+                    _require_enum(entry, "state", APPLY_STATUS_STATES, errors, ctx=ctx)
+                    _require_nullable(entry, "pushed_sha", str, errors, ctx=ctx)
+                    _require_nullable(entry, "pr_url", str, errors, ctx=ctx)
+                    _require_nullable(entry, "merged_sha", str, errors, ctx=ctx)
+                    _require_nullable(entry, "reason", str, errors, ctx=ctx)
+                    _require_nullable(entry, "intended_base", str, errors, ctx=ctx)
+                    _require_nullable(entry, "expected_head_sha", str, errors, ctx=ctx)
+                    _require_nullable(entry, "observed_base", str, errors, ctx=ctx)
+                    _require_nullable(entry, "observed_head_sha", str, errors, ctx=ctx)
+                    if entry.get("state") == "applied" and entry.get("merged_sha") is None:
+                        _err(errors, f"{ctx}merged_sha must not be null when state is applied")
+            # fleet invariants: `repos` keys may be a subset of `selection` during
+            # an in-progress run (repos not yet reached), but never contain a repo
+            # outside the selection.
+            selection = data.get("selection") or []
+            if not set(repos) <= set(selection):
+                _err(errors, "repos keys must be a subset of selection")
+        else:
+            # v1 scalar shape (legacy): keep the existing scalar checks.
+            _require(data, "branch", str, errors)
+            _require_nullable(data, "pushed_sha", str, errors)
+            _require_nullable(data, "pr_url", str, errors)
+            _require_nullable(data, "merged_sha", str, errors)
+            _require_nullable(data, "reason", str, errors)
+            _require_nullable(data, "intended_base", str, errors)
+            _require_nullable(data, "expected_head_sha", str, errors)
+            _require_nullable(data, "observed_base", str, errors)
+            _require_nullable(data, "observed_head_sha", str, errors)
+            state = data.get("state")
+            if state in {"pushed", "pr_opened", "applied"} and data.get("pushed_sha") is None:
+                _err(errors, f"pushed_sha must not be null when state is {state}")
+            if state in {"pr_opened", "applied"}:
+                if data.get("pr_url") is None:
+                    _err(errors, f"pr_url must not be null when state is {state}")
+                elif data.get("pr_url") == "":
+                    _err(errors, f"pr_url must not be empty when state is {state}")
+            if state == "applied" and data.get("merged_sha") is None:
+                _err(errors, "merged_sha must not be null when state is applied")
+            if state == "rejected" and data.get("reason") is None:
+                _err(errors, "reason must not be null when state is rejected")
+            if state in APPLY_STATUS_STATES and data.get("intended_base") is None:
+                _err(errors, f"intended_base must not be null when state is {state}")
+            if state in APPLY_STATUS_STATES and data.get("expected_head_sha") is None:
+                _err(errors, f"expected_head_sha must not be null when state is {state}")
+            if state == "applied" and data.get("observed_base") is None:
+                _err(errors, "observed_base must not be null when state is applied")
+            if state == "applied" and data.get("observed_head_sha") is None:
+                _err(errors, "observed_head_sha must not be null when state is applied")
+            pushed_sha_val = data.get("pushed_sha")
+            expected_head_sha_val = data.get("expected_head_sha")
+            if (
+                pushed_sha_val is not None
+                and expected_head_sha_val is not None
+                and pushed_sha_val != expected_head_sha_val
+            ):
+                _err(errors, "pushed_sha != expected_head_sha")
 
     return errors
+
 
 
 


### PR DESCRIPTION
## What

Generalizes the apply pipeline from one repository per run to **one proposal spanning N repositories**, with per-repo independent outcomes and a fleet-level rollup. Closes the `multi-repo apply is v2` stub.

- **`apply_rederive.py`** — neutral fleet expansion: explicit `repos` ∪ optional `repo_selector` (resolved via `nave fleet list --json`), per-repo HEAD, deterministic fleet id `apply-{t}-{owner}-{sha256(sorted repos)[:12]}`, multi-repo `_rederive_neutral`.
- **`apply_reconcile.py`** — multi-repo apply-status (`repos` map + `rollup_state`), v1 normalization, per-repo `open_apply_pr`/`reconcile_repos` with fleet-aware terminal.
- **`apply_driver.py`** — guard removed, per-repo base refs, `_run_multi_repo` fleet loop with independent per-repo outcomes; pen seeded via `repo:`-scoped terms.
- **`resolve_run.py`** — ledger step `repos: [...]`; `evaluate_merge_detected_gate(repo=…)`.
- **`validate_result.py`** — apply-status multi-repo schema.

## Spec / plan

- `docs/superpowers/specs/2026-08-15-multi-repo-apply-design.md`
- `docs/superpowers/plans/2026-08-15-multi-repo-apply.md`

## Verification

- 1531 pytest tests pass (1522 + 9 new).
- Live proof: one proposal → `hiivmind/hiivmind-corpus` + `hiivmind/swingle`, two PRs opened, per-repo reconcile correctly detected the corpus merge → `applied` while swingle stayed `pr_opened`, rollup `pr_opened`, ledger step `blocked-on-gate` until all repos applied.

## Depends on

- `discreteds/nave#5` (`nave fleet list --json` + `repo:` scope + stage-only-dirty).