### PR TITLE
fix(plan-sync): wire real gh_api into F8 driver's real collector call

### DIFF
--- a/lib/pulse/scripts/plan_sync_run.py
+++ b/lib/pulse/scripts/plan_sync_run.py
@@ -31,6 +31,7 @@ from lib.pulse.scripts import (
     plan_sync_snapshot,
     validate_result,
 )
+from lib.pulse.scripts.overlay_content import default_gh_api
 
 Collector = Callable[..., Any]
 
@@ -177,7 +178,7 @@ def run_driver(
             return 1
         bindings = matched
 
-    snapshot = collect(bindings, workdir=workspace)
+    snapshot = collect(bindings, workdir=workspace, gh_api=default_gh_api)
     registry = load_transformation_registry(workspace)
 
     result_data = plan_sync.build_result(

--- a/lib/pulse/scripts/tests/test_plan_sync_run.py
+++ b/lib/pulse/scripts/tests/test_plan_sync_run.py
@@ -194,3 +194,34 @@ def test_plan_sync_run_cli_abort_on_missing_plan_sync_yaml(tmp_path):
     assert "plan-sync.yaml not found" in data["errors"][0]
     assert str(config_dir / "plan-sync.yaml") in data["errors"][0]
     assert validate_result.validate(data, "plan-sync") == []
+
+
+def test_plan_sync_run_wires_real_gh_api_into_real_collector(tmp_path, monkeypatch):
+    """Regression: run_driver's real (non-injected) collector call must wire a
+    real gh_api seam. plan_sync_snapshot.collect() defaults gh_api to None,
+    and _github_snapshot() unconditionally fails every GitHub read with
+    "GitHub API reader is unavailable" when gh_api is None — so an unwired
+    driver can never fetch real issue evidence, regardless of how correct the
+    binding config is. Bindings themselves are irrelevant here: an empty
+    docs[] list still exercises the real collect() call and its gh_api kwarg.
+    """
+    config_dir = tmp_path / ".hiivmind" / "github"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config.yaml").write_text(yaml.dump({"workspace": {"login": "acme"}}))
+    (config_dir / "plan-sync.yaml").write_text(yaml.dump({"docs": []}))
+
+    captured = {}
+
+    def fake_collect(bindings, workdir=None, runner=None, gh_api=None):
+        captured["gh_api"] = gh_api
+        return plan_sync_snapshot.SyncSnapshot((), ())
+
+    monkeypatch.setattr(plan_sync_snapshot, "collect", fake_collect)
+
+    ret = plan_sync_run.run_driver(
+        workspace=tmp_path, repo_filter=None, result_path=tmp_path / "result.yaml",
+    )
+
+    assert ret == 0
+    assert captured["gh_api"] is not None
+    assert callable(captured["gh_api"])


### PR DESCRIPTION
`plan_sync_run.py`'s `run_driver` never passed `gh_api` into `plan_sync_snapshot.collect()` for its real (non-injected) path, so the default `None` reached `_github_snapshot()`, which unconditionally fails every GitHub read with "GitHub API reader is unavailable." F8's driver has never been able to fetch real issue evidence, independent of binding config correctness — masked because the only end-to-end test injects a full `collector=` override.

Found while live-testing the F8 plan-sync workflow. Fix: wire `overlay_content.default_gh_api` (the same `gh api <path>` seam `healthcheck_dispatch.py` uses) into the real `collect()` call. New regression test monkeypatches `plan_sync_snapshot.collect` directly (not the `collector=` injection point) — proven to fail before the fix, pass after.

Full suite: 1598 passed.