### PR TITLE
docs(backlogs): capture branch-governance, stale-branch, stale-release gaps

### DIFF
--- a/docs/backlogs/2026-08-17-stale-merged-branches.md
+++ b/docs/backlogs/2026-08-17-stale-merged-branches.md
@@ -1,0 +1,95 @@
+# Backlog: detect and clean up already-merged branches left behind
+
+**Date:** 2026-08-17
+**Status:** Open, no spec
+**Severity:** Operational hygiene — repo clutter / drift signal, not a bug
+**Found in:** user request, exploring workflow-coverage gaps alongside branch-protection
+governance-parity and stale-release-candidate detection
+**Scope:** a new fleet check (or workflow) distinct from `stale-check.yaml`; needs a new
+API-routing entry in `skills/gh-operations`; `lib/pulse/scripts` (no existing module owns this)
+
+## Problem
+
+A GitHub branch whose PR has already merged is frequently left behind: "delete
+branch on merge" is a per-repo GitHub setting, not always enabled, and even
+when it is, force-pushes, squash-merge edge cases, or PRs merged via `gh`/API
+outside the UI can leave the branch alive with no PR referencing it as open.
+Over time this accumulates dead branches nobody prunes. Nothing in this
+program detects it, per-repo or fleet-wide.
+
+**This is not `stale-check.yaml`.** That workflow's staleness condition is
+"open PR/issue, not updated in N days" — an item still awaiting action. A
+merged-and-abandoned branch is the opposite: the PR is already **closed**
+(merged), there is nothing left to act on except delete the ref. Zero overlap
+in trigger condition, data source, or remediation.
+
+## What this would require (real scope, not exhaustive by design)
+
+- **Detection data**: for each branch in a repo, whether it is an ancestor of
+  the default branch (or another declared base) — via the compare API
+  (`GET /repos/{o}/{r}/compare/{base}...{branch}`, `status: identical` or
+  `behind` means fully merged) or, since a PR's `merged_at` + `head.ref` is
+  already fetchable via `GET /repos/{o}/{r}/pulls?state=closed`, cross-referencing
+  closed-merged PRs against the live branch list (`GET /repos/{o}/{r}/branches`)
+  is the cheaper join (no per-branch compare call needed).
+- **A write primitive this program doesn't have yet**: branch ref deletion
+  (`DELETE /repos/{o}/{r}/git/refs/heads/{branch}`) is not in
+  `skills/gh-operations`'s domain-routing table at all today — only branch
+  *protection* routes exist (`skills/gh-operations` `domains/branch-protection.md`).
+  Needs adding as its own domain/operation before this can mutate anything.
+- **A staleness threshold and exclusion policy** — flag immediately on merge,
+  or only after N days (mirrors the same open question in `stale-check.yaml`'s
+  7d/14d thresholds)? Must exclude intentionally long-lived branches that can
+  legitimately show as "merged into main" transiently or by design
+  (`develop`, `release/*` in the mountainash three-tier flow — see the sibling
+  `2026-08-17-stale-release-candidates.md` item, which audits `release/*`
+  branches from the opposite direction: not-yet-merged, not already-merged).
+- **Mutation policy** — per this program's headless-contract convention
+  (`lib/patterns/headless-contract.md`), branch deletion is a real,
+  irreversible mutation; default posture should be `propose` or
+  `allow-listed`, never `auto`, mirroring `stale-check.yaml`'s
+  `mutation_allowlist: [comment, label]` pattern (deletion would need its own
+  explicit allow-list entry or stay ask-gated).
+- **Fleet aggregation** — one report/workflow across the configured repo
+  catalog, not a single-repo script; likely fits the existing
+  `templates/workflows/` + `skills/gh-workflows` pattern as a new template
+  (e.g. `stale-branch-cleanup.yaml`) rather than folding into
+  `stale-check.yaml`, since the trigger condition, data source, and mutation
+  are all disjoint from that workflow.
+
+## Evidence
+
+- `templates/workflows/stale-check.yaml` (read in full) — `GATHER` step is
+  `list open PRs not updated in the last 7 days` / `list open issues not
+  updated in the last 14 days`; no branch-lifecycle awareness anywhere in the
+  file.
+- Grepped `stale_branch|merged_branch|delete_branch|branch_cleanup|dangling`
+  across `lib/pulse/scripts/`, `skills/`, `docs/backlogs/`: zero matches.
+- `docs/superpowers/plans/2026-07-10-p5-pulse-scheduler.md:175-177` —
+  `stale_branches: [] # [{branch, pr_number, pr_age_days}] — unmerged
+  {BRANCH_PREFIX}* branches` is the only near-hit in this repo's design
+  history, but it's scoped exclusively to the pulse scheduler's own
+  `.hiivmind/github` self-management branches (automation-config proposal
+  branches), never a fleet-wide consumer-repo check — and it was never
+  implemented (zero code references the field or the concept it names).
+- `skills/gh-operations/SKILL.md`'s domain-routing table
+  (`domains/branch-protection.md`) documents only
+  `GET|PUT|DELETE /repos/{o}/{r}/branches/{branch}/protection` and its
+  sub-resources — no `List branches`, `compare`, or `DELETE .../git/refs/`
+  route exists anywhere in this skill's reference docs.
+- `~/.claude/CLAUDE.md` (global rules, this session) — "Post-merge hygiene:
+  `git checkout <base> && git pull --ff-only && git branch -d
+  <feature-branch>` in both repos after every merge." This backlog item is
+  exactly that manual per-session habit, surfaced and automated at fleet
+  scale — catching branches a human or another agent's session forgot to
+  clean up.
+
+## Notes
+
+No-spec. Needs a `brainstorming` pass to settle: (1) the staleness threshold
+(immediate-on-merge vs. N-day grace period), (2) exclusion rules for
+intentionally long-lived branch name patterns, and (3) whether this ships as
+its own workflow template or as a new `stale-check.yaml` mode — the trigger
+and data source argue for a separate template, but the UX ("stale things to
+clean up") is conceptually adjacent enough to be worth deciding explicitly
+rather than defaulting.

--- a/docs/backlogs/2026-08-17-stale-release-candidates.md
+++ b/docs/backlogs/2026-08-17-stale-release-candidates.md
@@ -1,0 +1,89 @@
+# Backlog: detect stale/abandoned release-candidate releases and branches
+
+**Date:** 2026-08-17
+**Status:** Open, no spec
+**Severity:** Operational hygiene / release-process hygiene, not a bug
+**Found in:** user request, same batch as `2026-08-17-stale-merged-branches.md` and the
+branch-protection governance-parity exploration
+**Scope:** a new fleet check distinct from `release-monitor.yaml`/`release-train.yaml`;
+`lib/pulse/scripts/marketplace_sync.py` (adjacent, different purpose, not reusable as-is)
+
+## Problem
+
+Two related but distinct "stale RC" signals exist in this program's domain,
+and neither is audited today:
+
+1. **A GitHub Release object marked `prerelease` or `draft`** can sit
+   indefinitely without ever being promoted to a stable release or removed.
+   Nothing computes its age or flags abandonment.
+2. **A `release/*` branch** (this repo's own documented mountainash
+   three-tier flow: `feature/* → develop → release/* → main + CalVer tag`,
+   per `~/.claude/CLAUDE.md`) can go stale if its PR into `main` stalls —
+   distinct from an already-merged branch (the sibling
+   `2026-08-17-stale-merged-branches.md` item) and from a normal open PR
+   (`stale-check.yaml`'s existing 7-day threshold does technically cover *a
+   PR* going stale, but nothing treats a release-branch PR as a distinguished
+   category worth its own signal, e.g. "an RC has been open N days without
+   shipping" as opposed to any generic PR).
+
+## What this would require (real scope, not exhaustive by design)
+
+- **Release-object staleness**: `GET /repos/{o}/{r}/releases` is already
+  fetched (`evaluate_checks.py`'s `releases.json` data-dir file, and
+  `marketplace_sync.py`'s live GraphQL query) — but only ever consulted for
+  "what is the current latest stable," never for the age of a
+  `prerelease`/`draft` entry itself. Would need: age computation from
+  `created_at`/`published_at`, a threshold, and a decision on whether a
+  `draft` (never published) and a `prerelease` (published but not
+  promoted) are the same check or two.
+- **Release-branch staleness**: needs branch age (last-commit timestamp) plus
+  whether an open PR targets `main` from it and that PR's own age/CI state —
+  effectively a specialized instance of "stale PR" scoped to
+  release-branch-shaped heads, which argues for reusing
+  `stale-check.yaml`'s existing PR-staleness machinery with a
+  release-branch filter rather than inventing a second PR-age computation.
+- **A staleness threshold and mutation policy** — mirrors the same open
+  question in the sibling stale-merged-branches item; likely propose-only
+  (ping the release owner, surface in a workflow's `PRESENT` step) — no
+  auto-deleting a release or force-merging a release branch. Matches
+  `release-monitor.yaml`'s existing `auto: false` posture.
+- **Scope decision**: this may be one workflow with two `GATHER` sources
+  (release objects + release-shaped branches) or two separate checks: a
+  `brainstorming` pass should settle this rather than assuming.
+
+## Evidence
+
+- `templates/workflows/release-monitor.yaml` (read in full) — `trigger:
+  {type: session_poll, source: releases, condition: state_changed}`; reacts
+  only to a *newly published* release (`GATHER: release = show latest
+  release...`), never computes age of an existing prerelease/draft, no
+  staleness logic anywhere in the file.
+- `templates/workflows/release-train.yaml` (read in full) — a one-shot,
+  on-demand version-bump DAG (`tag-lib → verify-lib → bump-consumers →
+  verify-consumers`) with completion `gate:` conditions per step
+  (e.g. `"release {params.version} published AND checks green"`), but no
+  age-based abandonment/timeout handling anywhere in the DSL shown; a stalled
+  gate just sits with no escalation defined at this layer.
+- `lib/pulse/scripts/marketplace_sync.py:83-108` — `isPrerelease`/`isDraft`
+  releases are explicitly *excluded* when selecting the newest stable tag
+  (fail-closed: any non-`False` or missing flag value is treated as
+  excluded), confirmed by
+  `tests/test_marketplace_sync.py::test_compare_excludes_prerelease_and_draft_releases`
+  and `::test_compare_excludes_draft_only_release_when_no_stable_present`.
+  This is a **selection filter**, not a **staleness detector** — it answers
+  "which release is the current stable," never "has this prerelease been
+  sitting too long."
+- Grepped `release` + `stale`/`abandoned` across `docs/backlogs/` and
+  `docs/superpowers/`: zero matches — no prior design captured this gap.
+- `~/.claude/CLAUDE.md` (global rules, this session) — the mountainash
+  `release/*` → `main` three-tier flow this item's second sub-signal would
+  audit for abandonment.
+
+## Notes
+
+No-spec. Two sub-signals (release-object staleness vs. release-branch
+staleness) sharing a name but not obviously one mechanism — a
+`brainstorming` pass should settle whether they ship as one workflow or two,
+the staleness threshold(s), and whether release-branch staleness is better
+expressed as a `stale-check.yaml` filter extension rather than new machinery,
+since it is structurally "a stale PR, scoped to a branch-name pattern."

--- a/docs/backlogs/README.md
+++ b/docs/backlogs/README.md
@@ -1,6 +1,6 @@
 # hiivmind-pulse-gh — fleet program roadmap & backlog index
 
-**Updated:** 2026-08-17 (Nave Python bindings item captured) · **One-page map of what is built, what is left, and where each item lives.**
+**Updated:** 2026-08-17 (branch-governance, stale-branch, stale-release gaps captured) · **One-page map of what is built, what is left, and where each item lives.**
 
 > Read in this order: **Status at a glance** (what shipped) → **Layer-completeness matrix**
 > (is it actually *runnable*) → **Cross-repo dependency map** (which repos an item spans) →
@@ -197,6 +197,9 @@ side's interactive path now runs too — single-repo, multi-repo (#147), and dep
 | **Extract `lib/pulse` as a standalone Python package** — 53 scripts invoked by `{PLUGIN_ROOT}`-relative path from every skill, no real install/version, only 2 of 53 have entry points. Concretizes audit F7's "neutral runtime root" recommendation; mirrors the Nave extraction precedent for the Python half. **Amended:** must ship as an importable SDK (FastAPI-consumable in-process), not just a CLI — the layer-1/driver/skill split already exists in code. | [`2026-08-17-lib-pulse-package-extraction.md`](2026-08-17-lib-pulse-package-extraction.md) |
 | **Nave native Python bindings (PyO3)** — `discreteds/nave` already ships a Python wheel, but `bindings = "bin"` (wraps the CLI binary, still subprocess). Real in-process bindings would wrap the workspace's existing library crates (`nave_pen`, `nave_apply`, etc. — already `pub fn`/`pub struct`, already serde-typed). `nave`-repo scope; async (tokio) bridging and `bin`-vs-`pyo3` coexistence are open forks. Design first. | [`2026-08-17-nave-python-bindings.md`](2026-08-17-nave-python-bindings.md) |
 | **Agent-native fleet UI** — a visual app (BuilderIO `agent-native`) presenting projects/statuses/workflows/issues, surfacing discrepancies (`findings`) and approvals from the existing typed result contracts, with an LLM agent panel that can invoke skills/`lib/pulse`/Nave tasks. Largest-scope open item; resolved cross-language direction is a FastAPI service (not raw subprocess shell-out) fronting both the `lib/pulse` SDK and Nave bindings above. Design first. | [`2026-08-17-agent-native-fleet-ui.md`](2026-08-17-agent-native-fleet-ui.md) |
+| **Fleet-wide branch-protection / ruleset governance parity** (branch-name-filter drift across repos) — `gh-healthcheck` only audits the *default* branch per repo; ruleset glob-pattern matching already exists in code (`adapters/generic.py`) but only to confirm default-branch coverage, never surfaced as cross-repo protected-branch-pattern drift or reconciled against a declared standard. Captured as an unstarted shortlist entry, not previously linked from this index. Design first (needs a golden-governance-spec conversation). | [`governance-parity` § 3.6.3](../superpowers/specs/2026-07-10-lockstep-bindings-and-target-workflows-design.md) — status `proposed`, priority PR3 (do not start), gated on P3.2 + P4 |
+| **Stale merged branches** — a PR's branch can survive its own merge (delete-on-merge disabled, or merged outside the UI); nothing detects or cleans these up fleet-wide today. Disjoint from `stale-check.yaml` (which covers *open*, untouched PRs/issues, not already-merged branches). Design first. | [`2026-08-17-stale-merged-branches.md`](2026-08-17-stale-merged-branches.md) |
+| **Stale release-candidate releases/branches** — a GitHub Release stuck `prerelease`/`draft`, or a `release/*` branch whose PR into `main` stalls, both go unaudited today; `release-monitor.yaml` only reacts to newly-published releases, `release-train.yaml` has no abandonment/timeout handling. Design first. | [`2026-08-17-stale-release-candidates.md`](2026-08-17-stale-release-candidates.md) |
 
 ### ⚪ Non-goals & tooling (recorded so they aren't re-proposed)
 - **Auto-merge** — permanent non-goal; Pulse opens PRs and detects merges, never merges. ([apply-mode v2](2026-07-29-apply-mode-v2-deferrals.md) § C)
@@ -234,6 +237,9 @@ side's interactive path now runs too — single-repo, multi-repo (#147), and dep
 - [`2026-08-17-lib-pulse-package-extraction.md`](2026-08-17-lib-pulse-package-extraction.md) — extract `lib/pulse` as a standalone Python package (SDK-amended), no-spec architectural item
 - [`2026-08-17-nave-python-bindings.md`](2026-08-17-nave-python-bindings.md) — Nave native Python (PyO3) bindings, no-spec, `nave`-repo scope
 - [`2026-08-17-agent-native-fleet-ui.md`](2026-08-17-agent-native-fleet-ui.md) — agent-native visual fleet UI proposal, no-spec, largest open item
+- [`2026-08-17-agent-native-fleet-ui-prior-art.md`](2026-08-17-agent-native-fleet-ui-prior-art.md) — prior-art research (Cortex.io/Port.io/OpsLevel/Backstage): the fleet-UI job-to-be-done is already sold by agentic IDPs; surfaces a build-vs-buy-vs-wedge fork
+- [`2026-08-17-stale-merged-branches.md`](2026-08-17-stale-merged-branches.md) — detect/clean up already-merged, undeleted branches across the fleet, no-spec
+- [`2026-08-17-stale-release-candidates.md`](2026-08-17-stale-release-candidates.md) — detect stale prerelease/draft releases and stalled `release/*` branches, no-spec
 - [`2026-07-11-workspace-config-stale-catalog.md`](2026-07-11-workspace-config-stale-catalog.md) — stale workspace data
 
 > Design-of-record for built/planned phases lives under `../superpowers/plans/` and


### PR DESCRIPTION
Explores three candidate fleet-workflow areas and grounds each against actual code.

**1. Branch protection across repos (branch-name filters)** — partially built, not specified for fleet-wide governance. `gh-healthcheck` only audits the default branch per repo; a ruleset glob matcher exists (`adapters/generic.py`) but only confirms default-branch coverage, never surfaces branch-name-pattern drift across repos. Real design already existed but was orphaned — §3.6.3 `governance-parity` in `docs/superpowers/specs/2026-07-10-lockstep-bindings-and-target-workflows-design.md` (status `proposed`, priority PR3/do-not-start) was never linked from the backlog index. Linked it rather than duplicating.

**2. Stale feature branches already merged** — absent. `stale-check.yaml` only covers open, untouched PRs/issues — disjoint from "PR merged, branch left behind." No code or backlog doc anywhere. New: `docs/backlogs/2026-08-17-stale-merged-branches.md`.

**3. Stale release-candidate releases** — absent. `release-monitor.yaml` only reacts to newly-published releases; `release-train.yaml` has completion gates but no abandonment/timeout handling; `marketplace_sync.py`'s prerelease/draft filtering is a selection filter, not a staleness detector. New: `docs/backlogs/2026-08-17-stale-release-candidates.md`.

Wired all three into `docs/backlogs/README.md`'s v2 table and docs list. No code changes.

Note: leaves `docs/backlogs/2026-08-17-agent-native-fleet-ui.md` (modified) and `...-prior-art.md` (untracked) alone — concurrent unrelated work from another session, not touched by this PR.