### PR TITLE
docs(backlogs): capture Nave Python bindings; amend SDK/UI items for FastAPI

### DIFF
--- a/docs/backlogs/2026-08-17-agent-native-fleet-ui.md
+++ b/docs/backlogs/2026-08-17-agent-native-fleet-ui.md
@@ -74,16 +74,19 @@ story for the "projects, statuses" half of the ask.
 
 ## What this would require (real scope)
 
-- **A cross-language action boundary.** agent-native is TypeScript/Node;
-  `lib/pulse/scripts/*.py` and `nave` are Python and Rust, invoked today by
-  subprocess (`uv run <script>.py`, `nave <verb>`) from Bash-driven skills.
-  Each agent-native `defineAction()`'s `run()` body would shell out to those
-  same binaries/scripts — this is exactly the boundary
-  `2026-08-17-lib-pulse-package-extraction.md` is about cleaning up (real
-  console entry points, no `{PLUGIN_ROOT}`-relative path coupling). **This
-  item is a direct downstream consumer of that one** — a Node process has no
-  natural way to resolve a Claude-plugin-root-relative script path; it needs
-  an installed CLI to shell out to.
+- **A cross-language action boundary — resolved direction: FastAPI, not raw
+  subprocess shell-out.** agent-native is TypeScript/Node; `lib/pulse` is
+  Python, `nave` is Rust. Rather than each `defineAction()`'s `run()` body
+  shelling out to a CLI per call, the likely shape is agent-native calling a
+  **FastAPI service** fronting `lib/pulse` (in-process Python calls) and,
+  once bound, Nave (in-process Rust calls via PyO3) — see the amendment in
+  `2026-08-17-lib-pulse-package-extraction.md` and the new
+  `2026-08-17-nave-python-bindings.md`. This item still depends on both
+  landing first: a Node process has no natural way to resolve a
+  Claude-plugin-root-relative script path or reach into a Python/Rust
+  process's memory directly, so an HTTP boundary (FastAPI) is the
+  connecting layer regardless of whether the Python/Rust side is
+  subprocess- or import-based underneath it.
 - **A read model for existing result contracts and committed state.** Actions
   reading `*-result.yaml` (per-machine, gitignored, transient — see
   `workspace-detection.md` § multi-machine topology), the committed
@@ -127,7 +130,11 @@ story for the "projects, statuses" half of the ask.
   pipeline; the closest existing analog to "visually present projects,
   statuses" today, currently only consumed by `gh-heartbeat`'s text summary.
 - `docs/backlogs/2026-08-17-lib-pulse-package-extraction.md` — the
-  prerequisite cross-language boundary problem this item inherits directly.
+  prerequisite cross-language boundary problem this item inherits directly,
+  now amended with the FastAPI/SDK resolution direction.
+- `docs/backlogs/2026-08-17-nave-python-bindings.md` — the Rust-side
+  counterpart: native Nave bindings so the FastAPI layer can reach Nave
+  in-process too, not just `lib/pulse`.
 - `docs/superpowers/specs/2026-07-30-apply-mode-production-wiring-design.md`
   — the lease/fence/journal apply-mode machinery an "Approve" button must
   drive through, not bypass.
@@ -138,5 +145,6 @@ Design-first, and the largest single open item in this backlog by scope — a
 new application, a new hosting/identity model, and a cross-language action
 boundary, not a change inside `hiivmind-pulse-gh`. Should get its own
 `brainstorming` → spec pass, and its sequencing should be considered relative
-to `2026-08-17-lib-pulse-package-extraction.md` (this item's cleanest path
-runs through that one landing first).
+to `2026-08-17-lib-pulse-package-extraction.md` and
+`2026-08-17-nave-python-bindings.md` (this item's cleanest path runs through
+both landing first).

--- a/docs/backlogs/2026-08-17-lib-pulse-package-extraction.md
+++ b/docs/backlogs/2026-08-17-lib-pulse-package-extraction.md
@@ -104,6 +104,44 @@ artifact, consumed by the plugin rather than living inside it.
   patterns + a declared dependency on the extracted package, not a repo that
   vendors 53 implementation modules alongside its plugin surface.
 
+## Amendment (2026-08-17): must be designed as an SDK, not just a CLI
+
+Follow-up to `2026-08-17-agent-native-fleet-ui.md`'s cross-language action
+boundary: shelling out from a Node/FastAPI-adjacent service to an installed
+CLI and parsing stdout works, but it re-imposes a serialization/subprocess
+boundary on every call — exactly the cost a proper extraction should let
+consumers avoid for in-process (or same-host-HTTP) callers. The likely
+resolution is a **FastAPI service** sitting in front of `lib/pulse`, calling
+its functions **in-process** (`import`, not `subprocess`), with the
+CLI/`uv run` story remaining for direct human/script invocation. That means
+extraction's primary deliverable is an **importable SDK with stable,
+typed, keyword-argument function signatures** — CLI entry points become one
+consumer of that SDK, not the whole product.
+
+**This is closer than it looks.** The codebase already enforces exactly this
+separation as an internal convention — `README.md`'s layer-completeness
+ladder names it explicitly: *"1. Library — pure Python that owns the
+decisions... 2. Driver — an argparse CLI... 3. Skill."* Confirmed in code:
+`plan_sync.build_result(snapshot, *, workspace, ...)`,
+`apply_reconcile.reconcile_apply(*, ledger_path, step_id, ...)`,
+`apply_rederive.collect_inputs(source_kind, binding_ref, recorded_summary, ...)`
+are already pure, keyword-argument, argparse-free functions — the "driver"
+layer (`*_run.py`'s `main()`) already exists only to parse CLI args and call
+into them. A FastAPI layer's request handlers would call these same layer-1
+functions directly; the work is exporting them as a package's public API
+(real `__init__.py` surface, stable signatures, versioned) and giving FastAPI
+something importable to call — not rewriting the decision logic.
+
+**Consequence for the PEP-723-vs-installed-package fork above:** this
+resolves it rather than leaving it purely open — the package needs
+`[project.dependencies]` and to be pip/uv-installable **regardless**, because
+an in-process FastAPI import cannot rely on PEP 723's `uv run <file>.py`
+self-containment (that mechanism only helps a fresh subprocess invocation,
+not a long-lived service process holding an import). Whether PEP 723 headers
+are *additionally* kept per-script for standalone `uv run` ergonomics is now
+a secondary, non-blocking decision — the installed-package form is required
+either way once a FastAPI consumer exists.
+
 ## Evidence
 
 - `pyproject.toml` (root) — `name = "hiivmind-pulse-gh-dev"`, `version = "0.0.0"`,
@@ -121,6 +159,10 @@ artifact, consumed by the plugin rather than living inside it.
 - `~/git/discreteds/nave` (this workspace) — the working precedent: an
   extracted, independently released, subprocess-consumed engine already
   proven for the Rust half of this program.
+- `README.md` (this repo) — the layer-completeness ladder already documents
+  the library/driver/skill separation this amendment leans on; `plan_sync.py`,
+  `apply_reconcile.py`, `apply_rederive.py` confirm pure, typed, keyword-only
+  library-layer function signatures already exist independent of argparse.
 
 ## Notes
 

--- a/docs/backlogs/2026-08-17-nave-python-bindings.md
+++ b/docs/backlogs/2026-08-17-nave-python-bindings.md
@@ -1,0 +1,147 @@
+# Backlog: expose Nave's Rust internals to Python (native bindings)
+
+**Date:** 2026-08-17
+**Status:** Open, no spec
+**Severity:** Architectural — enables the FastAPI/agent-native service layer,
+not a bug
+**Found in:** user follow-up on the cross-language action boundary raised in
+`2026-08-17-agent-native-fleet-ui.md`
+**Scope:** `discreteds/nave` (Rust workspace: `crates/nave*`, `pyproject.toml`,
+`python/nave/`) — a `nave`-repo item, not a `hiivmind-pulse-gh` change
+
+## Problem
+
+If `lib/pulse` grows a FastAPI service that calls its own Python functions
+in-process (see the SDK amendment in
+`2026-08-17-lib-pulse-package-extraction.md`), that service still has to
+reach Nave for every fleet-evidence, pen, and apply operation — and today
+that path is **always** a subprocess: `nave <verb> --json`, parse stdout.
+That's the same subprocess/serialization boundary the SDK amendment exists
+to remove for the Python side, just recreated at the Python↔Rust edge
+instead of the Node↔Python edge.
+
+**Nave already ships a Python package — but it wraps the binary, not the
+library.** `discreteds/nave`'s root `pyproject.toml` is already a working
+`maturin` build:
+
+```toml
+[build-system]
+requires = ["maturin>=1.9.3,<2.0"]
+build-backend = "maturin"
+
+[tool.maturin]
+bindings = "bin"
+manifest-path = "crates/nave/Cargo.toml"
+module-name = "nave"
+python-source = "python"
+```
+
+`bindings = "bin"` is maturin's *binary-wrapping* mode: it compiles the
+`nave` CLI crate and bundles the executable into a wheel, and
+`python/nave/{__init__.py,__main__.py,_find_nave.py}` is a thin shim that
+locates and execs that bundled binary. `pip install nave` today gives you a
+`nave` command — still invoked as a subprocess, still communicating over
+stdout JSON. There is **no `pyo3` dependency anywhere in the workspace** and
+no `bindings = "pyo3"` target — confirmed by grep; the only `pyo3`/`maturin`
+strings in the Rust source are nave's own **test fixtures**, because nave's
+job includes parsing and rewriting *other* repos' `pyproject.toml` files
+that happen to use PyO3 bindings (`nave_rewrite::apply` test data) — that is
+nave modeling a capability of repos it manages, not a capability of itself.
+
+## What native bindings would add
+
+Rust functions callable **in-process** from Python — no subprocess spawn, no
+JSON stdout parsing, and (with `pyo3-asyncio` or an explicit
+`tokio::runtime::Runtime::block_on` bridge) real error propagation instead of
+exit-code/stderr sniffing. This is a second `maturin` binding target
+alongside (not necessarily replacing) the existing `bindings = "bin"` wheel —
+maturin supports both `bin` and `pyo3` binding modes, they aren't mutually
+exclusive as a project's overall distribution strategy, though a single
+`[tool.maturin]` table picks one at a time (a genuine open question below).
+
+**The Rust side is already shaped for this.** The workspace already
+separates a CLI-only binary crate (`crates/nave`, `src/main.rs`, no
+`lib.rs`) from real library crates with public APIs:
+`nave_pen::{create_pen, exec_pen, rewrite_pen, ...}`,
+`nave_apply` (`BranchRepoRequest`/`BranchResult`, `CommitRepoRequest`, etc. —
+already `pub struct`/`pub fn`, already `serde`-derived for the existing JSON
+CLI contract), `nave_scan`, `nave_search`, `nave_config`. A `pyo3` binding
+crate would wrap **these existing library crates' public functions**, not
+require carving new library boundaries out of CLI-only code — the same
+situation the SDK amendment found on the Python side.
+
+## Real open questions (design fork, not detail)
+
+- **Async bridging.** `nave_pen` (and presumably other crates) depend on
+  `tokio`. PyO3 bindings need an explicit strategy for calling `async fn`
+  Rust from Python: block on a runtime per-call (`Runtime::block_on`, simple
+  but blocks the GIL-released thread for the call's duration), integrate
+  `pyo3-asyncio` for a real async Python API, or restrict the bound surface
+  to Nave's synchronous entry points only. This changes the shape of the
+  Python API a FastAPI handler would await.
+- **Which functions get bound.** Not "all of nave" — the FastAPI service's
+  actual call sites (evidence scan, pen create/exec, apply branch/commit/push,
+  reconcile inputs) should drive an initial bound surface, not a blanket
+  wrap of every public Rust item.
+- **`bin` vs `pyo3` maturin coexistence.** One `pyproject.toml`'s
+  `[tool.maturin]` table selects one `bindings` mode. Shipping both a CLI
+  wheel (today's `pip install nave` → `nave` on PATH) and a native-extension
+  wheel (`import nave_native`, or similar) likely means either two build
+  targets/publish artifacts from one workspace, or a deliberate choice to
+  fold the CLI into a thin wrapper over the same compiled extension instead
+  of a second `bin` crate — a real Rust/Python packaging design decision.
+- **Error/JSON contract parity.** The CLI's current JSON-on-stdout contract
+  (`nave_pen`'s `serde`-derived result types) is the de facto stable
+  interface `apply_driver.py`/`nave_adapter.py` already depend on. Native
+  bindings should return the same typed shapes (via `pyo3`'s struct/dict
+  conversion) rather than a divergent second contract — needs an explicit
+  compatibility statement once designed.
+- **Versioning/compatibility.** `nave`'s Python package version (`0.0.8`)
+  already exists as one artifact; a `pyo3`-bound extension is effectively a
+  second, ABI-sensitive artifact (tied to a specific Python/Rust build) that
+  needs its own release discipline alongside the existing binary wheel and
+  the `cargo build --release` path this program already pins
+  (`~/.local/bin/nave`).
+
+## Why this belongs in `nave`, not `hiivmind-pulse-gh`
+
+Everything above is Rust-workspace and Rust-packaging scope in
+`discreteds/nave`. `hiivmind-pulse-gh`'s only stake is being a consumer: once
+bindings exist, `apply_driver.py`/`nave_adapter.py`'s subprocess calls become
+candidates for replacement by direct `import nave_native` calls inside the
+same SDK/FastAPI layer `2026-08-17-lib-pulse-package-extraction.md` is
+building. That migration is this repo's follow-on work, not this item's.
+
+## Evidence
+
+- `~/git/discreteds/nave/pyproject.toml` — `[build-system] requires =
+  ["maturin"]`, `[tool.maturin] bindings = "bin"`, `module-name = "nave"`,
+  `python-source = "python"`.
+- `~/git/discreteds/nave/python/nave/{__init__.py,__main__.py,_find_nave.py}`
+  — the existing binary-locating shim confirming `bin` mode, not native
+  bindings.
+- `~/git/discreteds/nave/Cargo.toml` (workspace) — `crates/nave` (binary,
+  `src/main.rs` only, no `lib.rs`) vs. library crates (`nave_pen`,
+  `nave_apply`, `nave_scan`, etc.) with real `pub use`/`pub fn`/`pub struct`
+  surfaces — confirmed via `crates/nave_pen/src/lib.rs`'s `pub use` block and
+  `crates/nave_apply/src/lib.rs`'s public request/result types.
+- Grep confirms no `pyo3` crate dependency anywhere in the workspace; every
+  `pyo3`/`maturin` string hit is nave's own test fixture data for rewriting
+  *other* repos' `pyproject.toml` files (`nave_config::match_pred`,
+  `nave_rewrite::apply` test cases).
+- `crates/nave_pen/Cargo.toml` — `tokio` dependency, confirming the async
+  bridging question is real, not hypothetical.
+- `docs/backlogs/2026-08-17-lib-pulse-package-extraction.md` (Amendment
+  2026-08-17) — the Python-side SDK requirement this item is the Rust-side
+  counterpart to.
+- `docs/backlogs/2026-08-17-agent-native-fleet-ui.md` — where the
+  cross-language action boundary was first raised.
+
+## Notes
+
+Design-first, `nave`-repo scope. Should get its own brainstorm/spec pass in
+`discreteds/nave`, sequenced alongside (not necessarily after) the
+`lib/pulse` SDK work — the two are the same architectural move (in-process
+callable library instead of subprocess CLI) applied to each language, and a
+FastAPI service's design should account for both from the start rather than
+bolting Rust bindings on after the Python SDK ships.

--- a/docs/backlogs/README.md
+++ b/docs/backlogs/README.md
@@ -1,6 +1,6 @@
 # hiivmind-pulse-gh — fleet program roadmap & backlog index
 
-**Updated:** 2026-08-17 (agent-native fleet UI captured) · **One-page map of what is built, what is left, and where each item lives.**
+**Updated:** 2026-08-17 (Nave Python bindings item captured) · **One-page map of what is built, what is left, and where each item lives.**
 
 > Read in this order: **Status at a glance** (what shipped) → **Layer-completeness matrix**
 > (is it actually *runnable*) → **Cross-repo dependency map** (which repos an item spans) →
@@ -194,8 +194,9 @@ side's interactive path now runs too — single-repo, multi-repo (#147), and dep
 | **Single-repo-atomic Path A push** — only if a future Nave surface yields per-repo exec signal | [`2026-07-29-apply-mode-v2-deferrals.md`](2026-07-29-apply-mode-v2-deferrals.md) § B |
 | **Non-neutral multi-repo** — plan-sync / generated-artifact / marketplace-sync remain single-repo; the driver/reconcile are source-agnostic but their fleet binding shapes need a spec | [`2026-08-15-multi-repo-apply-design.md`](../superpowers/specs/2026-08-15-multi-repo-apply-design.md) § 10 |
 | **F8: GitHub Projects (v2) field sync** — sync a bound doc against a linked Project item's custom fields (Status, Priority, Iteration, arbitrary user fields), not just the issue's own title/state/assignees/milestone/body. GraphQL-only surface, no write path exists yet, issue↔project cardinality (0..N) needs resolving. Design first. | [`2026-08-17-f8-projects-v2-field-sync.md`](2026-08-17-f8-projects-v2-field-sync.md) |
-| **Extract `lib/pulse` as a standalone Python package** — 53 scripts invoked by `{PLUGIN_ROOT}`-relative path from every skill, no real install/version, only 2 of 53 have entry points. Concretizes audit F7's "neutral runtime root" recommendation; mirrors the Nave extraction precedent for the Python half. Design first (PEP-723-vs-installed-package fork). | [`2026-08-17-lib-pulse-package-extraction.md`](2026-08-17-lib-pulse-package-extraction.md) |
-| **Agent-native fleet UI** — a visual app (BuilderIO `agent-native`) presenting projects/statuses/workflows/issues, surfacing discrepancies (`findings`) and approvals from the existing typed result contracts, with an LLM agent panel that can invoke skills/`lib/pulse`/Nave tasks. Largest-scope open item; depends on `lib/pulse` extraction landing first. Design first. | [`2026-08-17-agent-native-fleet-ui.md`](2026-08-17-agent-native-fleet-ui.md) |
+| **Extract `lib/pulse` as a standalone Python package** — 53 scripts invoked by `{PLUGIN_ROOT}`-relative path from every skill, no real install/version, only 2 of 53 have entry points. Concretizes audit F7's "neutral runtime root" recommendation; mirrors the Nave extraction precedent for the Python half. **Amended:** must ship as an importable SDK (FastAPI-consumable in-process), not just a CLI — the layer-1/driver/skill split already exists in code. | [`2026-08-17-lib-pulse-package-extraction.md`](2026-08-17-lib-pulse-package-extraction.md) |
+| **Nave native Python bindings (PyO3)** — `discreteds/nave` already ships a Python wheel, but `bindings = "bin"` (wraps the CLI binary, still subprocess). Real in-process bindings would wrap the workspace's existing library crates (`nave_pen`, `nave_apply`, etc. — already `pub fn`/`pub struct`, already serde-typed). `nave`-repo scope; async (tokio) bridging and `bin`-vs-`pyo3` coexistence are open forks. Design first. | [`2026-08-17-nave-python-bindings.md`](2026-08-17-nave-python-bindings.md) |
+| **Agent-native fleet UI** — a visual app (BuilderIO `agent-native`) presenting projects/statuses/workflows/issues, surfacing discrepancies (`findings`) and approvals from the existing typed result contracts, with an LLM agent panel that can invoke skills/`lib/pulse`/Nave tasks. Largest-scope open item; resolved cross-language direction is a FastAPI service (not raw subprocess shell-out) fronting both the `lib/pulse` SDK and Nave bindings above. Design first. | [`2026-08-17-agent-native-fleet-ui.md`](2026-08-17-agent-native-fleet-ui.md) |
 
 ### ⚪ Non-goals & tooling (recorded so they aren't re-proposed)
 - **Auto-merge** — permanent non-goal; Pulse opens PRs and detects merges, never merges. ([apply-mode v2](2026-07-29-apply-mode-v2-deferrals.md) § C)
@@ -230,7 +231,8 @@ side's interactive path now runs too — single-repo, multi-repo (#147), and dep
 - [`2026-07-13-nave-json-lifecycle-protocol.md`](2026-07-13-nave-json-lifecycle-protocol.md) — upstream Nave protocol proposal
 - [`2026-07-11-relationships-schema-drift.md`](2026-07-11-relationships-schema-drift.md) — schema-drift correctness bug
 - [`2026-08-17-f8-projects-v2-field-sync.md`](2026-08-17-f8-projects-v2-field-sync.md) — F8 Projects (v2) custom-field sync, no-spec capability gap
-- [`2026-08-17-lib-pulse-package-extraction.md`](2026-08-17-lib-pulse-package-extraction.md) — extract `lib/pulse` as a standalone Python package, no-spec architectural item
+- [`2026-08-17-lib-pulse-package-extraction.md`](2026-08-17-lib-pulse-package-extraction.md) — extract `lib/pulse` as a standalone Python package (SDK-amended), no-spec architectural item
+- [`2026-08-17-nave-python-bindings.md`](2026-08-17-nave-python-bindings.md) — Nave native Python (PyO3) bindings, no-spec, `nave`-repo scope
 - [`2026-08-17-agent-native-fleet-ui.md`](2026-08-17-agent-native-fleet-ui.md) — agent-native visual fleet UI proposal, no-spec, largest open item
 - [`2026-07-11-workspace-config-stale-catalog.md`](2026-07-11-workspace-config-stale-catalog.md) — stale workspace data
 


### PR DESCRIPTION
Captures the FastAPI-service-layer implication the user raised: many lib/pulse (and Nave) operations will likely need FastAPI endpoints, which means (a) the lib/pulse package extraction must be designed as an importable SDK, and (b) Nave's Rust internals likely need native Python bindings too.

New: docs/backlogs/2026-08-17-nave-python-bindings.md — grounded in discreteds/nave's actual pyproject.toml (already maturin-built, but bindings = "bin" wraps the CLI binary as a subprocess, not native functions) and the workspace's existing library-crate boundaries (nave_pen, nave_apply already have real pub fn/pub struct APIs). Names the real forks: tokio async bridging, bin-vs-pyo3 coexistence, bound-surface selection, JSON-contract parity. nave-repo scope.

Amended: 2026-08-17-lib-pulse-package-extraction.md now requires an importable SDK (not just CLI entry points) for in-process FastAPI calls — and shows this is closer than expected, since the library/driver/skill layering already exists as documented convention (plan_sync.build_result, apply_reconcile.reconcile_apply are already pure typed functions). This also resolves the earlier PEP-723-vs-installed-package fork: installed-package form is required regardless.

Amended: 2026-08-17-agent-native-fleet-ui.md's cross-language boundary section now names the resolved direction (FastAPI fronting in-process Python/Rust, not raw subprocess per action) and cross-references both dependency docs.

No code changes.